### PR TITLE
fix(widget): Fix multiple widget instances conflict

### DIFF
--- a/public/widget.js
+++ b/public/widget.js
@@ -3,7 +3,9 @@
 
   const script = document.currentScript;
   const chatbocDomain = script.getAttribute("data-domain") || new URL(script.src).origin;
-  const iframeId = `chatboc-iframe-${Math.random().toString(36).substring(2, 9)}`;
+  const randomId = Math.random().toString(36).substring(2, 9);
+  const iframeId = `chatboc-iframe-${randomId}`;
+  const containerId = `chatboc-widget-container-${randomId}`;
 
   const params = new URLSearchParams();
   for (const attr of script.attributes) {
@@ -27,7 +29,7 @@
   console.log("Widget.js: Iframe source:", iframeSrc);
 
   const container = document.createElement('div');
-  container.id = 'chatboc-widget-container';
+  container.id = containerId;
   document.body.appendChild(container);
 
   const shadow = container.attachShadow({ mode: 'open' });


### PR DESCRIPTION
I refactored the ChatWidget component to use `useRef` for managing timeouts instead of global variables. This prevents state corruption when multiple widget instances are loaded on the same page, ensuring each widget maintains its own state.

I also updated the widget loader script (`public/widget.js`) to generate a unique ID for each widget's container element. This resolves an issue with duplicate DOM element IDs, which is invalid HTML and could cause unpredictable behavior.