### PR TITLE
Fix: Ensure categories is always an array in InternalUsers page

### DIFF
--- a/src/pages/InternalUsers.tsx
+++ b/src/pages/InternalUsers.tsx
@@ -45,7 +45,15 @@ export default function InternalUsers() {
         setLoading(false);
       });
     apiFetch<Category[]>('/municipal/categorias')
-      .then((data) => setCategories(data))
+      .then((data) => {
+        if (Array.isArray(data)) {
+          setCategories(data);
+        } else {
+          // Log an error or handle unexpected data format if necessary
+          console.warn("Categories data is not an array:", data);
+          setCategories([]); // Default to an empty array
+        }
+      })
       .catch((err: any) => {
         if (err instanceof ApiError && err.status === 404) {
           setError('Funcionalidad no disponible');


### PR DESCRIPTION
Previously, if the API endpoint /municipal/categorias returned a non-array payload (e.g., null or an object) with a successful status code, the `categories` state could be set to this non-array value. This would lead to a TypeError when `categories.map` was called during rendering.

This change modifies the .then() callback for the categories fetch to explicitly check if the received data is an array using `Array.isArray()`. If it is, `setCategories` is called with the data. Otherwise, a warning is logged and `setCategories` is called with an empty array, ensuring that the `categories` state is always an array and preventing the runtime error.