### PR TITLE
feat: Display more user information in ticket details

### DIFF
--- a/src/components/tickets/DetailsPanel.tsx
+++ b/src/components/tickets/DetailsPanel.tsx
@@ -36,7 +36,29 @@ const DetailsPanel: React.FC = () => {
     );
   }
 
-  const userName = ticket.nombre_usuario || ticket.user?.nombre_usuario || 'Usuario Desconocido';
+  const extractUserNameFromSubject = (subject: string) => {
+    if (!subject) return null;
+
+    const patterns = [
+      /Solicitud de Chat en Vivo por:\s*(.*)/i,
+      /Reclamo \(LLM\):\s*(.*)/i,
+    ];
+
+    for (const pattern of patterns) {
+      const match = subject.match(pattern);
+      if (match && match[1]) {
+        return match[1].trim();
+      }
+    }
+
+    return null;
+  };
+
+  const userName =
+    ticket.nombre_usuario ||
+    ticket.user?.nombre_usuario ||
+    extractUserNameFromSubject(ticket.asunto) ||
+    'Usuario Desconocido';
 
   const hasLocation = ticket.direccion || (ticket.latitud && ticket.longitud);
 


### PR DESCRIPTION
This change updates the ticket details panel to extract and display user information from the ticket's subject when available.

This improves the user experience for tickets created via channels like 'Atención en Vivo' where the user's name is part of the subject line.