### PR TITLE
fix: Correctly parse tickets from API response

### DIFF
--- a/src/pages/TicketsPanel.tsx
+++ b/src/pages/TicketsPanel.tsx
@@ -107,8 +107,8 @@ export default function TicketsPanel() {
     setIsLoading(true);
     setError(null);
     try {
-      const data = await apiFetch<TicketSummary[]>("/tickets", { sendEntityToken: true });
-      setAllTickets(data);
+      const data = await apiFetch<{tickets: TicketSummary[]}>("/tickets", { sendEntityToken: true });
+      setAllTickets(data.tickets);
     } catch (err) {
       const errorMessage = err instanceof ApiError ? err.message : "Error al cargar los tickets. Por favor, intente de nuevo más tarde.";
       setError(errorMessage);


### PR DESCRIPTION
The frontend was expecting an array of tickets, but the backend returns an object with a 'tickets' property. This commit fixes the frontend to correctly parse the response and display the tickets.