### PR TITLE
fix(chat): Ensure widget loads correctly on refresh

### DIFF
--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -262,7 +262,7 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
       console.log("ChatWidget: Intentando obtener perfil con token:", entityToken);
       try {
         const data = await apiFetch<any>("/perfil", {
-          sendEntityToken: true,
+          entityToken: entityToken,
           skipAuth: true,
         });
         console.log("ChatWidget: Perfil recibido:", data);

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -25,7 +25,7 @@ interface ApiFetchOptions {
   body?: any;
   skipAuth?: boolean;
   sendAnonId?: boolean;
-  sendEntityToken?: boolean;
+  entityToken?: string | null;
 }
 
 /**
@@ -37,11 +37,10 @@ export async function apiFetch<T>(
   path: string,
   options: ApiFetchOptions = {}
 ): Promise<T> {
-  const { method = "GET", body, skipAuth, sendAnonId, sendEntityToken } = options;
+  const { method = "GET", body, skipAuth, sendAnonId, entityToken } = options;
 
   const token = safeLocalStorage.getItem("authToken");
   const anonId = safeLocalStorage.getItem("anon_id");
-  const entityToken = safeLocalStorage.getItem("entityToken");
   const chatSessionId = getOrCreateChatSessionId(); // Get or create the chat session ID
 
   const url = `${API_BASE_URL}${path}`;


### PR DESCRIPTION
Refactored the API and ChatWidget components to make entity token handling explicit, fixing a critical bug where the chat widget would fail to load on a page refresh.

Previously, the `apiFetch` utility implicitly read the `entityToken` from localStorage, creating a disconnect with the `ChatWidget` component, which relied on a prop for the same token. This led to a race condition on subsequent page loads, causing the widget to fail to initialize.

The changes are:
1.  Modified `apiFetch` to no longer read from `localStorage`. It now requires the `entityToken` to be passed explicitly in its options.
2.  Updated `ChatWidget` to pass its `entityToken` prop directly to `apiFetch`.

This makes the data flow robust and predictable, resolving the refresh issue.