### PR TITLE
Fix: Simplify chat widget animations to prevent getting stuck

### DIFF
--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -283,16 +283,16 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
       y: 0,
       scale: 1,
       borderRadius: isMobileView ? "0px" : "16px",
-      transition: { ...openSpring, delay: 0.05 } // Original spring animation
-      // transition: { type: "tween", duration: 0.3, ease: "easeOut", delay: 0.05 } // Simplified tween animation
+      // transition: { ...openSpring, delay: 0.05 } // Original spring animation
+      transition: { type: "tween", duration: 0.3, ease: "easeOut", delay: 0.05 } // Simplified tween animation
     },
     exit: {
       opacity: 0,
       y: 30,
       scale: 0.95,
       borderRadius: "30%",
-      transition: closeSpring // Original spring animation for exit
-      // transition: { type: "tween", duration: 0.2, ease: "easeIn" } // Simplified tween animation for exit
+      // transition: closeSpring // Original spring animation for exit
+      transition: { type: "tween", duration: 0.2, ease: "easeIn" } // Simplified tween animation for exit
     }
   };
 


### PR DESCRIPTION
Replaced spring animations with tween animations for the chat panel's open and close transitions. This should provide a smoother and more reliable animation, addressing the issue where the panel could get stuck partially open.