### PR TITLE
Refactor: Unify chat components and data structures

### DIFF
--- a/src/components/tickets/ChatMessage.tsx
+++ b/src/components/tickets/ChatMessage.tsx
@@ -1,56 +1,14 @@
-import React from 'react';
-import { Message, Ticket, Attachment } from '@/types/tickets';
-import { Paperclip, FileText, ImageIcon } from 'lucide-react';
+import React, { forwardRef } from 'react';
+import ChatMessageBase, { ChatMessageBaseProps } from '@/components/chat/ChatMessageBase';
 
-interface ChatMessageProps {
-  message: Message;
-  user: Ticket;
-}
+export type ChatMessageProps = ChatMessageBaseProps;
 
-const isImage = (filename: string) => {
-  const imageExtensions = ['jpg', 'jpeg', 'png', 'gif', 'webp', 'svg', 'avif'];
-  const extension = filename.split('.').pop()?.toLowerCase();
-  return extension ? imageExtensions.includes(extension) : false;
-};
-
-const AttachmentPreview: React.FC<{ attachment: Attachment }> = ({ attachment }) => {
-  if (isImage(attachment.filename)) {
-    return (
-      <a href={attachment.url} target="_blank" rel="noopener noreferrer" className="mt-2 block">
-        <img src={attachment.url} alt={attachment.filename} className="max-w-xs rounded-lg" />
-      </a>
-    );
+const ChatMessage = forwardRef<HTMLDivElement, ChatMessageProps>(
+  (props, ref) => {
+    return <ChatMessageBase {...props} ref={ref} />;
   }
+);
 
-  return (
-    <a href={attachment.url} target="_blank" rel="noopener noreferrer" className="mt-2 flex items-center gap-2 p-2 rounded-lg bg-black/10 hover:bg-black/20 transition-colors">
-      {attachment.filename.endsWith('.pdf') ? <FileText className="w-6 h-6" /> : <Paperclip className="w-6 h-6" />}
-      <div className="flex flex-col">
-        <span className="font-semibold">{attachment.filename}</span>
-        <span className="text-xs">{Math.round(attachment.size / 1024)} KB</span>
-      </div>
-    </a>
-  );
-};
-
-const ChatMessage: React.FC<ChatMessageProps> = ({ message, user }) => {
-  const isAdmin = message.author === 'agent';
-
-  return (
-    <div className={`flex ${isAdmin ? 'justify-end' : 'justify-start'}`}>
-      <div
-        className={`rounded-lg px-3 py-2 max-w-lg text-sm shadow-md ${isAdmin ? 'bg-blue-600 text-white' : 'bg-gray-200 text-gray-800'}`}
-      >
-        <p className="whitespace-pre-wrap">{message.content}</p>
-        {message.attachments && message.attachments.map(att => (
-          <AttachmentPreview key={att.id} attachment={att} />
-        ))}
-        <div className={`text-xs mt-1 ${isAdmin ? 'text-blue-200' : 'text-gray-500'}`}>
-          {new Date(message.timestamp).toLocaleString()}
-        </div>
-      </div>
-    </div>
-  );
-};
+ChatMessage.displayName = 'ChatMessage';
 
 export default ChatMessage;

--- a/src/types/tickets.ts
+++ b/src/types/tickets.ts
@@ -1,3 +1,5 @@
+import { Boton, StructuredContentItem } from './chat';
+
 export type TicketStatus = 'nuevo' | 'abierto' | 'en-espera' | 'resuelto' | 'cerrado' | 'en_proceso';
 export type TicketPriority = 'baja' | 'media' | 'alta' | 'urgente';
 
@@ -10,21 +12,32 @@ export interface User {
   phone?: string;
 }
 
-export interface Message {
-  id: string;
-  author: 'user' | 'agent';
-  agentName?: string;
-  content: string;
-  timestamp: string;
-  isInternalNote?: boolean;
-}
-
 export interface Attachment {
-  id: string;
+  id: number;
   filename: string;
   url: string;
   size: number;
+  mime_type?: string;
 }
+
+export interface Message {
+  id: number;
+  author: 'user' | 'agent';
+  agentName?: string;
+  content: string; // Corresponds to 'text' in ChatMessageData
+  timestamp: string; // Corresponds to 'timestamp'
+  isInternalNote?: boolean;
+
+  // Fields to align with ChatMessageData
+  attachments?: Attachment[];
+  botones?: Boton[];
+  structuredContent?: StructuredContentItem[];
+
+  // Optional fields from original Message type in tickets
+  media_url?: string;
+  ubicacion?: { lat: number; lon: number; name?: string; address?: string; };
+}
+
 
 export interface Ticket {
   id: number;


### PR DESCRIPTION
This commit unifies the chat components and data structures between the main chat and the live support chat.

- Refactored `ChatMessage` in `tickets` to use the shared `ChatMessageBase` component.
- Adapted `ConversationPanel` to handle the new message and ticket structure, including interactive buttons, structured content, and attachments.
- Updated `Ticket` and `Message` types in `tickets.ts` to align with the main chat.