### PR TITLE
Fix: Remove panel animation delay for smoother first open

### DIFF
--- a/chat/ChatWidget.tsx
+++ b/chat/ChatWidget.tsx
@@ -278,7 +278,7 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
       y: 0,
       scale: 1,
       borderRadius: isMobileView ? "0px" : "16px",
-      transition: { ...openSpring, delay: 0.05 }
+      transition: openSpring // Removed delay
     },
     exit: {
       opacity: 0,


### PR DESCRIPTION
Addresses issue where the chat widget would appear too narrow on its initial opening animation. The 50ms delay in the panel's opening animation (framer-motion) was removed to ensure the content animation starts immediately as the parent container resizes. This provides tighter synchronization and should prevent the 'starts narrow' appearance on the first open.