### PR TITLE
fix(chat): remove double JSON.stringify in useChatLogic

### DIFF
--- a/src/hooks/useChatLogic.ts
+++ b/src/hooks/useChatLogic.ts
@@ -119,7 +119,7 @@ export function useChatLogic({ initialWelcomeMessage, tipoChat }: UseChatLogicOp
             ...(attachmentInfo && { attachment_info: attachmentInfo }),
             ...(ubicacion_usuario && { ubicacion: ubicacion_usuario }),
         };
-        await apiFetch(`/tickets/chat/${activeTicketId}/responder_ciudadano`, { method: "POST", body: JSON.stringify(bodyRequest) });
+        await apiFetch(`/tickets/chat/${activeTicketId}/responder_ciudadano`, { method: "POST", body: bodyRequest });
       } else {
         const storedUser = JSON.parse(safeLocalStorage.getItem('user') || 'null');
         const rubro = storedUser?.rubro?.clave || storedUser?.rubro?.nombre || safeLocalStorage.getItem("rubroSeleccionado") || null;
@@ -140,7 +140,7 @@ export function useChatLogic({ initialWelcomeMessage, tipoChat }: UseChatLogicOp
         };
 
         const endpoint = getAskEndpoint({ tipoChat: tipoChatFinal, rubro });
-        const data = await apiFetch<any>(endpoint, { method: 'POST', body: JSON.stringify(requestBody) });
+        const data = await apiFetch<any>(endpoint, { method: 'POST', body: requestBody });
         
         const finalContext = updateMunicipioContext(updatedContext, { llmResponse: data });
         setContexto(finalContext);


### PR DESCRIPTION
The apiFetch utility already stringifies the request body if it's not FormData. The handleSend function in useChatLogic was also stringifying the body, leading to a double-stringified payload that the backend could not parse.

This commit removes the redundant JSON.stringify calls from handleSend, ensuring that the request body is sent as a correctly formatted JSON object.