### PR TITLE
feat: Enhance frontend error handling and UI

### DIFF
--- a/src/components/chat/ChatMessageBase.tsx
+++ b/src/components/chat/ChatMessageBase.tsx
@@ -200,7 +200,15 @@ const ChatMessageBase = React.forwardRef<HTMLDivElement, ChatMessageBaseProps>( 
       <div className={`flex items-end gap-2 ${isBot ? "" : "flex-row-reverse"}`}>
         {isBot && <AvatarBot isTyping={isTyping} />}
 
-        <MessageBubble className={cn(bubbleBaseClass, bubbleStyleClass)}>
+        <MessageBubble className={cn(bubbleBaseClass, bubbleStyleClass, message.isError && "bg-destructive/20 border border-destructive/50")}>
+          {/* Icono de error */}
+          {message.isError && (
+            <div className="flex items-center gap-2 mb-2 text-destructive">
+              <UserIcon size={16} className="text-destructive" />
+              <span className="font-semibold">Error</span>
+            </div>
+          )}
+
           {/* Prioridad al texto si no hay otros contenidos especiales */}
           {(!showAttachmentOrMap && !showStructuredContent && sanitizedHtml) && (
             <span

--- a/src/hooks/useChatLogic.ts
+++ b/src/hooks/useChatLogic.ts
@@ -214,6 +214,7 @@ export function useChatLogic({ initialWelcomeMessage, tipoChat }: UseChatLogicOp
         const finalContext = updateMunicipioContext(updatedContext, { llmResponse: data });
         setContexto(finalContext);
         
+        const isErrorResponse = !data.respuesta_usuario;
         const botMessage: Message = {
           id: generateClientMessageId(),
           text: data.respuesta_usuario || "⚠️ No se pudo generar una respuesta.",
@@ -223,6 +224,7 @@ export function useChatLogic({ initialWelcomeMessage, tipoChat }: UseChatLogicOp
           mediaUrl: data.media_url,
           locationData: data.location_data,
           attachmentInfo: data.attachment_info,
+          isError: isErrorResponse,
         };
         setMessages(prev => [...prev, botMessage]);
 
@@ -234,7 +236,7 @@ export function useChatLogic({ initialWelcomeMessage, tipoChat }: UseChatLogicOp
       }
     } catch (error: any) {
       const errorMsg = getErrorMessage(error, '⚠️ No se pudo conectar con el servidor.');
-      setMessages(prev => [...prev, { id: generateClientMessageId(), text: errorMsg, isBot: true, timestamp: new Date() }]);
+      setMessages(prev => [...prev, { id: generateClientMessageId(), text: errorMsg, isBot: true, timestamp: new Date(), isError: true }]);
     } finally {
       setIsTyping(false);
     }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -130,13 +130,26 @@ export async function apiFetch<T>(
 /**
  * Extrae un mensaje amigable de error para mostrar en la interfaz.
  */
-export function getErrorMessage(error: unknown, fallback = "Error") {
+export function getErrorMessage(error: unknown, fallback = "Ocurrió un error inesperado.") {
   if (error instanceof ApiError) {
-    if (error.status === 403) return "Acceso prohibido";
-    if (error.status === 404) return "No encontrado";
-    return error.message;
+    switch (error.status) {
+      case 400:
+        return "Hubo un problema con la solicitud. Por favor, verifica los datos enviados.";
+      case 401:
+        return "No estás autorizado para realizar esta acción. Por favor, inicia sesión de nuevo.";
+      case 403:
+        return "No tienes permiso para acceder a este recurso.";
+      case 404:
+        return "No se pudo encontrar el recurso solicitado (Error 404).";
+      case 500:
+        return "Ocurrió un error en el servidor. Por favor, intenta de nuevo más tarde.";
+      default:
+        // Usa el mensaje de la API si está disponible, si no, un genérico con el status.
+        return error.message || `Ocurrió un error (código: ${error.status})`;
+    }
   }
   if (error && typeof (error as any).message === "string") {
+    // Para errores que no son de la API pero tienen un mensaje (ej. errores de red)
     return (error as any).message;
   }
   return fallback;


### PR DESCRIPTION
This commit introduces several improvements to the frontend to provide a better user experience when errors occur.

Key changes:
- **Improved API Error Messages:** The `getErrorMessage` function in `src/utils/api.ts` now returns more specific and user-friendly messages for common HTTP error codes (400, 401, 403, 404, 500).
- **Enhanced Error Display in Chat:**
  - Messages identified as errors are now visually distinguished with a different background color, a border, and an error icon.
  - The `useChatLogic` hook has been updated to flag messages as errors, both for failed API calls and for empty responses from the backend (e.g., "No se pudo generar una respuesta").

These changes address your feedback about unhelpful error messages and improve the overall robustness of the chat widget.