### PR TITLE
Fix /pedidos availability check for municipal users

### DIFF
--- a/QuickLinksCard.tsx
+++ b/QuickLinksCard.tsx
@@ -40,7 +40,9 @@ const ITEMS: LinkItem[] = [
 export default function QuickLinksCard() {
   const navigate = useNavigate();
   const { user, refreshUser } = useUser();
-  const pedidosAvailable = useEndpointAvailable('/pedidos');
+  const pedidosAvailable = useEndpointAvailable(
+    user?.tipo_chat === 'pyme' ? '/pedidos' : null
+  );
 
   useEffect(() => {
     if (!user) {

--- a/hooks/useEndpointAvailable.tsx
+++ b/hooks/useEndpointAvailable.tsx
@@ -7,11 +7,17 @@ import { apiFetch, ApiError } from '@/utils/api';
  *   false -> endpoint returned 404 or 403
  *   null  -> still checking
  */
-export default function useEndpointAvailable(path: string) {
+export default function useEndpointAvailable(path?: string | null) {
   const [available, setAvailable] = useState<boolean | null>(null);
 
   useEffect(() => {
     let canceled = false;
+    if (!path) {
+      setAvailable(null);
+      return () => {
+        canceled = true;
+      };
+    }
     (async () => {
       try {
         await apiFetch(path);


### PR DESCRIPTION
## Summary
- avoid hitting `/pedidos` endpoint when logged in as a municipality user
- allow `useEndpointAvailable` to accept `null` path so callers can skip the check

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68810664a20c832291da06817b8c9a79