### PR TITLE
I've made a fix to address the issue with the VITE_API_URL in the ser…

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,9 @@ import path from "path";
 import { VitePWA } from 'vite-plugin-pwa';
 
 export default defineConfig({
+  define: {
+    'process.env.VITE_API_URL': JSON.stringify(process.env.VITE_API_URL)
+  },
   plugins: [
     react(),
     VitePWA({
@@ -45,7 +48,7 @@ export default defineConfig({
             // Cache para las llamadas a tu API
             urlPattern: ({ url }) =>
               url.pathname.startsWith('/api') ||
-              url.origin === import.meta.env.VITE_API_URL,
+              url.origin === process.env.VITE_API_URL,
             handler: 'NetworkFirst',
             options: {
               cacheName: 'api-cache',


### PR DESCRIPTION
…vice worker. Here's what I did:

- I defined a global constant in `vite.config.ts` to make the `VITE_API_URL` environment variable available to the service worker.
- I then updated the service worker caching rule to use this new constant.