### PR TITLE
Fix widget fallback for missing iframe.html

### DIFF
--- a/widget.js
+++ b/widget.js
@@ -185,7 +185,15 @@
         iframe.style.opacity = "1";
       };
 
+      let attemptedFallback = false;
       iframe.onerror = () => {
+        if (!attemptedFallback) {
+          attemptedFallback = true;
+          iframe.style.display = "none";
+          iframe.src = `${chatbocDomain}/iframe`;
+          iframe.style.display = "block";
+          return;
+        }
         iframeHasLoaded = true;
         clearTimeout(loadTimeout);
         loader.innerHTML = `<div style="font-family: system-ui, sans-serif; color: white; font-size: 14px; text-align: center; padding: 10px;">Error al cargar. Intente de nuevo.</div>`;


### PR DESCRIPTION
## Summary
- improve widget error handling: if loading `/iframe.html` fails, retry `/iframe`

## Testing
- `npm test` *(fails: `vitest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6883d9d3b62c83229d0ef63c4a08a554