### PR TITLE
fix(chat): Correctly parse button actions from backend

### DIFF
--- a/utils/parseChatResponse.ts
+++ b/utils/parseChatResponse.ts
@@ -5,6 +5,7 @@ export interface Boton {
   url?: string;
   accion_interna?: string;
   action?: string;
+  action_id?: string;
 }
 
 export interface ChatApiResponse {
@@ -57,6 +58,7 @@ export function parseChatResponse(data: ChatApiResponse): {
   botones = botones.map((b) => ({
     ...b,
     action: b.action ?? b.accion_interna,
+    url: b.url ?? b.action_id,
   }));
 
   // Validar y limpiar attachmentInfo si es necesario


### PR DESCRIPTION
The backend was sending an `action_id` field for buttons that should navigate to a URL. The frontend was not correctly parsing this field, causing the buttons to not work as expected.

This change updates the `parseChatResponse` function to:
1. Add `action_id` to the `Boton` interface.
2. Map the `action_id` from the backend response to the `url` property of the button object used by the frontend.