### PR TITLE
Fix entityToken retrieval in auth panels

### DIFF
--- a/src/components/chat/ChatUserLoginPanel.tsx
+++ b/src/components/chat/ChatUserLoginPanel.tsx
@@ -33,6 +33,16 @@ const ChatUserLoginPanel: React.FC<Props> = ({ onSuccess, onShowRegister }) => {
     emailRef.current?.focus();
   }, []);
 
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const params = new URLSearchParams(window.location.search);
+      const tokenFromUrl = params.get('token');
+      if (tokenFromUrl) {
+        safeLocalStorage.setItem('entityToken', tokenFromUrl);
+      }
+    }
+  }, []);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError("");

--- a/src/components/chat/ChatUserRegisterPanel.tsx
+++ b/src/components/chat/ChatUserRegisterPanel.tsx
@@ -33,6 +33,16 @@ const ChatUserRegisterPanel: React.FC<Props> = ({ onSuccess, onShowLogin }) => {
   const nameRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const params = new URLSearchParams(window.location.search);
+      const tokenFromUrl = params.get('token');
+      if (tokenFromUrl) {
+        safeLocalStorage.setItem('entityToken', tokenFromUrl);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
     nameRef.current?.focus();
   }, []);
 


### PR DESCRIPTION
## Summary
- load `token` param from URL on login/register panels

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c122e11048322982080922269aa35