### PR TITLE
fix(auth): Ensure entityToken is set on login and sent with API requests

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -17,6 +17,7 @@ interface LoginResponse {
   email: string;
   plan: string;
   tipo_chat?: 'pyme' | 'municipio';
+  entityToken?: string;
 }
 
 const Login = () => {
@@ -39,6 +40,9 @@ const Login = () => {
       });
 
       safeLocalStorage.setItem("authToken", data.token);
+      if (data.entityToken) {
+        safeLocalStorage.setItem("entityToken", data.entityToken);
+      }
 
       await refreshUser();
       navigate("/perfil");

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -60,7 +60,7 @@ export async function apiFetch<T>(
   if (((!token && anonId) || sendAnonId) && anonId) {
     headers["Anon-Id"] = anonId;
   }
-  if ((sendEntityToken || false) && entityToken) {
+  if (entityToken) {
     headers["X-Entity-Token"] = entityToken;
   }
 


### PR DESCRIPTION
This commit addresses an issue where tickets were not visible to municipal admins. The root cause was that the `entityToken`, required for authenticating as a municipal user, was not being set in local storage during the main application's login process. This token was only being set when using the embedded chat widget.

This commit introduces the following changes:

1.  **Updated `Login.tsx`:**
    *   The `LoginResponse` interface now includes an optional `entityToken` field.
    *   After a successful login, the `entityToken` from the response is stored in `safeLocalStorage`.

2.  **Updated `utils/api.ts`:**
    *   The `apiFetch` function has been modified to automatically include the `X-Entity-Token` header in all API requests if an `entityToken` is present in `safeLocalStorage`. This removes the need for the `sendEntityToken` flag and ensures that the token is always sent when available.

These changes ensure that municipal admins are properly authenticated and can view their tickets.