### PR TITLE
fix: Bypass RubroSelector when entityToken is provided

### DIFF
--- a/public/test-widget.html
+++ b/public/test-widget.html
@@ -56,16 +56,24 @@
     -->
     <script>
         document.addEventListener('DOMContentLoaded', function () {
+            const urlParams = new URLSearchParams(window.location.search);
+            const token = urlParams.get('token');
+
+            if (!token) {
+                console.error('No token provided in the URL. Please add a ?token=YOUR_TOKEN parameter.');
+                return;
+            }
+
           // Asegura que el widget se destruya y se vuelva a crear si ya existe
           if (window.chatbocDestroyWidget) {
-            window.chatbocDestroyWidget('845a43cf-1711-442a-8888-c924237924fa');
+            window.chatbocDestroyWidget(token);
           }
           window.APP_TARGET = 'municipio'; // Define el endpoint antes de cargar el script
 
           var s = document.createElement('script');
           s.src = '/widget.js'; // URL del script del widget
           s.async = true; // Carga asíncrona para no bloquear el renderizado de la página
-          s.setAttribute('data-token', '1146cb3e-eaef-4230-b54e-1c340ac062d8'); // Token de autenticación del usuario
+          s.setAttribute('data-token', token); // Token de autenticación del usuario
           s.setAttribute('data-default-open', 'true'); // El widget comienza cerrado por defecto
           s.setAttribute('data-width', '460px'); // Ancho del widget abierto
           s.setAttribute('data-height', '680px'); // Alto del widget abierto

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -537,7 +537,7 @@ const ChatPanel = ({
   );
 
   useEffect(() => {
-    if (esAnonimo && mode === "standalone" && !selectedRubro) {
+    if (esAnonimo && mode === "standalone" && !selectedRubro && !propEntityToken) {
       setEsperandoRubro(true); cargarRubros(); return;
     }
     setEsperandoRubro(false);
@@ -547,7 +547,7 @@ const ChatPanel = ({
       }
       initialMessageAddedRef.current = true;
     }
-  }, [esAnonimo, mode, selectedRubro, messages.length]); // messages.length para re-evaluar si se borran mensajes
+  }, [esAnonimo, mode, selectedRubro, propEntityToken, messages.length]); // messages.length para re-evaluar si se borran mensajes
 
   useEffect(() => {
     const container = chatContainerRef.current;

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -383,7 +383,7 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
                     muted={muted}
                     onToggleSound={toggleMuted}
                     onCart={openCart}
-                    selectedRubro={selectedRubro}
+                    selectedRubro={entityInfo?.rubro || selectedRubro}
                     onRubroSelect={setSelectedRubro}
                   />}
             </motion.div>


### PR DESCRIPTION
This commit fixes an issue where the `RubroSelector` was being displayed even when an `entityToken` was provided. This was caused by the `ChatPanel` component not correctly handling the `entityToken` and `selectedRubro` props.

Changes include:
- Modified `ChatWidget.tsx` to pass the `rubro` from the fetched `entityInfo` to the `ChatPanel` as the `selectedRubro` prop.
- Modified `ChatPanel.tsx` to take into account the `entityToken`. If an `entityToken` is present, `esperandoRubro` is set to `false`.