### PR TITLE
Persist company name in user context

### DIFF
--- a/hooks/useUser.tsx
+++ b/hooks/useUser.tsx
@@ -10,6 +10,7 @@ interface UserData {
   token?: string;
   plan?: string;
   rubro?: string;
+  nombre_empresa?: string;
   tipo_chat?: 'pyme' | 'municipio';
   rol?: string;
 }
@@ -61,6 +62,7 @@ export const UserProvider: React.FC<{ children: React.ReactNode }> = ({ children
       email: data.email,
       plan: data.plan || 'free',
       rubro: rubroNorm,
+      nombre_empresa: data.nombre_empresa,
       tipo_chat: finalTipo,
       rol: data.rol,
       token,

--- a/src/hooks/useUser.tsx
+++ b/src/hooks/useUser.tsx
@@ -10,6 +10,7 @@ interface UserData {
   token?: string;
   plan?: string;
   rubro?: string;
+  nombre_empresa?: string;
   tipo_chat?: 'pyme' | 'municipio';
   rol?: string;
 }
@@ -61,6 +62,7 @@ export const UserProvider: React.FC<{ children: React.ReactNode }> = ({ children
       email: data.email,
       plan: data.plan || 'free',
       rubro: rubroNorm,
+      nombre_empresa: data.nombre_empresa,
       tipo_chat: finalTipo,
       rol: data.rol,
       token,


### PR DESCRIPTION
## Summary
- include company name when fetching `/me`
- store `nombre_empresa` in user context

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880e9f64f708322adb6e6b6c281cee7