### PR TITLE
fix: Keep chat input enabled when live chat is unavailable

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -15,7 +15,6 @@ interface Props {
   inputRef?: React.RefObject<HTMLInputElement>;
   onTypingChange?: (typing: boolean) => void;
   onFileUploaded: (data: any) => void;
-  disabled?: boolean;
 }
 
 const PLACEHOLDERS = [
@@ -25,7 +24,7 @@ const PLACEHOLDERS = [
   "¿Cuánto cuesta el servicio?",
 ];
 
-const ChatInput: React.FC<Props> = ({ onSendMessage, isTyping, inputRef, onTypingChange, onFileUploaded, disabled = false }) => {
+const ChatInput: React.FC<Props> = ({ onSendMessage, isTyping, inputRef, onTypingChange, onFileUploaded }) => {
   const [input, setInput] = useState("");
   const [placeholderIndex, setPlaceholderIndex] = useState(0);
   const [isLocating, setIsLocating] = useState(false);
@@ -111,11 +110,11 @@ const ChatInput: React.FC<Props> = ({ onSendMessage, isTyping, inputRef, onTypin
 
   return (
     <div className="w-full flex items-center gap-1 sm:gap-2 px-2 py-2 sm:px-3 sm:py-3 bg-background">
-      <AdjuntarArchivo onUpload={handleFileUploaded} asImage disabled={isRecording || disabled} />
-      <AdjuntarArchivo onUpload={handleFileUploaded} disabled={isRecording || disabled} />
+      <AdjuntarArchivo onUpload={handleFileUploaded} asImage disabled={isRecording} />
+      <AdjuntarArchivo onUpload={handleFileUploaded} disabled={isRecording} />
       <button
         onClick={handleShareLocation}
-        disabled={isTyping || isLocating || isRecording || disabled}
+        disabled={isTyping || isLocating || isRecording}
         className={`
           flex items-center justify-center
           rounded-full p-2 sm:p-2.5
@@ -145,7 +144,7 @@ const ChatInput: React.FC<Props> = ({ onSendMessage, isTyping, inputRef, onTypin
             }
           }
         }}
-        disabled={isTyping || isLocating || disabled}
+        disabled={isTyping || isLocating}
         className={`
           flex items-center justify-center
           rounded-full p-2 sm:p-2.5
@@ -195,7 +194,7 @@ const ChatInput: React.FC<Props> = ({ onSendMessage, isTyping, inputRef, onTypin
         autoComplete="off"
         maxLength={200}
         aria-label="Escribir mensaje"
-        disabled={isTyping || isRecording || disabled}
+        disabled={isTyping || isRecording}
       />
       <button
         className={`
@@ -208,7 +207,7 @@ const ChatInput: React.FC<Props> = ({ onSendMessage, isTyping, inputRef, onTypin
           disabled:opacity-50 disabled:cursor-not-allowed
         `}
         onClick={handleSend}
-        disabled={!input.trim() || isTyping || isRecording || disabled}
+        disabled={!input.trim() || isTyping || isRecording}
         aria-label="Enviar mensaje"
         type="button"
       >

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -254,12 +254,14 @@ const ChatPanel = ({
                 Hablar con un representante
               </Button>
             ) : (
-              <div className="text-center text-sm text-muted-foreground p-2">
-                <p>Nuestros agentes no están disponibles en este momento.</p>
-                <p>
-                  <strong>Horario de atención:</strong> {horariosAtencion}
-                </p>
-              </div>
+              horariosAtencion && (
+                <div className="text-center text-sm text-muted-foreground p-2">
+                  <p>Para hablar con un representante, nuestro horario de atención es:</p>
+                  <p>
+                    <strong>{horariosAtencion}</strong>
+                  </p>
+                </div>
+              )
             )
         )}
         <ChatInput
@@ -268,7 +270,6 @@ const ChatPanel = ({
           inputRef={chatInputRef}
           onTypingChange={setUserTyping}
           onFileUploaded={handleFileUploaded}
-          disabled={!activeTicketId && !isLiveChatEnabled}
         />
       </div>
     </div>


### PR DESCRIPTION
This commit fixes an issue where the chat input was disabled when the live chat with an agent was not available. You should be able to interact with the bot at all times.

Changes:
- The `disabled` prop has been removed from the `ChatInput` component.
- The `ChatPanel` component no longer disables the `ChatInput` when live chat is unavailable. The business hours message is now displayed above the chat input.