### PR TITLE
fix: Add /api prefix to ticket service routes

### DIFF
--- a/src/services/ticketService.ts
+++ b/src/services/ticketService.ts
@@ -3,7 +3,7 @@ import { Ticket } from '@/types/tickets';
 
 export const getTickets = async (anonId?: string): Promise<Ticket[]> => {
   try {
-    const endpoint = anonId ? `/tickets/anonymous?anonId=${anonId}` : '/tickets';
+    const endpoint = anonId ? `/api/tickets/anonymous?anonId=${anonId}` : '/api/tickets';
     const response = await apiFetch<Ticket[]>(endpoint, { sendAnonId: !!anonId });
     return response;
   } catch (error) {
@@ -14,7 +14,7 @@ export const getTickets = async (anonId?: string): Promise<Ticket[]> => {
 
 export const getTicketById = async (id: string): Promise<Ticket> => {
     try {
-        const response = await apiFetch<Ticket>(`/tickets/${id}`);
+        const response = await apiFetch<Ticket>(`/api/tickets/${id}`);
         return response;
     } catch (error) {
         console.error(`Error fetching ticket ${id}:`, error);


### PR DESCRIPTION
This commit fixes a critical issue where the frontend was making API calls to the wrong endpoints. The backend registers the ticket blueprint with an `/api` prefix, which was missing in the frontend service.

The `ticketService.ts` has been updated to include the `/api` prefix for all ticket-related endpoints, ensuring that the frontend can now correctly communicate with the backend.