### PR TITLE
Persist real user info in portal

### DIFF
--- a/hooks/useUser.tsx
+++ b/hooks/useUser.tsx
@@ -10,6 +10,9 @@ interface UserData {
   token?: string;
   plan?: string;
   rubro?: string;
+  nombre_empresa?: string;
+  logo_url?: string;
+  picture?: string;
   tipo_chat?: 'pyme' | 'municipio';
   rol?: string;
 }
@@ -61,6 +64,9 @@ export const UserProvider: React.FC<{ children: React.ReactNode }> = ({ children
       email: data.email,
       plan: data.plan || 'free',
       rubro: rubroNorm,
+      nombre_empresa: data.nombre_empresa,
+      logo_url: data.logo_url,
+      picture: data.picture,
       tipo_chat: finalTipo,
       rol: data.rol,
       token,

--- a/src/components/user-portal/layout/UserPortalLayout.tsx
+++ b/src/components/user-portal/layout/UserPortalLayout.tsx
@@ -14,22 +14,13 @@ import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { Menu as MenuIconLucide, Bell, Settings, LogOut, Building, ChevronDown } from 'lucide-react';
 import SideNavigationBar from '../navigation/SideNavigationBar';
 import BottomNavigationBar from '../navigation/BottomNavigationBar';
+import { useUser } from '@/hooks/useUser';
 
-// Datos dummy iniciales
-const currentUser = {
-  nombre: "Ana Vocos",
-  email: "ana.vocos@email.com",
-  avatarUrl: undefined,
-};
-
-const currentOrganization = {
-  nombre: "Municipio de Junín",
-  logoUrl: "/logos/municipio-junin-placeholder.png", // Asegúrate que este placeholder exista o usa uno genérico
-};
 
 const UserPortalLayout: React.FC = () => {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const navigate = useNavigate();
+  const { user } = useUser();
 
   const handleLogout = () => {
     console.log("Cerrar Sesión");
@@ -46,11 +37,16 @@ const UserPortalLayout: React.FC = () => {
             {/* Logo de la Organización */}
             <Link to="/portal/dashboard" className="flex items-center gap-2">
               <Avatar className="h-8 w-8 sm:h-9 sm:w-9">
-                <AvatarImage src={currentOrganization.logoUrl} alt={currentOrganization.nombre} />
-                <AvatarFallback><Building className="h-5 w-5 text-muted-foreground" /></AvatarFallback>
+                <AvatarImage src={user?.logo_url} alt={user?.nombre_empresa} />
+                <AvatarFallback>
+                  <Building className="h-5 w-5 text-muted-foreground" />
+                </AvatarFallback>
               </Avatar>
-              <span className="font-semibold text-foreground hidden sm:inline-block truncate max-w-[150px] md:max-w-xs" title={currentOrganization.nombre}>
-                {currentOrganization.nombre}
+              <span
+                className="font-semibold text-foreground hidden sm:inline-block truncate max-w-[150px] md:max-w-xs"
+                title={user?.nombre_empresa}
+              >
+                {user?.nombre_empresa}
               </span>
             </Link>
           </div>
@@ -66,14 +62,14 @@ const UserPortalLayout: React.FC = () => {
               <DropdownMenuTrigger asChild>
                 <Button variant="ghost" className="flex items-center gap-2 px-1 sm:px-2 py-1 h-auto rounded-full">
                   <Avatar className="h-8 w-8 sm:h-9 sm:w-9">
-                    <AvatarImage src={currentUser.avatarUrl} alt={currentUser.nombre} />
+                    <AvatarImage src={user?.picture} alt={user?.name} />
                     <AvatarFallback className="text-sm">
-                      {currentUser.nombre?.charAt(0).toUpperCase()}
-                      {currentUser.nombre?.split(' ')[1]?.charAt(0).toUpperCase()}
+                      {user?.name?.charAt(0).toUpperCase()}
+                      {user?.name?.split(' ')[1]?.charAt(0).toUpperCase()}
                     </AvatarFallback>
                   </Avatar>
                   <span className="hidden md:inline-block text-sm font-medium text-foreground">
-                    {currentUser.nombre}
+                    {user?.name}
                   </span>
                   <ChevronDown className="h-4 w-4 text-muted-foreground hidden md:inline-block ml-1" />
                 </Button>
@@ -81,9 +77,9 @@ const UserPortalLayout: React.FC = () => {
               <DropdownMenuContent align="end" className="w-56 mt-1">
                 <DropdownMenuLabel className="font-normal">
                   <div className="flex flex-col space-y-1">
-                    <p className="text-sm font-medium leading-none text-foreground">{currentUser.nombre}</p>
+                    <p className="text-sm font-medium leading-none text-foreground">{user?.name}</p>
                     <p className="text-xs leading-none text-muted-foreground">
-                      {currentUser.email}
+                      {user?.email}
                     </p>
                   </div>
                 </DropdownMenuLabel>

--- a/src/hooks/useUser.tsx
+++ b/src/hooks/useUser.tsx
@@ -10,6 +10,9 @@ interface UserData {
   token?: string;
   plan?: string;
   rubro?: string;
+  nombre_empresa?: string;
+  logo_url?: string;
+  picture?: string;
   tipo_chat?: 'pyme' | 'municipio';
   rol?: string;
 }
@@ -61,6 +64,9 @@ export const UserProvider: React.FC<{ children: React.ReactNode }> = ({ children
       email: data.email,
       plan: data.plan || 'free',
       rubro: rubroNorm,
+      nombre_empresa: data.nombre_empresa,
+      logo_url: data.logo_url,
+      picture: data.picture,
       tipo_chat: finalTipo,
       rol: data.rol,
       token,

--- a/src/pages/user-portal/UserDashboardPage.tsx
+++ b/src/pages/user-portal/UserDashboardPage.tsx
@@ -8,15 +8,9 @@ import {
   MessageSquareQuote, ClipboardList, ImageOff
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { useUser } from '@/hooks/useUser';
 
-// --- Datos Dummy (Mover a un archivo separado o contexto/estado global más adelante) ---
-const currentUser = {
-  nombre: "Ana Vocos",
-};
-
-const currentOrganization = {
-  nombre: "Municipio de Junín",
-};
+// Datos de usuario real obtenidos del contexto
 
 const recentActivities = [
   { id: 'R001', type: 'RECLAMO', description: 'Poste de luz caído en Av. San Martín y Belgrano', status: 'Recibido', statusType: 'info', date: '03/08/2024', link: '/portal/pedidos/R001' },
@@ -36,7 +30,6 @@ const activeBenefits = [
 const pendingSurveys = [
   { id: 'S001', title: 'Encuesta de Satisfacción sobre Servicios de Limpieza Urbana', link: '/portal/encuestas/S001' },
 ];
-// --- Fin Datos Dummy ---
 
 const UserDashboardPage = () => {
   const navigate = useNavigate();
@@ -63,14 +56,16 @@ const UserDashboardPage = () => {
     }
   };
 
+  const { user } = useUser();
+
   return (
     <div className="flex flex-col gap-6 md:gap-8">
       <div className="mb-2">
         <h1 className="text-2xl md:text-3xl font-bold text-dark">
-          ¡Hola, {currentUser.nombre}!
+          ¡Hola, {user?.name}!
         </h1>
         <p className="text-muted-foreground">
-          Bienvenido/a a tu portal con {currentOrganization.nombre}.
+          Bienvenido/a a tu portal con {user?.nombre_empresa}.
         </p>
       </div>
 


### PR DESCRIPTION
## Summary
- store logo and profile image in user context
- replace dummy portal data with authenticated user info

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880e9f64f708322adb6e6b6c281cee7