### PR TITLE
fix(chat): suppress user message display on button clicks

### DIFF
--- a/src/hooks/useChatLogic.ts
+++ b/src/hooks/useChatLogic.ts
@@ -117,15 +117,18 @@ export function useChatLogic({ initialWelcomeMessage, tipoChat }: UseChatLogicOp
     if (!userMessageText && !attachmentInfo && !ubicacion_usuario && !action && !actualPayload.archivo_url) return;
     if (isTyping) return;
 
-    const userMessage: Message = {
-      id: generateClientMessageId(),
-      text: userMessageText,
-      isBot: false,
-      timestamp: new Date(),
-      attachmentInfo,
-      locationData: ubicacion_usuario,
-    };
-    setMessages(prev => [...prev, userMessage]);
+    // Solo mostrar el mensaje del usuario si no es una acción de botón
+    if (!action) {
+      const userMessage: Message = {
+        id: generateClientMessageId(),
+        text: userMessageText,
+        isBot: false,
+        timestamp: new Date(),
+        attachmentInfo,
+        locationData: ubicacion_usuario,
+      };
+      setMessages(prev => [...prev, userMessage]);
+    }
     setIsTyping(true);
 
     try {


### PR DESCRIPTION
- I've modified the `handleSend` function in `useChatLogic.ts`.
- A condition is added to check for the presence of an `action` in the send payload.
- If an `action` exists (indicating a button click), the function no longer creates a `userMessage` to be displayed in the chat history.
- This prevents the redundant display of the button's text as a user message, creating a cleaner and more immediate user experience.