### PR TITLE
fix(chat): Pass entity token to API calls from embedded widget

### DIFF
--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -80,6 +80,7 @@ const ChatPanel = ({
   const { messages, isTyping, handleSend, activeTicketId, setMessages } = useChatLogic({
     initialWelcomeMessage: "¡Hola! Soy Chatboc. ¿En qué puedo ayudarte hoy?",
     tipoChat: tipoChat,
+    entityToken: propEntityToken,
   });
 
   const [esperandoDireccion, setEsperandoDireccion] = useState(false);

--- a/src/hooks/useChatLogic.ts
+++ b/src/hooks/useChatLogic.ts
@@ -12,9 +12,10 @@ import { MunicipioContext, updateMunicipioContext, getInitialMunicipioContext } 
 interface UseChatLogicOptions {
   initialWelcomeMessage: string;
   tipoChat: 'pyme' | 'municipio';
+  entityToken?: string | null;
 }
 
-export function useChatLogic({ initialWelcomeMessage, tipoChat }: UseChatLogicOptions) {
+export function useChatLogic({ initialWelcomeMessage, tipoChat, entityToken }: UseChatLogicOptions) {
   const [messages, setMessages] = useState<Message[]>([]);
   const [isTyping, setIsTyping] = useState(false);
   const [contexto, setContexto] = useState<MunicipioContext>(() => getInitialMunicipioContext());
@@ -159,7 +160,11 @@ export function useChatLogic({ initialWelcomeMessage, tipoChat }: UseChatLogicOp
         };
 
         const endpoint = getAskEndpoint({ tipoChat: tipoChatFinal, rubro });
-        const data = await apiFetch<any>(endpoint, { method: 'POST', body: requestBody });
+        const data = await apiFetch<any>(endpoint, {
+          method: 'POST',
+          body: requestBody,
+          entityToken,
+        });
         
         const finalContext = updateMunicipioContext(updatedContext, { llmResponse: data });
         setContexto(finalContext);
@@ -189,7 +194,7 @@ export function useChatLogic({ initialWelcomeMessage, tipoChat }: UseChatLogicOp
     } finally {
       setIsTyping(false);
     }
-  }, [contexto, activeTicketId, isTyping, isAnonimo, anonId, currentClaimIdempotencyKey, tipoChat]);
+  }, [contexto, activeTicketId, isTyping, isAnonimo, anonId, currentClaimIdempotencyKey, tipoChat, entityToken]);
 
   return { messages, isTyping, handleSend, activeTicketId, setMessages, setContexto, setActiveTicketId };
 }


### PR DESCRIPTION
This commit fixes a bug where the embedded chat widget would display a "No se pudo generar una respuesta" error because the backend was not receiving the necessary entity token to process the request.

The `entityToken` was being correctly passed from the embed script to the iframe and down through the component hierarchy, but it was not being included in the final API call.

The fix involves:
1.  Updating the `useChatLogic` hook to accept an `entityToken` and pass it to the `apiFetch` utility.
2.  Modifying the `ChatPanel` component to pass the `entityToken` it receives as a prop to the `useChatLogic` hook.

This ensures that all API requests from the embedded widget include the `X-Entity-Token` header, allowing the backend to correctly identify the municipality and provide a valid response.