### PR TITLE
feat: Replace speech-to-text with audio recording

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -2,9 +2,10 @@
 import React, { useState, useEffect, useRef } from "react";
 import { Send, MapPin, Mic, MicOff } from "lucide-react";
 import AdjuntarArchivo from "@/components/ui/AdjuntarArchivo";
+import { apiFetch } from "@/utils/api";
 import { requestLocation } from "@/utils/geolocation";
 import { toast } from "@/components/ui/use-toast";
-import useSpeechRecognition from "@/hooks/useSpeechRecognition";
+import useAudioRecorder from "@/hooks/useAudioRecorder";
 import { AttachmentInfo } from "@/utils/attachment";
 import { SendPayload } from "@/types/chat"; // Asegúrate que SendPayload en types/chat.ts tiene attachmentInfo
 
@@ -27,7 +28,7 @@ const ChatInput: React.FC<Props> = ({ onSendMessage, isTyping, inputRef, onTypin
   const [placeholderIndex, setPlaceholderIndex] = useState(0);
   const [isLocating, setIsLocating] = useState(false);
   const internalRef = inputRef || useRef<HTMLInputElement>(null);
-  const { supported, listening, transcript, start, stop } = useSpeechRecognition();
+  const { isRecording, startRecording, stopRecording } = useAudioRecorder();
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -103,22 +104,47 @@ const ChatInput: React.FC<Props> = ({ onSendMessage, isTyping, inputRef, onTypin
     onTypingChange?.(false);
   };
 
-  useEffect(() => {
-    if (!listening && transcript) {
-      onSendMessage({ text: transcript.trim() });
-      setInput("");
-      onTypingChange?.(false);
-      internalRef.current?.focus();
+  const handleSendAudio = async (audioBlob: Blob) => {
+    if (isTyping) return;
+    toast({ title: "Enviando audio...", description: "Tu grabación se está procesando.", duration: 3000 });
+
+    const formData = new FormData();
+    formData.append('archivo', audioBlob, `audio-grabado-${Date.now()}.webm`);
+
+    try {
+      const data = await apiFetch<any>('/archivos/subir', {
+        method: 'POST',
+        body: formData,
+      });
+
+      if (!data || !data.url || !data.filename) {
+        toast({ title: "Error de subida", description: "La respuesta del servidor fue inválida.", variant: "destructive" });
+        return;
+      }
+
+      onSendMessage({
+        text: `Audio adjunto: ${data.filename}`,
+        archivo_url: data.url,
+        attachmentInfo: {
+          name: data.filename,
+          url: data.url,
+          mimeType: 'audio/webm',
+        }
+      });
+      toast({ title: "Audio enviado", description: "Tu mensaje de voz ha sido enviado.", duration: 3000 });
+    } catch (error) {
+      console.error("Error al enviar audio:", error);
+      toast({ title: "Error al enviar audio", description: "Hubo un problema al subir tu grabación.", variant: "destructive" });
     }
-  }, [listening, transcript]);
+  };
 
   return (
     <div className="w-full flex items-center gap-1 sm:gap-2 px-2 py-2 sm:px-3 sm:py-3 bg-background">
-      <AdjuntarArchivo onUpload={handleFileUploaded} asImage />
-      <AdjuntarArchivo onUpload={handleFileUploaded} />
+      <AdjuntarArchivo onUpload={handleFileUploaded} asImage disabled={isRecording} />
+      <AdjuntarArchivo onUpload={handleFileUploaded} disabled={isRecording} />
       <button
         onClick={handleShareLocation}
-        disabled={isTyping || isLocating}
+        disabled={isTyping || isLocating || isRecording}
         className={`
           flex items-center justify-center
           rounded-full p-2 sm:p-2.5
@@ -134,18 +160,21 @@ const ChatInput: React.FC<Props> = ({ onSendMessage, isTyping, inputRef, onTypin
         {isLocating ? <div className="w-5 h-5 border-2 border-t-transparent border-white rounded-full animate-spin" /> : <MapPin className="w-5 h-5" />}
       </button>
       <button
-        onClick={() => {
-          if (listening) {
-            stop();
-          } else {
-            if (!supported) {
-              toast({ title: "Dictado no soportado", description: "Tu navegador no admite reconocimiento de voz", variant: "destructive" });
-              return;
+        onClick={async () => {
+          if (isRecording) {
+            const audioBlob = await stopRecording();
+            if (audioBlob) {
+              handleSendAudio(audioBlob);
             }
-            start();
+          } else {
+            try {
+              await startRecording();
+            } catch (error) {
+              toast({ title: "Error al grabar", description: "No se pudo iniciar la grabación. Verifica los permisos del micrófono.", variant: "destructive" });
+            }
           }
         }}
-        disabled={isTyping}
+        disabled={isTyping || isLocating}
         className={`
           flex items-center justify-center
           rounded-full p-2 sm:p-2.5
@@ -153,13 +182,13 @@ const ChatInput: React.FC<Props> = ({ onSendMessage, isTyping, inputRef, onTypin
           focus:outline-none focus:ring-2 focus:ring-primary/60 focus:ring-offset-1 focus:ring-offset-background
           active:scale-95
           bg-secondary text-secondary-foreground hover:bg-secondary/80
-          ${isTyping ? "opacity-50 cursor-not-allowed" : ""}
-          ${listening ? "text-destructive bg-destructive/20 hover:bg-destructive/30" : ""}
+          ${isTyping || isLocating ? "opacity-50 cursor-not-allowed" : ""}
+          ${isRecording ? "text-destructive bg-destructive/20 hover:bg-destructive/30" : ""}
         `}
-        aria-label={listening ? "Detener dictado" : "Dictar mensaje"}
+        aria-label={isRecording ? "Detener grabación" : "Grabar audio"}
         type="button"
       >
-        {listening ? <MicOff className="w-5 h-5" /> : <Mic className="w-5 h-5" />}
+        {isRecording ? <MicOff className="w-5 h-5" /> : <Mic className="w-5 h-5" />}
       </button>
       <input
         ref={internalRef}
@@ -195,7 +224,7 @@ const ChatInput: React.FC<Props> = ({ onSendMessage, isTyping, inputRef, onTypin
         autoComplete="off"
         maxLength={200}
         aria-label="Escribir mensaje"
-        disabled={isTyping}
+        disabled={isTyping || isRecording}
       />
       <button
         className={`
@@ -208,7 +237,7 @@ const ChatInput: React.FC<Props> = ({ onSendMessage, isTyping, inputRef, onTypin
           disabled:opacity-50 disabled:cursor-not-allowed
         `}
         onClick={handleSend}
-        disabled={!input.trim() || isTyping}
+        disabled={!input.trim() || isTyping || isRecording}
         aria-label="Enviar mensaje"
         type="button"
       >

--- a/src/components/ui/AdjuntarArchivo.tsx
+++ b/src/components/ui/AdjuntarArchivo.tsx
@@ -17,9 +17,10 @@ const IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif', 'webp', 'svg', 'avif'];
 export interface AdjuntarArchivoProps {
   onUpload?: (data: any) => void;
   asImage?: boolean;
+  disabled?: boolean;
 }
 
-const AdjuntarArchivo: React.FC<AdjuntarArchivoProps> = ({ onUpload, asImage = false }) => {
+const AdjuntarArchivo: React.FC<AdjuntarArchivoProps> = ({ onUpload, asImage = false, disabled = false }) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const { user } = useUser();
 
@@ -103,7 +104,7 @@ const AdjuntarArchivo: React.FC<AdjuntarArchivoProps> = ({ onUpload, asImage = f
         size="icon"
         type="button" // Importante para no enviar formularios accidentalmente
         aria-label="Adjuntar archivo"
-        // Podríamos añadir un estado 'disabled' mientras sube, si es necesario.
+        disabled={disabled}
       >
         <Paperclip className="w-4 h-4" />
       </Button>
@@ -113,6 +114,7 @@ const AdjuntarArchivo: React.FC<AdjuntarArchivoProps> = ({ onUpload, asImage = f
         accept={allowedExtensions.map((ext) => `.${ext}`).join(',')}
         className="hidden"
         onChange={handleFileChange}
+        disabled={disabled}
       />
       {/* El span de error local se ha eliminado. Los errores se muestran mediante toasts. */}
     </div>

--- a/src/hooks/useAudioRecorder.ts
+++ b/src/hooks/useAudioRecorder.ts
@@ -1,0 +1,85 @@
+// src/hooks/useAudioRecorder.ts
+import { useState, useRef, useCallback } from 'react';
+
+type AudioRecorderState = 'inactive' | 'recording' | 'paused';
+
+interface UseAudioRecorderReturn {
+  recorderState: AudioRecorderState;
+  startRecording: () => Promise<void>;
+  stopRecording: () => Promise<Blob | null>;
+  isRecording: boolean;
+}
+
+export const useAudioRecorder = (): UseAudioRecorderReturn => {
+  const [recorderState, setRecorderState] = useState<AudioRecorderState>('inactive');
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const audioChunksRef = useRef<Blob[]>([]);
+
+  const startRecording = useCallback(async (): Promise<void> => {
+    if (recorderState !== 'inactive') {
+      console.warn('Recording is already active.');
+      return;
+    }
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const recorder = new MediaRecorder(stream);
+      mediaRecorderRef.current = recorder;
+      audioChunksRef.current = [];
+
+      recorder.ondataavailable = (event) => {
+        if (event.data.size > 0) {
+          audioChunksRef.current.push(event.data);
+        }
+      };
+
+      recorder.onstart = () => {
+        setRecorderState('recording');
+      };
+
+      // The 'stop' event is handled in the stopRecording function to return the Blob.
+      recorder.start();
+    } catch (error) {
+      console.error('Error starting audio recording:', error);
+      setRecorderState('inactive');
+      // Re-throw to allow UI components to catch the error and show a toast
+      throw error;
+    }
+  }, [recorderState]);
+
+  const stopRecording = useCallback((): Promise<Blob | null> => {
+    return new Promise((resolve) => {
+      const recorder = mediaRecorderRef.current;
+      if (!recorder || recorderState !== 'recording') {
+        console.warn('No active recording to stop.');
+        resolve(null);
+        return;
+      }
+
+      recorder.onstop = () => {
+        const audioBlob = new Blob(audioChunksRef.current, { type: 'audio/webm' });
+
+        // Stop all media tracks to turn off the microphone indicator in the browser
+        recorder.stream.getTracks().forEach(track => track.stop());
+
+        // Reset state
+        audioChunksRef.current = [];
+        mediaRecorderRef.current = null;
+        setRecorderState('inactive');
+
+        resolve(audioBlob);
+      };
+
+      recorder.stop();
+    });
+  }, [recorderState]);
+
+  return {
+    recorderState,
+    startRecording,
+    stopRecording,
+    isRecording: recorderState === 'recording',
+  };
+};
+
+export default useAudioRecorder;


### PR DESCRIPTION
- Replaced the speech-to-text dictation functionality with a new audio recording feature.
- Created a new `useAudioRecorder` hook to handle audio recording logic using the MediaRecorder API.
- Updated the `ChatInput` component to use the new hook, allowing you to record and send audio messages.
- The recorded audio is uploaded to the `/archivos/subir` endpoint.
- The UI has been updated to show the recording state and disable other controls during recording.