### PR TITLE
fix: Correct ticket fetching logic for admin panel

### DIFF
--- a/src/services/ticketService.ts
+++ b/src/services/ticketService.ts
@@ -1,10 +1,9 @@
 import { apiFetch } from '@/utils/api';
 import { Ticket } from '@/types/tickets';
 
-export const getTickets = async (anonId?: string): Promise<Ticket[]> => {
+export const getTickets = async (): Promise<Ticket[]> => {
   try {
-    const endpoint = anonId ? `/tickets/anonymous?anonId=${anonId}` : '/tickets';
-    const response = await apiFetch<Ticket[]>(endpoint, { sendAnonId: !!anonId });
+    const response = await apiFetch<Ticket[]>('/tickets');
     return response;
   } catch (error) {
     console.error('Error fetching tickets:', error);


### PR DESCRIPTION
This commit resolves a fundamental issue in the ticket fetching logic for the administration panel. The previous implementation incorrectly included logic for anonymous users, which is not applicable in an authenticated admin context.

Key changes:
- Removed all `anonId` related logic from `ticketService.ts` and `NewTicketsPanel.tsx`.
- The `getTickets` service now makes a clean call to the `/tickets` endpoint, relying on your session token for authentication, which aligns with the backend's implementation.
- Simplified the data handling in `NewTicketsPanel.tsx` to correctly process the expected API response.

This change ensures that the ticket panel now correctly fetches and displays tickets for the logged-in administrator or employee. All tests continue to pass.