### PR TITLE
Fix widget build path

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ If your site blocks external JavaScript, you can embed the chatbot using an
 ```html
 <iframe
   id="chatboc-iframe"
-  src="https://www.chatboc.ar/iframe?token=TU_TOKEN_AQUI&tipo_chat=pyme&rubro=comercio" <!-- or "municipio" -->
+  src="https://www.chatboc.ar/iframe.html?token=TU_TOKEN_AQUI&tipo_chat=pyme&rubro=comercio" <!-- or "municipio" -->
   style="position:fixed;bottom:24px;right:24px;border:none;border-radius:50%;z-index:9999;box-shadow:0 4px 32px rgba(0,0,0,0.2);background:transparent;overflow:hidden;width:96px!important;height:96px!important;display:block"
   allow="clipboard-write; geolocation"
   loading="lazy"

--- a/pages/Integracion.tsx
+++ b/pages/Integracion.tsx
@@ -135,7 +135,10 @@ document.addEventListener('DOMContentLoaded', function () {
 });
 </script>`, [userToken, endpoint]);
 
-  const iframeSrcUrl = useMemo(() => `https://www.chatboc.ar/iframe?token=${userToken}&tipo_chat=${endpoint}`, [userToken, endpoint]);
+  const iframeSrcUrl = useMemo(
+    () => `https://www.chatboc.ar/iframe.html?token=${userToken}&tipo_chat=${endpoint}`,
+    [userToken, endpoint]
+  );
   
   const codeIframe = useMemo(() => `<iframe
   id="chatboc-iframe"

--- a/pruebaiframe.html
+++ b/pruebaiframe.html
@@ -1,6 +1,6 @@
 <iframe
   id="chatboc-iframe"
-  src="https://www.chatboc.ar/iframe?token=845a43cf-1711-442a-8888-c924237924fa&tipo_chat=municipio"
+  src="https://www.chatboc.ar/iframe.html?token=845a43cf-1711-442a-8888-c924237924fa&tipo_chat=municipio"
   style="position:fixed; bottom:20px; right:20px; border:none; border-radius:50%; z-index:9999; box-shadow:0 4px 32px rgba(0,0,0,0.2); background:transparent; overflow:hidden; width:112px; height:112px; display:block; transition: width 0.3s ease, height 0.3s ease, border-radius 0.3s ease;"
   allow="clipboard-write; geolocation"
   loading="lazy"

--- a/public/widget.js
+++ b/public/widget.js
@@ -135,7 +135,7 @@
 
       const iframe = document.createElement("iframe");
       iframe.id = iframeId;
-      iframe.src = `${chatbocDomain}/iframe?token=${encodeURIComponent(token)}&widgetId=${iframeId}&defaultOpen=${defaultOpen}&tipo_chat=${tipoChat}&openWidth=${encodeURIComponent(WIDGET_DIMENSIONS_JS.OPEN.width)}&openHeight=${encodeURIComponent(WIDGET_DIMENSIONS_JS.OPEN.height)}&closedWidth=${encodeURIComponent(WIDGET_DIMENSIONS_JS.CLOSED.width)}&closedHeight=${encodeURIComponent(WIDGET_DIMENSIONS_JS.CLOSED.height)}${theme ? `&theme=${encodeURIComponent(theme)}` : ""}${rubroAttr ? `&rubro=${encodeURIComponent(rubroAttr)}` : ""}${finalCta ? `&ctaMessage=${encodeURIComponent(finalCta)}` : ""}`;
+      iframe.src = `${chatbocDomain}/iframe.html?token=${encodeURIComponent(token)}&widgetId=${iframeId}&defaultOpen=${defaultOpen}&tipo_chat=${tipoChat}&openWidth=${encodeURIComponent(WIDGET_DIMENSIONS_JS.OPEN.width)}&openHeight=${encodeURIComponent(WIDGET_DIMENSIONS_JS.OPEN.height)}&closedWidth=${encodeURIComponent(WIDGET_DIMENSIONS_JS.CLOSED.width)}&closedHeight=${encodeURIComponent(WIDGET_DIMENSIONS_JS.CLOSED.height)}${theme ? `&theme=${encodeURIComponent(theme)}` : ""}${rubroAttr ? `&rubro=${encodeURIComponent(rubroAttr)}` : ""}${finalCta ? `&ctaMessage=${encodeURIComponent(finalCta)}` : ""}`;
       Object.assign(iframe.style, {
         border: "none",
         width: "100%", 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -150,6 +150,7 @@ export default defineConfig(({ mode }) => {
       rollupOptions: {
         input: {
           main: path.resolve(__dirname, "index.html"),
+          iframe: path.resolve(__dirname, "iframe.html"),
         },
       },
     },

--- a/widget.js
+++ b/widget.js
@@ -141,7 +141,8 @@
 
       const iframe = document.createElement("iframe");
       iframe.id = iframeId;
-      const iframeSrc = new URL(`${chatbocDomain}/iframe`);
+      // Use explicit .html path so integrations without rewrite rules work
+      const iframeSrc = new URL(`${chatbocDomain}/iframe.html`);
       iframeSrc.searchParams.set("token", token);
       iframeSrc.searchParams.set("widgetId", iframeId);
       iframeSrc.searchParams.set("defaultOpen", defaultOpen);


### PR DESCRIPTION
## Summary
- include `iframe.html` as a Vite build entry so deployments serve the iframe

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68839eac03ac8322a60ec3ce533147ea