### PR TITLE
feat: Bypass RubroSelector when entityToken is provided

### DIFF
--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -90,6 +90,15 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
   const [proactiveMessage, setProactiveMessage] = useState<string | null>(null);
   const [showProactiveBubble, setShowProactiveBubble] = useState(false);
   const [proactiveCycle, setProactiveCycle] = useState(0);
+  const [selectedRubro, setSelectedRubro] = useState<string | null>(initialRubro || null);
+  const [hasSetInitialRubro, setHasSetInitialRubro] = useState(false);
+
+  useEffect(() => {
+    if (initialRubro && !hasSetInitialRubro) {
+      setSelectedRubro(initialRubro);
+      setHasSetInitialRubro(true);
+    }
+  }, [initialRubro, hasSetInitialRubro]);
 
   const openUserPanel = useCallback(() => {
     if (user) {
@@ -355,7 +364,24 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
                 : view === "login" ? <ChatUserLoginPanel onSuccess={() => setView("chat")} onShowRegister={() => setView("register")} />
                 : view === "user" ? <ChatUserPanel onClose={() => setView("chat")} />
                 : view === "info" ? <EntityInfoPanel info={entityInfo} onClose={() => setView("chat")} />
-                : <ChatPanel mode={mode} widgetId={widgetId} entityToken={entityToken} initialRubro={initialRubro} openWidth={finalOpenWidth} openHeight={finalOpenHeight} onClose={toggleChat} tipoChat={resolvedTipoChat} onRequireAuth={() => setView("register")} onShowLogin={() => setView("login")} onShowRegister={() => setView("register")} onOpenUserPanel={openUserPanel} muted={muted} onToggleSound={toggleMuted} onCart={openCart} />}
+                : <ChatPanel
+                    mode={mode}
+                    widgetId={widgetId}
+                    entityToken={entityToken}
+                    openWidth={finalOpenWidth}
+                    openHeight={finalOpenHeight}
+                    onClose={toggleChat}
+                    tipoChat={resolvedTipoChat}
+                    onRequireAuth={() => setView("register")}
+                    onShowLogin={() => setView("login")}
+                    onShowRegister={() => setView("register")}
+                    onOpenUserPanel={openUserPanel}
+                    muted={muted}
+                    onToggleSound={toggleMuted}
+                    onCart={openCart}
+                    selectedRubro={selectedRubro}
+                    onRubroSelect={setSelectedRubro}
+                  />}
             </motion.div>
           ) : (
             <motion.div

--- a/widget.js
+++ b/widget.js
@@ -145,7 +145,7 @@
       const iframeSrc = new URL(`${chatbocDomain}/iframe.html`);
       iframeSrc.searchParams.set("token", token);
       iframeSrc.searchParams.set("widgetId", iframeId);
-      iframeSrc.searchParams.set("defaultOpen", defaultOpen);
+      iframeSrc.searchParams.set("defaultOpen", String(defaultOpen));
       iframeSrc.searchParams.set("tipo_chat", tipoChat);
       iframeSrc.searchParams.set("openWidth", WIDGET_DIMENSIONS.OPEN.width);
       iframeSrc.searchParams.set("openHeight", WIDGET_DIMENSIONS.OPEN.height);


### PR DESCRIPTION
This commit modifies the chat widget to bypass the RubroSelector when an entityToken is provided. This allows for a more direct user experience when the widget is embedded in a context where the entity is already known.

Changes include:
- Modified `ChatWidget.tsx` to accept `entityToken` and `initialRubro` props.
- Updated `widget.js` to pass the `data-token` and `data-rubro` attributes to the `ChatWidget` component.
- Modified `ChatPanel.tsx` to bypass the `RubroSelector` if an `entityToken` is provided.