### PR TITLE
fix: Correct import for AdjuntarArchivo component

### DIFF
--- a/src/components/tickets/ConversationPanel.tsx
+++ b/src/components/tickets/ConversationPanel.tsx
@@ -16,7 +16,7 @@ import { useUser } from '@/hooks/useUser';
 import { useTickets } from '@/context/TicketContext';
 import { Avatar, AvatarFallback, AvatarImage } from '../ui/avatar';
 import ScrollToBottomButton from '../ui/ScrollToBottomButton';
-import { AdjuntarArchivo } from '../ui/AdjuntarArchivo';
+import AdjuntarArchivo from '../ui/AdjuntarArchivo';
 
 interface ConversationPanelProps {
   isMobile: boolean;


### PR DESCRIPTION
This commit fixes a bug where the `AdjuntarArchivo` component was being imported as a named export instead of a default export in `ConversationPanel.tsx`. This caused the application to crash.