### PR TITLE
debug: Desactivar MapComponent en ClientInfoPanel para aislar error

### DIFF
--- a/src/components/tickets/ClientInfoPanel.tsx
+++ b/src/components/tickets/ClientInfoPanel.tsx
@@ -118,7 +118,8 @@ const ClientInfoPanel: React.FC<ClientInfoPanelProps> = ({ ticket }) => {
                     <AccordionItem value="location">
                         <AccordionTrigger className="text-base font-semibold">Ubicación</AccordionTrigger>
                         <AccordionContent className="pt-2">
-                           <MapComponent ticket={ticket} />
+                           {/* <MapComponent ticket={ticket} /> */}
+                           <div>Mapa desactivado para depuración.</div>
                         </AccordionContent>
                     </AccordionItem>
                 </Accordion>

--- a/src/components/tickets/TicketsPanelLayout.tsx
+++ b/src/components/tickets/TicketsPanelLayout.tsx
@@ -201,20 +201,7 @@ const TicketsPanelLayout: React.FC = () => {
         </ResizablePanel>
         <ResizableHandle withHandle />
         <ResizablePanel defaultSize={25} minSize={20} maxSize={40}>
-          {/* El ClientInfoPanel se desactiva temporalmente debido a un error de renderizado
-              que causa una pantalla en blanco. El error parece ser una incompatibilidad
-              entre las librerías utilizadas dentro del componente. Se necesita una
-              investigación más a fondo para solucionarlo. */}
-          {detailedTicket && (
-            <div className="p-4">
-              <h3 className="font-semibold">Panel de Información del Cliente</h3>
-              <p className="text-sm text-muted-foreground mt-2">
-                Este panel está temporalmente desactivado debido a un error técnico.
-                La información del cliente (email, teléfono, etc.) se puede encontrar
-                en el cuerpo del ticket por ahora.
-              </p>
-            </div>
-          )}
+          {detailedTicket && <ClientInfoPanel ticket={detailedTicket} />}
         </ResizablePanel>
       </ResizablePanelGroup>
     </div>


### PR DESCRIPTION
Este commit es un paso de depuración específico para determinar si el componente del mapa de Google es la causa del error de renderizado de la "pantalla blanca".

Cambios:

*   **Reactivación del Panel**: Se ha reactivado el `ClientInfoPanel` en el layout principal.
*   **Aislamiento del Mapa**: Se ha comentado el componente `MapComponent` dentro de `ClientInfoPanel.tsx` y se ha reemplazado por un `div` de depuración.

**Razonamiento:**

El `MapComponent`, que utiliza la librería `@react-google-maps/api`, es el componente más complejo y el principal sospechoso de causar el conflicto de renderizado.

*   **Si la aplicación funciona sin el mapa**, hemos confirmado que la incompatibilidad reside en este componente específico. El siguiente paso será investigar por qué falla o buscar una alternativa.
*   **Si el error persiste**, el problema está en otro de los componentes de `ClientInfoPanel` (por ejemplo, el `Accordion` o `AttachmentPreview`).

Este commit es clave para acotar el problema a un único componente y poder aplicar una solución definitiva.