### PR TITLE
feat(chat): Add categorized accordions for chat options

### DIFF
--- a/src/components/chat/CategorizedButtons.tsx
+++ b/src/components/chat/CategorizedButtons.tsx
@@ -1,0 +1,116 @@
+// src/components/chat/CategorizedButtons.tsx
+import React from 'react';
+import { Categoria, SendPayload, Boton } from '@/types/chat';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
+import { motion } from 'framer-motion';
+
+interface CategorizedButtonsProps {
+  categorias: Categoria[];
+  onButtonClick: (payload: SendPayload) => void;
+  onInternalAction?: (action: string) => void;
+}
+
+// We need a simplified button handler here since ChatButtons is complex.
+// Let's create a lean version for the accordion content.
+const SimpleButton: React.FC<{ boton: Boton, onClick: (boton: Boton) => void }> = ({ boton, onClick }) => {
+    const baseClass = "rounded-xl px-3 py-1 text-sm font-semibold bg-white text-blue-800 border border-blue-200 hover:bg-blue-50 hover:shadow transition-all text-left";
+
+    if (boton.url) {
+        return (
+            <a
+                href={boton.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={`${baseClass} no-underline inline-block w-full`}
+                title={boton.texto}
+            >
+                {boton.texto}
+            </a>
+        );
+    }
+
+    return (
+        <button
+            onClick={() => onClick(boton)}
+            className={`${baseClass} w-full`}
+            title={boton.texto}
+        >
+            {boton.texto}
+        </button>
+    );
+};
+
+
+const CategorizedButtons: React.FC<CategorizedButtonsProps> = ({
+  categorias,
+  onButtonClick,
+  onInternalAction,
+}) => {
+  if (!categorias || categorias.length === 0) {
+    return null;
+  }
+
+  const handleButtonClick = (boton: Boton) => {
+    const normalize = (v: string) => v.toLowerCase().replace(/[\s_-]+/g, "");
+    const loginActions = ["login", "loginpanel", "chatuserloginpanel"].map(normalize);
+    const registerActions = ["register", "registerpanel", "chatuserregisterpanel"].map(normalize);
+
+    const action = boton.action || boton.accion_interna;
+    const normalizedAction = action ? normalize(action) : null;
+
+    if (normalizedAction && (loginActions.includes(normalizedAction) || registerActions.includes(normalizedAction))) {
+        if (onInternalAction) onInternalAction(normalizedAction);
+        return;
+    }
+
+    if (action) {
+      onButtonClick({ text: boton.texto, action: action });
+      if (onInternalAction) onInternalAction(action);
+      return;
+    }
+
+    if (boton.url) {
+      window.open(boton.url, "_blank", "noopener,noreferrer");
+      return;
+    }
+
+    onButtonClick({ text: boton.texto });
+  };
+
+  return (
+    <motion.div
+      className="w-full mt-2"
+      initial={{ opacity: 0, y: -10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3, ease: "easeOut" }}
+    >
+      <Accordion type="multiple" className="w-full">
+        {categorias.map((categoria, index) => (
+          <AccordionItem value={`cat-${index}`} key={index}>
+            <AccordionTrigger className="text-sm font-semibold hover:no-underline py-3">
+              {categoria.titulo}
+            </AccordionTrigger>
+            <AccordionContent>
+                <div className="flex flex-col gap-2 pt-1">
+                    {categoria.botones.map((boton, btnIndex) => (
+                        <SimpleButton
+                            key={btnIndex}
+                            boton={boton}
+                            onClick={handleButtonClick}
+                        />
+                    ))}
+                </div>
+            </AccordionContent>
+          </AccordionItem>
+        ))}
+      </Accordion>
+    </motion.div>
+  );
+};
+
+export default CategorizedButtons;

--- a/src/components/chat/ChatMessageBase.tsx
+++ b/src/components/chat/ChatMessageBase.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import { Message, SendPayload, StructuredContentItem } from "@/types/chat";
 import ChatButtons from "./ChatButtons";
+import CategorizedButtons from "./CategorizedButtons";
 import { motion } from "framer-motion";
 import ChatbocLogoAnimated from "./ChatbocLogoAnimated";
 import sanitizeMessageHtml from "@/utils/sanitizeMessageHtml";
@@ -231,14 +232,20 @@ const ChatMessageBase = React.forwardRef<HTMLDivElement, ChatMessageBaseProps>( 
             </>
           )}
 
-          {/* Botones siempre al final si existen */}
-          {isBot && message.botones && message.botones.length > 0 && (
+          {/* Botones siempre al final si existen, con lógica condicional */}
+          {isBot && message.categorias && message.categorias.length > 0 ? (
+            <CategorizedButtons
+              categorias={message.categorias}
+              onButtonClick={onButtonClick}
+              onInternalAction={onInternalAction}
+            />
+          ) : isBot && message.botones && message.botones.length > 0 ? (
             <ChatButtons
               botones={message.botones}
               onButtonClick={onButtonClick}
               onInternalAction={onInternalAction}
             />
-          )}
+          ) : null}
         </MessageBubble>
 
         {!isBot && <UserChatAvatar />}

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -5,12 +5,18 @@ export interface AttachmentInfo {
   mimeType?: string;
   size?: number;
 }
-// Define cómo es un objeto Botón
+// Define cómo es un objeto Boton
 export interface Boton {
   texto: string;
   url?: string;
   accion_interna?: string; // Para acciones que el frontend debe interpretar sin enviar al backend (ej. abrir panel)
   action?: string; // Valor que se envía al backend cuando se hace clic en el botón
+}
+
+// Nuevo: Define la estructura para una categoría de botones
+export interface Categoria {
+  titulo: string; // Título de la categoría que se mostrará en el acordeón
+  botones: Boton[]; // Array de botones dentro de esa categoría
 }
 
 // Nuevo: Define la estructura para contenido estructurado dentro de un mensaje
@@ -32,6 +38,7 @@ export interface Message {
   isBot: boolean; // True si el mensaje es del bot, false si es del usuario
   timestamp: Date; // Fecha y hora del mensaje
   botones?: Boton[]; // Array de botones interactivos asociados al mensaje (si los hay)
+  categorias?: Categoria[]; // Array de categorías con botones (formato anidado para acordeones)
   query?: string; // La consulta original del usuario que generó esta respuesta (opcional)
 
   // Campos para contenido multimedia y adjuntos


### PR DESCRIPTION
This commit introduces a new UI for displaying chat options in the widget. Instead of a flat list of buttons, options can now be grouped into categories and displayed within an accordion. This improves your experience when there are many options available, making the list more organized and easier to navigate.

The changes include:
- A new `Categoria` type in `src/types/chat.ts` to support a structured response from the backend.
- A new `CategorizedButtons` component that renders the accordion UI.
- The `ChatMessageBase` component is updated to conditionally render either the new categorized view or the old flat button list, ensuring backward compatibility.