### PR TITLE
fix: Corregir error crítico de importación en ClientInfoPanel

### DIFF
--- a/src/components/tickets/ClientInfoPanel.tsx
+++ b/src/components/tickets/ClientInfoPanel.tsx
@@ -10,7 +10,8 @@ import { cn } from '@/lib/utils';
 import { useDateSettings } from '@/hooks/useDateSettings';
 import { formatDate } from '@/utils/fecha';
 import { formatPhoneNumberForWhatsApp } from '@/utils/phoneUtils';
-import AttachmentPreview, { deriveAttachmentInfo } from '@/components/chat/AttachmentPreview';
+import AttachmentPreview from '@/components/chat/AttachmentPreview';
+import { deriveAttachmentInfo } from '@/utils/attachment';
 import { GoogleMap, useJsApiLoader, Marker } from '@react-google-maps/api';
 import { Skeleton } from '@/components/ui/skeleton';
 


### PR DESCRIPTION
Este commit soluciona la causa raíz del error de la "pantalla blanca" y la inestabilidad general del `TicketsPanel`, que era un error de importación en `ClientInfoPanel.tsx`.

Cambios:

*   **Importación Corregida**: He corregido la importación de la función `deriveAttachmentInfo` en `ClientInfoPanel.tsx`. Estaba siendo importada incorrectamente desde `AttachmentPreview.tsx` en lugar de su ubicación correcta en `src/utils/attachment.ts`.
*   **Reactivación de Paneles**: He restaurado el `ClientInfoPanel` a un estado activo en el layout principal. El `MapComponent` dentro de este panel permanece comentado como medida de precaución hasta que se confirme la estabilidad.

**Análisis del Problema:**

El error `The requested module does not provide an export named 'deriveAttachmentInfo'` era la causa principal de la cascada de errores de renderizado. Este error de importación rompía el proceso de renderizado de React, lo que resultaba en la "pantalla blanca" con texto de comentarios y otros errores engañosos de `framer-motion`.

Con esta corrección, se espera que la aplicación vuelva a un estado estable, permitiendo la implementación de las funcionalidades restantes y el refinamiento final de la UX/UI.