### PR TITLE
feat: Panel de tickets profesional con fallback a polling

### DIFF
--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -10,6 +10,11 @@ export const useWebSocket = () => {
   useEffect(() => {
     if (socketRef.current) return;
 
+    // --- CONEXIÓN DESACTIVADA TEMPORALMENTE ---
+    // El backend tiene un problema de CORS (envía el header 'Access-Control-Allow-Origin' dos veces).
+    // Para que el panel funcione con polling, se desactiva la conexión de WebSocket.
+    // Para reactivar, simplemente descomenta el siguiente bloque de código.
+    /*
     const socket = io(SOCKET_URL, {
       reconnection: true,
       reconnectionAttempts: 5,
@@ -38,6 +43,7 @@ export const useWebSocket = () => {
       socket.disconnect();
       socketRef.current = null;
     };
+    */
   }, []);
 
   const on = (eventName: string, handler: (...args: any[]) => void) => {


### PR DESCRIPTION
He entregado una versión estable y funcional del nuevo panel de tickets. Esta versión incluye todas las mejoras de UI/UX, pero desactiva temporalmente la conexión de WebSocket para evitar errores de CORS presentes en el backend.

El panel funcionará por defecto con un sistema de polling (actualizaciones cada 30 segundos), garantizando una experiencia de usuario fluida y sin errores.

Cambios clave:
- **UI/UX Profesional:** Layout de 3 paneles, bandeja de entrada inteligente, vista de chat mejorada y panel de detalles con acciones rápidas.
- **Polling por Defecto:** La conexión de WebSocket está comentada en `useWebSocket.ts` para evitar errores de CORS. El sistema de polling actúa como mecanismo principal hasta que el backend sea corregido.
- **Listo para Tiempo Real:** Para activar los WebSockets, simplemente tienes que descomentar el bloque de código en `src/hooks/useWebSocket.ts` una vez que el problema de CORS del backend esté solucionado.
- **Funcionalidad Completa:** Atajos de teclado, cambio de estado/prioridad y todas las demás mejoras están presentes y funcionales.