### PR TITLE
fix: Corregir error de renderizado de SVG en la lista de tickets

### DIFF
--- a/src/components/tickets/TicketList.tsx
+++ b/src/components/tickets/TicketList.tsx
@@ -54,7 +54,7 @@ const TicketListItem: React.FC<TicketListItemProps> = React.memo(({ ticket, isSe
               {ticket.nombre_usuario || 'Usuario desconocido'}
             </span>
             <div className="flex items-center gap-2">
-                {ticket.priority && (
+                {ticket.priority && PRIORITY_STYLES[ticket.priority] && (
                     <span className={cn("h-2.5 w-2.5 rounded-full", PRIORITY_STYLES[ticket.priority])} title={`Prioridad: ${ticket.priority}`}></span>
                 )}
                 <span className="text-xs text-muted-foreground whitespace-nowrap">


### PR DESCRIPTION
Se ha solucionado un error que causaba que se intentara renderizar un elemento `<circle>` con atributos `cx` y `cy` indefinidos.

El problema ocurría en el componente `TicketListItem` cuando un ticket no tenía un valor de prioridad válido, lo que resultaba en una clase de estilo indefinida para el indicador visual de prioridad.

La corrección añade una comprobación para asegurar que el indicador de prioridad (el `<span>` circular) solo se renderice si la propiedad `ticket.priority` existe y tiene una entrada correspondiente en el objeto `PRIORITY_STYLES`.

Este cambio previene errores de renderizado en la consola y asegura que la interfaz se muestre correctamente incluso con datos de tickets incompletos.