### PR TITLE
feat: Implement client-side chat session ID

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -5,6 +5,7 @@
 // point to the real backend URL.
 const API_BASE_URL = import.meta.env.VITE_API_URL || "/api";
 import { safeLocalStorage } from "@/utils/safeLocalStorage";
+import getOrCreateChatSessionId from "@/utils/chatSessionId"; // Import the new function
 
 export class ApiError extends Error {
   public readonly status: number;
@@ -41,6 +42,7 @@ export async function apiFetch<T>(
   const token = safeLocalStorage.getItem("authToken");
   const anonId = safeLocalStorage.getItem("anon_id");
   const entityToken = safeLocalStorage.getItem("entityToken");
+  const chatSessionId = getOrCreateChatSessionId(); // Get or create the chat session ID
 
   const url = `${API_BASE_URL}${path}`;
   const headers: Record<string, string> = { ...(options.headers || {}) };
@@ -48,6 +50,8 @@ export async function apiFetch<T>(
   const isForm = body instanceof FormData;
   if (!isForm) headers["Content-Type"] = "application/json";
 
+  // Add the chat session ID header to all requests
+  headers["X-Chat-Session-Id"] = chatSessionId;
 
   if (!skipAuth && token) {
     headers["Authorization"] = `Bearer ${token}`;

--- a/src/utils/chatSessionId.ts
+++ b/src/utils/chatSessionId.ts
@@ -1,0 +1,33 @@
+// src/utils/chatSessionId.ts
+import { safeLocalStorage } from './safeLocalStorage';
+import { v4 as uuidv4 } from 'uuid';
+
+const CHAT_SESSION_ID_KEY = 'chat_session_id';
+
+/**
+ * Retrieves the chat session ID from local storage.
+ * If not found, generates a new UUID v4, stores it, and returns it.
+ * This ID is persistent for the user's browser until local storage is cleared.
+ */
+export function getOrCreateChatSessionId(): string {
+  if (typeof window === 'undefined') {
+    // Should not happen in a browser environment where chat operates
+    console.warn('getOrCreateChatSessionId called in a non-browser environment.');
+    return `server-generated-${uuidv4()}`; // Fallback for SSR or tests if needed, though client should always have one
+  }
+  try {
+    let sessionId = safeLocalStorage.getItem(CHAT_SESSION_ID_KEY);
+    if (!sessionId) {
+      sessionId = uuidv4();
+      safeLocalStorage.setItem(CHAT_SESSION_ID_KEY, sessionId);
+    }
+    return sessionId;
+  } catch (error) {
+    console.error('Error accessing localStorage for chat session ID:', error);
+    // Fallback if localStorage is completely inaccessible (e.g., security settings)
+    // This ID will not be persisted.
+    return uuidv4();
+  }
+}
+
+export default getOrCreateChatSessionId;


### PR DESCRIPTION
- Add getOrCreateChatSessionId utility to generate and store chat_session_id in localStorage.
- Modify apiFetch to send X-Chat-Session-Id header with all API requests.

This enables the backend to manage chat context using a client-generated ID instead of relying on server-side session cookies.