### PR TITLE
fix: Correct TicketMap import path in DetailsPanel

### DIFF
--- a/src/components/tickets/DetailsPanel.tsx
+++ b/src/components/tickets/DetailsPanel.tsx
@@ -7,7 +7,7 @@ import { Mail, Phone, MapPin, Ticket as TicketIcon, FolderOpen, Info, History } 
 import { Ticket } from '@/types/tickets';
 import { Badge } from '@/components/ui/badge';
 import { motion } from 'framer-motion';
-import TicketMap from './TicketMap';
+import TicketMap from '../TicketMap';
 
 interface DetailsPanelProps {
   ticket: Ticket | null;


### PR DESCRIPTION
This commit fixes a critical bug that prevented the application from compiling. The `DetailsPanel` component was trying to import `TicketMap` from a wrong relative path.

The import path has been corrected to point to the correct location in `src/components/`, resolving the build failure.