### PR TITLE
Improve ticket export and panel layout

### DIFF
--- a/src/components/tickets/DetailsPanel.tsx
+++ b/src/components/tickets/DetailsPanel.tsx
@@ -18,7 +18,7 @@ const DetailsPanel: React.FC = () => {
 
   if (!ticket) {
     return (
-       <aside className="w-96 border-l border-border flex-col h-screen bg-muted/20 shrink-0 hidden lg:flex items-center justify-center p-6">
+       <aside className="w-80 border-l border-border flex-col h-screen bg-muted/20 shrink-0 hidden lg:flex items-center justify-center p-6">
          <div className="text-center text-muted-foreground">
             <Info className="h-12 w-12 mx-auto mb-4" />
             <h3 className="font-semibold">Detalles del Ticket</h3>
@@ -36,7 +36,7 @@ const DetailsPanel: React.FC = () => {
         initial={{ opacity: 0.5 }}
         animate={{ opacity: 1 }}
         transition={{ duration: 0.5 }}
-        className="w-96 border-l border-border flex flex-col h-screen bg-muted/20 shrink-0"
+        className="w-80 border-l border-border flex flex-col h-screen bg-muted/20 shrink-0"
     >
       <ScrollArea className="flex-1">
         <div className="p-6 space-y-6">

--- a/src/components/tickets/NewTicketsPanel.tsx
+++ b/src/components/tickets/NewTicketsPanel.tsx
@@ -27,7 +27,7 @@ const NewTicketsPanel: React.FC = () => {
   if (loading) {
     return (
         <div className="flex h-screen w-full bg-background text-foreground overflow-hidden">
-            <div className="w-96 border-r border-border p-4 space-y-4">
+            <div className="w-80 border-r border-border p-4 space-y-4">
                 <Skeleton className="h-12 w-full" />
                 <Skeleton className="h-10 w-full" />
                 <div className="space-y-4 mt-4">

--- a/src/components/tickets/Sidebar.tsx
+++ b/src/components/tickets/Sidebar.tsx
@@ -34,16 +34,16 @@ const Sidebar: React.FC = () => {
   }, [ticketsByCategory, debouncedSearchTerm]);
 
   return (
-    <aside className="w-96 border-r border-border flex flex-col h-screen bg-muted/20 shrink-0">
+    <aside className="w-80 border-r border-border flex flex-col h-screen bg-muted/20 shrink-0">
       <div className="p-4 space-y-4">
         <div className="flex justify-between items-center">
             <h1 className="text-2xl font-bold">Tickets</h1>
             <div className="flex gap-2">
-                <Button variant="outline" size="sm" onClick={() => exportToExcel(tickets, 'todos')}>
+                <Button variant="outline" size="sm" onClick={() => exportToExcel(tickets)}>
                     <FileDown className="h-4 w-4 mr-2" />
                     Excel
                 </Button>
-                <Button variant="outline" size="sm" onClick={() => exportToPdf(tickets, 'todos')}>
+                <Button variant="outline" size="sm" onClick={() => exportToPdf(tickets)}>
                     <FileDown className="h-4 w-4 mr-2" />
                     PDF
                 </Button>

--- a/src/services/exportService.ts
+++ b/src/services/exportService.ts
@@ -8,22 +8,51 @@ interface jsPDFWithAutoTable extends jsPDF {
   autoTable: (options: any) => jsPDF;
 }
 
-export const exportToPdf = (tickets: any[], columns: string[]) => {
+export const exportToPdf = (
+  tickets: any[],
+  columns?: string[] | "todos" | "all"
+) => {
+  const columnsToUse: string[] =
+    !columns || columns === "todos" || columns === "all"
+      ? Object.keys(tickets[0] || {})
+      : columns;
+
   const doc = new jsPDF() as jsPDFWithAutoTable;
   const tableData = tickets.map((ticket) =>
-    columns.map((column) => ticket[column])
+    columnsToUse.map((column) => ticket[column])
   );
 
   doc.autoTable({
-    head: [columns],
+    head: [columnsToUse],
     body: tableData,
+    theme: "grid",
+    headStyles: { fillColor: [22, 163, 74] },
+    styles: { fontSize: 8 },
   });
 
   doc.save("tickets.pdf");
 };
 
-export const exportToExcel = (tickets: any[], columns: string[]) => {
-  const worksheet = XLSX.utils.json_to_sheet(tickets, { header: columns });
+export const exportToExcel = (
+  tickets: any[],
+  columns?: string[] | "todos" | "all"
+) => {
+  const columnsToUse: string[] =
+    !columns || columns === "todos" || columns === "all"
+      ? Object.keys(tickets[0] || {})
+      : columns;
+
+  const worksheetData = tickets.map((ticket) => {
+    const row: Record<string, any> = {};
+    columnsToUse.forEach((col) => {
+      row[col] = ticket[col];
+    });
+    return row;
+  });
+
+  const worksheet = XLSX.utils.json_to_sheet(worksheetData, {
+    header: columnsToUse,
+  });
   const workbook = XLSX.utils.book_new();
   XLSX.utils.book_append_sheet(workbook, worksheet, "Tickets");
   XLSX.writeFile(workbook, "tickets.xlsx");


### PR DESCRIPTION
## Summary
- adjust Sidebar and Details widths for more chat space
- enhance loading skeleton width
- style exported files and auto-detect columns

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882dd3bf7e083229636445feeee70ba