### PR TITLE
chore(build): Increase Workbox cache limit to 3MB

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,6 +32,7 @@ export default defineConfig(({ mode }) => {
         },
         workbox: {
           globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
+          maximumFileSizeToCacheInBytes: 3 * 1024 * 1024,
           runtimeCaching: [
             {
               urlPattern: /^https:\/\/maps\.googleapis\.com\/.*/,


### PR DESCRIPTION
The Vercel build was failing because the main JavaScript bundle (`assets/main.js`) exceeded the default 2MB `maximumFileSizeToCacheInBytes` limit set by Workbox for precaching.

This commit increases the limit to 3MB in `vite.config.ts` to allow the build to pass with the current bundle size.