### PR TITLE
fix(widget): Correct initial size and SVG rendering on refresh

### DIFF
--- a/public/widget.js
+++ b/public/widget.js
@@ -39,14 +39,17 @@
   iframe.style.cssText = 'width: 100%; height: 100%; border: none; background: transparent;';
   iframe.allow = 'clipboard-write; geolocation';
 
+  const closedWidth = params.get('closed-width') || '100px';
+  const closedHeight = params.get('closed-height') || '100px';
+
   const style = document.createElement('style');
   style.textContent = `
     :host {
       position: fixed;
-      bottom: 20px;
-      right: 20px;
-      width: 100px;
-      height: 100px;
+      bottom: ${params.get('bottom') || '20px'};
+      right: ${params.get('right') || '20px'};
+      width: ${closedWidth};
+      height: ${closedHeight};
       z-index: 2147483647;
       border: none;
       background: transparent;

--- a/src/components/chat/ChatbocLogoAnimated.tsx
+++ b/src/components/chat/ChatbocLogoAnimated.tsx
@@ -79,10 +79,9 @@ const ChatbocLogoAnimated = ({
       >
         {/* Ojos */}
         <motion.circle
-          cx={leftEyeX ?? 18}
-          cy={eyeBaseY ?? 24}
           r={3.5}
           fill="#FFFFFF"
+          initial={{ cx: leftEyeX ?? 18, cy: eyeBaseY ?? 24 }}
           animate={{ cx: leftEyeX ?? 18, cy: eyeBaseY ?? 24 }}
           transition={
             blinking
@@ -94,10 +93,9 @@ const ChatbocLogoAnimated = ({
           style={{ transformOrigin: "center" }}
         />
         <motion.circle
-          cx={rightEyeX ?? 38}
-          cy={eyeBaseY ?? 24}
           r={3.5}
           fill="#FFFFFF"
+          initial={{ cx: rightEyeX ?? 38, cy: eyeBaseY ?? 24 }}
           animate={{ cx: rightEyeX ?? 38, cy: eyeBaseY ?? 24 }}
           transition={
             blinking


### PR DESCRIPTION
I addressed two issues that caused your chat widget to break upon a hard page refresh:

1.  **Incorrect Initial Size:** The `widget.js` script was hardcoding the initial container size to 100x100px, ignoring the `data-closed-width` and `data-closed-height` attributes. This caused a visual glitch where the widget content would overflow its container on refresh. I updated the script to read these attributes and apply them to the widget container, ensuring it loads with the correct dimensions from the start.

2.  **SVG Rendering Error:** The `ChatbocLogoAnimated` component contained redundant SVG attributes (`cx`, `cy`) that were also being controlled by `framer-motion`. This likely caused a race condition during refresh, leading to `framer-motion` assigning an `undefined` value and breaking the SVG rendering. I refactored the component to handle these attributes exclusively through `framer-motion`'s `initial` and `animate` props, making the rendering more robust.