### PR TITLE
Fix: Correct syntax error in Perfil.tsx

### DIFF
--- a/src/pages/Perfil.tsx
+++ b/src/pages/Perfil.tsx
@@ -438,9 +438,10 @@ export default function Perfil() {
                                                         // Futuro: ir si hay >1 y ninguno es default, o si el usuario elige configurar.
 
     if (shouldGoToMappingPage) {
-    // En lugar de redirigir, ahora abrimos el modal.
-    setIsMappingModalOpen(true);
-    // El resto de la lógica (parseo, etc.) se manejará dentro del modal y sus funciones.
+      // En lugar de redirigir, ahora abrimos el modal.
+      setIsMappingModalOpen(true);
+      // El resto de la lógica (parseo, etc.) se manejará dentro del modal y sus funciones.
+    }
   };
 
   // Lógica de parseo y guardado para el nuevo flujo del modal


### PR DESCRIPTION
The build was failing with an 'Unexpected end of file' error in `src/pages/Perfil.tsx`.

This was caused by a missing closing brace for an `if` statement within the `handleSubirArchivo` function. This change adds the missing brace, which resolves the parsing error and allows the build to complete successfully.