### PR TITLE
feat: Add user name to ticket panel and linkify WhatsApp numbers

### DIFF
--- a/src/components/tickets/TicketListItem.tsx
+++ b/src/components/tickets/TicketListItem.tsx
@@ -11,8 +11,8 @@ interface TicketListItemProps {
 }
 
 const TicketListItem: React.FC<TicketListItemProps> = ({ ticket, isSelected, onClick }) => {
-  const getInitials = (name: string) => {
-    return name ? name.split(' ').map(n => n[0]).join('').toUpperCase() : '??';
+const getInitials = (nombre_usuario: string) => {
+    return nombre_usuario ? nombre_usuario.split(' ').map(n => n[0]).join('').toUpperCase() : '??';
   };
 
   return (
@@ -30,11 +30,11 @@ const TicketListItem: React.FC<TicketListItemProps> = ({ ticket, isSelected, onC
       <div className="flex items-start justify-between mb-1">
         <div className="flex items-center gap-3">
           <Avatar className="h-10 w-10">
-            <AvatarImage src={ticket.avatarUrl} alt={ticket.name} />
-            <AvatarFallback>{getInitials(ticket.name || '')}</AvatarFallback>
+            <AvatarImage src={ticket.avatarUrl} alt={ticket.nombre_usuario} />
+            <AvatarFallback>{getInitials(ticket.nombre_usuario || '')}</AvatarFallback>
           </Avatar>
           <div>
-            <p className="font-semibold text-sm">{ticket.name || 'Usuario desconocido'}</p>
+            <p className="font-semibold text-sm">{ticket.nombre_usuario || 'Usuario desconocido'}</p>
             <p className="text-xs text-muted-foreground">{ticket.nro_ticket}</p>
           </div>
         </div>

--- a/src/types/tickets.ts
+++ b/src/types/tickets.ts
@@ -5,7 +5,7 @@ export type TicketPriority = 'baja' | 'media' | 'alta' | 'urgente';
 
 export interface User {
   id: string;
-  name: string;
+  nombre_usuario: string;
   email: string;
   avatarUrl?: string;
   location?: string;
@@ -66,7 +66,7 @@ export interface Ticket {
 
   // For backwards compatibility and flexibility
   user?: User;
-  name?: string;
+  nombre_usuario?: string;
   title?: string; // Keep for components that might still use it
   lastMessage?: string; // Keep for components that might still use it
 }

--- a/src/utils/sanitizeMessageHtml.ts
+++ b/src/utils/sanitizeMessageHtml.ts
@@ -13,17 +13,48 @@ const ALLOWED_TAGS = [
   'li',
   'a',
   'span',
-  // Permitir tablas simples para mostrar catálogos tal cual los envía el backend
   'table',
   'thead',
   'tbody',
   'tr',
   'th',
   'td',
+  'svg', // Allow SVG for icons
+  'path', // Allow path for SVG
 ];
 
+// Regex to find potential phone numbers, avoiding numbers that are part of URLs
+const phoneRegex = /(?<!https:\/\/wa\.me\/)(?<!\d)(?:\+?\d{1,3}[-.\s]?)?(?:\(?\d{2,4}\)?[-.\s]?){2,}\d{3,4}(?!\d)/g;
+
+
 export function sanitizeMessageHtml(html: string): string {
-  return DOMPurify.sanitize(html, { ALLOWED_TAGS });
+  // First, linkify phone numbers that are not already linked
+  const linkifiedHtml = html.replace(phoneRegex, (match) => {
+    // Clean the matched number to create a valid wa.me link
+    const sanitizedNumber = match.replace(/[-.()\s]/g, '');
+
+    // Basic check to avoid linking very short numbers
+    if (sanitizedNumber.length < 9) {
+        return match;
+    }
+
+    // Add country code if missing (assuming Argentina '54' for now)
+    // A more robust solution might require context about the number's origin
+    const fullNumber = sanitizedNumber.startsWith('+') ? sanitizedNumber : `54${sanitizedNumber}`;
+
+    return `<a href="https://wa.me/${fullNumber}" target="_blank" rel="noopener noreferrer" style="color: #25D366; text-decoration: none; font-weight: bold;">
+              ${match}
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display: inline-block; vertical-align: middle; margin-left: 4px;">
+                <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"></path>
+              </svg>
+            </a>`;
+  });
+
+  // Then, sanitize the result
+  return DOMPurify.sanitize(linkifiedHtml, {
+    ALLOWED_TAGS,
+    ALLOWED_ATTR: ['href', 'target', 'rel', 'style', 'xmlns', 'width', 'height', 'viewBox', 'fill', 'stroke', 'stroke-width', 'stroke-linecap', 'stroke-linejoin'],
+  });
 }
 
 export default sanitizeMessageHtml;


### PR DESCRIPTION
This commit introduces two main features:

1.  **Display User Name in Ticket Panel:**
    - The `Ticket` type definition was inconsistent across the app. This has been resolved by consolidating on `nombre_usuario` as the property for your name.
    - The `TicketListItem` component has been updated to use this property, so your name now appears next to your tickets in the main panel.

2.  **Clickable WhatsApp Links:**
    - The `sanitizeMessageHtml` utility has been enhanced to automatically detect phone numbers in chat messages.
    - These numbers are now converted into clickable `https://wa.me/` links, complete with a WhatsApp icon, improving your experience.