### PR TITLE
fix: Export all tickets to a single PDF

### DIFF
--- a/src/components/tickets/Sidebar.tsx
+++ b/src/components/tickets/Sidebar.tsx
@@ -7,7 +7,7 @@ import { useDebounce } from '@/hooks/useDebounce';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
 import TicketListItem from './TicketListItem';
 import { useTickets } from '@/context/TicketContext';
-import { exportToPdf, exportToExcel } from '@/services/exportService';
+import { exportToPdf, exportToExcel, exportAllToPdf } from '@/services/exportService';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -52,10 +52,13 @@ const Sidebar: React.FC = () => {
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               <DropdownMenuItem onClick={() => exportToExcel(tickets)}>
-                Exportar a Excel
+                Exportar a Excel (Todos)
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => exportToPdf(selectedTicket, selectedTicket?.messages || [])}>
-                Exportar a PDF (seleccionado)
+              <DropdownMenuItem onClick={() => exportAllToPdf(tickets)}>
+                Exportar a PDF (Todos)
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => exportToPdf(selectedTicket, selectedTicket?.messages || [])} disabled={!selectedTicket}>
+                Exportar Ticket a PDF
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>

--- a/src/services/exportService.ts
+++ b/src/services/exportService.ts
@@ -109,3 +109,33 @@ export const exportToExcel = (tickets: Ticket[]) => {
 
   XLSX.writeFile(workbook, 'tickets.xlsx');
 };
+
+export const exportAllToPdf = (tickets: Ticket[]) => {
+  const doc = new jsPDF();
+  doc.setFontSize(20);
+  doc.text('Resumen de Tickets', 14, 22);
+
+  autoTable(doc, {
+    startY: 30,
+    head: [['ID', 'Asunto', 'Estado', 'Cliente', 'Fecha']],
+    body: tickets.map(ticket => [
+      ticket.nro_ticket,
+      ticket.asunto,
+      ticket.estado,
+      ticket.name || 'N/A',
+      formatDate(ticket.fecha),
+    ]),
+    theme: 'grid',
+    headStyles: { fillColor: [22, 160, 133] },
+  });
+
+  const pageCount = (doc as any).internal.getNumberOfPages();
+  for (let i = 1; i <= pageCount; i++) {
+    doc.setPage(i);
+    doc.setFontSize(10);
+    doc.setTextColor(150);
+    doc.text(`Página ${i} de ${pageCount}`, doc.internal.pageSize.width - 20, doc.internal.pageSize.height - 10);
+  }
+
+  doc.save('resumen_tickets.pdf');
+};


### PR DESCRIPTION
This commit fixes the PDF export functionality to allow exporting all tickets to a single PDF. It also improves the UI by renaming the export options and disabling the single ticket export when no ticket is selected.