### PR TITLE
Improve response parser for new field

### DIFF
--- a/src/utils/adminChatFilter.js
+++ b/src/utils/adminChatFilter.js
@@ -33,6 +33,5 @@ function filterLoginPrompt(text, buttons = [], role) {
   return { text: finalText, buttons: finalButtons };
 }
 
-// >>>> REEMPLAZÁ TODO ESTO:
 export default filterLoginPrompt;
 export { filterLoginPrompt };

--- a/src/utils/parseChatResponse.ts
+++ b/src/utils/parseChatResponse.ts
@@ -8,10 +8,11 @@ export interface Boton {
 }
 
 export interface ChatApiResponse {
-  respuesta?: string | { respuesta?: string; botones?: Boton[]; attachmentInfo?: Message['attachmentInfo'] }; // Añadir attachmentInfo aquí
+  respuesta?: string | { respuesta?: string; botones?: Boton[]; attachmentInfo?: Message['attachmentInfo'] };
+  respuesta_usuario?: string | { respuesta?: string; botones?: Boton[]; attachmentInfo?: Message['attachmentInfo'] };
   botones?: Boton[];
   contexto_actualizado?: any;
-  attachmentInfo?: Message['attachmentInfo']; // Y/o aquí, a nivel raíz de la respuesta
+  attachmentInfo?: Message['attachmentInfo'];
   [key: string]: any;
 }
 
@@ -31,19 +32,22 @@ export function parseChatResponse(data: ChatApiResponse): {
     attachmentInfo = data.attachmentInfo;
   }
 
-  if (typeof data.respuesta === 'object' && data.respuesta !== null) {
-    if (typeof data.respuesta.respuesta === 'string') {
-      text = data.respuesta.respuesta;
+  const rawRespuesta =
+    data.respuesta !== undefined ? data.respuesta : data.respuesta_usuario;
+
+  if (typeof rawRespuesta === 'object' && rawRespuesta !== null) {
+    if (typeof rawRespuesta.respuesta === 'string') {
+      text = rawRespuesta.respuesta;
     }
-    if (Array.isArray((data.respuesta as any).botones)) {
-      botones = (data.respuesta as any).botones;
+    if (Array.isArray((rawRespuesta as any).botones)) {
+      botones = (rawRespuesta as any).botones;
     }
     // Buscar attachmentInfo dentro del objeto respuesta si no se encontró a nivel raíz
-    if (!attachmentInfo && data.respuesta.attachmentInfo && typeof data.respuesta.attachmentInfo === 'object') {
-      attachmentInfo = data.respuesta.attachmentInfo;
+    if (!attachmentInfo && rawRespuesta.attachmentInfo && typeof rawRespuesta.attachmentInfo === 'object') {
+      attachmentInfo = rawRespuesta.attachmentInfo;
     }
-  } else if (typeof data.respuesta === 'string') {
-    text = data.respuesta;
+  } else if (typeof rawRespuesta === 'string') {
+    text = rawRespuesta;
   }
 
   if (Array.isArray(data.botones)) {

--- a/tests/parseChatResponse.test.cjs
+++ b/tests/parseChatResponse.test.cjs
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { parseChatResponse } from '../src/utils/parseChatResponse.ts';
+
+describe('parseChatResponse', () => {
+  it('handles respuesta field', () => {
+    const res = parseChatResponse({ respuesta: 'hola' });
+    expect(res.text).toBe('hola');
+  });
+
+  it('handles respuesta_usuario field', () => {
+    const res = parseChatResponse({ respuesta_usuario: 'hola' });
+    expect(res.text).toBe('hola');
+  });
+
+  it('handles object form', () => {
+    const res = parseChatResponse({ respuesta_usuario: { respuesta: 'ok', botones: [{ texto: 'b1', action: 'a' }] } });
+    expect(res.text).toBe('ok');
+    expect(res.botones[0].texto).toBe('b1');
+  });
+});

--- a/utils/adminChatFilter.js
+++ b/utils/adminChatFilter.js
@@ -33,6 +33,5 @@ function filterLoginPrompt(text, buttons = [], role) {
   return { text: finalText, buttons: finalButtons };
 }
 
-// >>>> REEMPLAZÁ TODO ESTO:
 export default filterLoginPrompt;
 export { filterLoginPrompt };

--- a/utils/parseChatResponse.ts
+++ b/utils/parseChatResponse.ts
@@ -8,10 +8,11 @@ export interface Boton {
 }
 
 export interface ChatApiResponse {
-  respuesta?: string | { respuesta?: string; botones?: Boton[]; attachmentInfo?: Message['attachmentInfo'] }; // Añadir attachmentInfo aquí
+  respuesta?: string | { respuesta?: string; botones?: Boton[]; attachmentInfo?: Message['attachmentInfo'] };
+  respuesta_usuario?: string | { respuesta?: string; botones?: Boton[]; attachmentInfo?: Message['attachmentInfo'] };
   botones?: Boton[];
   contexto_actualizado?: any;
-  attachmentInfo?: Message['attachmentInfo']; // Y/o aquí, a nivel raíz de la respuesta
+  attachmentInfo?: Message['attachmentInfo'];
   [key: string]: any;
 }
 
@@ -31,19 +32,22 @@ export function parseChatResponse(data: ChatApiResponse): {
     attachmentInfo = data.attachmentInfo;
   }
 
-  if (typeof data.respuesta === 'object' && data.respuesta !== null) {
-    if (typeof data.respuesta.respuesta === 'string') {
-      text = data.respuesta.respuesta;
+  const rawRespuesta =
+    data.respuesta !== undefined ? data.respuesta : data.respuesta_usuario;
+
+  if (typeof rawRespuesta === 'object' && rawRespuesta !== null) {
+    if (typeof rawRespuesta.respuesta === 'string') {
+      text = rawRespuesta.respuesta;
     }
-    if (Array.isArray((data.respuesta as any).botones)) {
-      botones = (data.respuesta as any).botones;
+    if (Array.isArray((rawRespuesta as any).botones)) {
+      botones = (rawRespuesta as any).botones;
     }
     // Buscar attachmentInfo dentro del objeto respuesta si no se encontró a nivel raíz
-    if (!attachmentInfo && data.respuesta.attachmentInfo && typeof data.respuesta.attachmentInfo === 'object') {
-      attachmentInfo = data.respuesta.attachmentInfo;
+    if (!attachmentInfo && rawRespuesta.attachmentInfo && typeof rawRespuesta.attachmentInfo === 'object') {
+      attachmentInfo = rawRespuesta.attachmentInfo;
     }
-  } else if (typeof data.respuesta === 'string') {
-    text = data.respuesta;
+  } else if (typeof rawRespuesta === 'string') {
+    text = rawRespuesta;
   }
 
   if (Array.isArray(data.botones)) {


### PR DESCRIPTION
## Summary
- support `respuesta_usuario` field when parsing chat responses
- clean up admin chat filter exports
- add tests for parseChatResponse

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687eeab8ecb0832284c9efa38b2c00b2