### PR TITLE
feat: Overhaul ticket panel and export functionality

### DIFF
--- a/src/components/tickets/DetailsPanel.tsx
+++ b/src/components/tickets/DetailsPanel.tsx
@@ -3,7 +3,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Mail, Phone, MapPin, Ticket as TicketIcon, Info, FileDown, User, ExternalLink, MessageCircle, Building, Hash } from 'lucide-react';
+import { Mail, Phone, MapPin, Ticket as TicketIcon, Info, FileDown, User, ExternalLink, MessageCircle, Building, Hash, Clipboard, Copy, ChevronDown, ChevronUp, UserCheck, Bot } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { motion } from 'framer-motion';
 import TicketMap from '../TicketMap';
@@ -16,9 +16,21 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { FaWhatsapp } from 'react-icons/fa';
+import { toast } from 'sonner';
+import { cn } from '@/lib/utils';
 
 const DetailsPanel: React.FC = () => {
   const { selectedTicket: ticket } = useTickets();
+  const [isDescriptionExpanded, setIsDescriptionExpanded] = React.useState(false);
+
+  const copyToClipboard = (text: string, label: string) => {
+    navigator.clipboard.writeText(text).then(() => {
+      toast.success(`${label} copiado al portapapeles`);
+    }).catch(err => {
+      toast.error('Error al copiar');
+      console.error('Error al copiar: ', err);
+    });
+  };
 
   const getInitials = (name: string) => {
     return name ? name.split(' ').map(n => n[0]).join('').toUpperCase() : '??';
@@ -89,6 +101,24 @@ const DetailsPanel: React.FC = () => {
   const userEmail = ticket.email_usuario || ticket.email || ticket.user?.email_usuario || ticket.user?.email;
   const userPhone = ticket.telefono || ticket.user?.phone;
 
+  const formatCategory = (ticket: any) => {
+    if (!ticket.categoria) return 'No informada';
+    let base = `Reclamo por ${ticket.categoria}`;
+    if (ticket.direccion) {
+      base += ` en ${ticket.direccion}`;
+    }
+    return base;
+  };
+
+  const getCustomerInfoText = () => {
+    let info = `Nombre: ${userName}\n`;
+    if (userEmail) info += `Email: ${userEmail}\n`;
+    if (userPhone) info += `Teléfono: ${userPhone}\n`;
+    if (ticket.dni) info += `DNI: ${ticket.dni}\n`;
+    if (ticket.direccion) info += `Dirección: ${ticket.direccion}\n`;
+    return info;
+  };
+
   return (
     <motion.aside
         key={ticket.id}
@@ -116,55 +146,107 @@ const DetailsPanel: React.FC = () => {
         <div className="p-6 space-y-6">
           {/* User Details */}
           <Card>
-            <CardHeader className="flex flex-row items-center gap-4 p-4">
-               <Avatar className="h-16 w-16">
-                <AvatarImage src={ticket.avatarUrl || ticket.user?.avatarUrl} alt={userName} />
-                <AvatarFallback>{getInitials(userName)}</AvatarFallback>
-              </Avatar>
-              <div className="flex-grow">
-                <h2 className="text-xl font-bold">{userName}</h2>
-                <p className="text-sm text-muted-foreground">{ticket.tipo === 'municipio' ? 'Vecino/a' : 'Cliente'}</p>
-                {ticket.estado_cliente && <Badge variant="secondary" className="mt-1">{ticket.estado_cliente}</Badge>}
+            <CardHeader className="flex flex-row items-center justify-between p-4">
+              <div className="flex items-center gap-4">
+                <Avatar className="h-16 w-16">
+                  <AvatarImage src={ticket.avatarUrl || ticket.user?.avatarUrl} alt={userName} />
+                  <AvatarFallback>{getInitials(userName)}</AvatarFallback>
+                </Avatar>
+                <div>
+                  <h2 className="text-xl font-bold">{userName}</h2>
+                  <p className="text-sm text-muted-foreground">{ticket.tipo === 'municipio' ? 'Vecino/a' : 'Cliente'}</p>
+                  {ticket.estado_cliente && <Badge variant="secondary" className="mt-1">{ticket.estado_cliente}</Badge>}
+                </div>
               </div>
+              <Button variant="ghost" size="icon" onClick={() => copyToClipboard(getCustomerInfoText(), 'Datos del cliente')}>
+                <Copy className="h-5 w-5" />
+              </Button>
             </CardHeader>
             <CardContent className="p-4 space-y-4 text-sm">
-              <div className="flex items-start gap-3">
-                <User className="h-4 w-4 mt-0.5 text-muted-foreground" />
-                <span>{userName}</span>
-              </div>
-              {userEmail && (
+              {userEmail ? (
                 <div className="flex items-start gap-3">
-                    <Mail className="h-4 w-4 mt-0.5 text-muted-foreground" />
-                    <span>{userEmail}</span>
+                  <Mail className="h-4 w-4 mt-0.5 text-muted-foreground" />
+                  <a href={`mailto:${userEmail}`} className="hover:underline">{userEmail}</a>
+                </div>
+              ) : (
+                <div className="flex items-start gap-3">
+                  <Mail className="h-4 w-4 mt-0.5 text-muted-foreground" />
+                  <span>No informado</span>
                 </div>
               )}
-              {userPhone && (
+              {userPhone ? (
                 <div className="flex items-start gap-3">
-                    <Phone className="h-4 w-4 mt-0.5 text-muted-foreground" />
-                    <div className="flex items-center justify-between w-full">
-                      <span>{userPhone}</span>
-                      <Button variant="ghost" size="icon" onClick={openWhatsApp}>
-                        <FaWhatsapp className="h-5 w-5 text-green-500" />
-                      </Button>
-                    </div>
+                  <Phone className="h-4 w-4 mt-0.5 text-muted-foreground" />
+                  <div className="flex items-center justify-between w-full">
+                    <span>{userPhone}</span>
+                    <Button variant="ghost" size="icon" onClick={openWhatsApp}>
+                      <FaWhatsapp className="h-5 w-5 text-green-500" />
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <div className="flex items-start gap-3">
+                  <Phone className="h-4 w-4 mt-0.5 text-muted-foreground" />
+                  <span>No informado</span>
                 </div>
               )}
               {ticket.dni && (
                 <div className="flex items-start gap-3">
-                    <Info className="h-4 w-4 mt-0.5 text-muted-foreground" />
-                    <span>DNI: {ticket.dni}</span>
+                  <Info className="h-4 w-4 mt-0.5 text-muted-foreground" />
+                  <span>DNI: {ticket.dni}</span>
                 </div>
-              )}
-              {ticket.direccion && (
-               <div className="flex items-start gap-3">
-                <MapPin className="h-4 w-4 mt-0.5 text-muted-foreground" />
-                <span>{ticket.direccion}</span>
-              </div>
               )}
             </CardContent>
           </Card>
 
-          {hasLocation && (
+          {/* Address */}
+          {ticket.direccion && (
+            <Card>
+                <CardHeader>
+                    <CardTitle className="flex items-center justify-between text-base">
+                        <div className="flex items-center gap-2">
+                            <MapPin className="h-5 w-5" />
+                            Dirección
+                        </div>
+                        <Button variant="ghost" size="icon" onClick={openGoogleMaps}>
+                            <ExternalLink className="h-4 w-4" />
+                        </Button>
+                    </CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <p className="text-lg font-semibold text-primary">{ticket.direccion}</p>
+                </CardContent>
+            </Card>
+          )}
+
+          {/* Ticket Description */}
+          {ticket.description && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center justify-between">
+                  <span>Descripción del Reclamo</span>
+                  <Button variant="ghost" size="icon" onClick={() => copyToClipboard(ticket.description || '', 'Descripción')}>
+                    <Copy className="h-4 w-4" />
+                  </Button>
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="text-sm text-muted-foreground space-y-2">
+                  <p className={cn(!isDescriptionExpanded && "line-clamp-4")}>
+                    {ticket.description}
+                  </p>
+                  {ticket.description.length > 200 && (
+                     <Button variant="link" className="p-0 h-auto" onClick={() => setIsDescriptionExpanded(!isDescriptionExpanded)}>
+                      {isDescriptionExpanded ? 'Ver menos' : 'Ver más'}
+                    </Button>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Location Map */}
+          {hasLocation && !ticket.direccion && (
             <Card>
               <CardHeader>
                 <CardTitle className="flex items-center justify-between">
@@ -186,28 +268,63 @@ const DetailsPanel: React.FC = () => {
               <CardTitle className="flex items-center gap-2"><TicketIcon className="h-5 w-5" /> Info del Ticket</CardTitle>
             </CardHeader>
             <CardContent className="space-y-3 text-sm">
-                <div className="flex justify-between items-center">
-                    <span className="text-muted-foreground">ID:</span>
-                    <span className="font-mono">{ticket.nro_ticket}</span>
-                </div>
-                <div className="flex justify-between items-center">
-                    <span className="text-muted-foreground">Tipo:</span>
-                    <Badge variant={ticket.tipo === 'municipio' ? 'default' : 'secondary'} className="capitalize">{ticket.tipo}</Badge>
-                </div>
-                <div className="flex justify-between items-center">
-                    <span className="text-muted-foreground">Categoría:</span>
-                    <span className="capitalize">{ticket.categoria || 'N/A'}</span>
-                </div>
-                 <div className="flex justify-between items-center">
-                    <span className="text-muted-foreground">Creado:</span>
-                    <span>{new Date(ticket.fecha).toLocaleString()}</span>
-                </div>
-                <div className="flex justify-between items-center">
-                    <span className="text-muted-foreground">Estado:</span>
-                    <Badge variant="outline" className="capitalize">{ticket.estado}</Badge>
-                </div>
+              <div className="flex justify-between items-center">
+                <span className="text-muted-foreground">ID:</span>
+                <span className="font-mono">{ticket.nro_ticket || 'No informado'}</span>
+              </div>
+              <div className="flex justify-between items-center">
+                <span className="text-muted-foreground">Canal:</span>
+                <span className="capitalize">{ticket.channel || 'No informado'}</span>
+              </div>
+              <div className="flex justify-between items-center">
+                <span className="text-muted-foreground">Estado:</span>
+                <Badge variant="outline" className="capitalize">{ticket.estado || 'No informado'}</Badge>
+              </div>
+              <div className="flex justify-between items-center">
+                <span className="text-muted-foreground">Creado:</span>
+                <span>{new Date(ticket.fecha).toLocaleString() || 'No informado'}</span>
+              </div>
+              <div className="space-y-1">
+                 <span className="text-muted-foreground">Categoría:</span>
+                 <p className="font-semibold">{formatCategory(ticket)}</p>
+              </div>
             </CardContent>
           </Card>
+
+          {/* Assigned Agent */}
+          {ticket.assignedAgent && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <UserCheck className="h-5 w-5" />
+                  <span>Agente Asignado</span>
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm">
+                 <div className="flex items-start gap-3">
+                    <User className="h-4 w-4 mt-0.5 text-muted-foreground" />
+                    <span>{ticket.assignedAgent.nombre_usuario}</span>
+                 </div>
+                {ticket.assignedAgent.email && (
+                  <div className="flex items-start gap-3">
+                    <Mail className="h-4 w-4 mt-0.5 text-muted-foreground" />
+                    <a href={`mailto:${ticket.assignedAgent.email}`} className="hover:underline">{ticket.assignedAgent.email}</a>
+                  </div>
+                )}
+                {ticket.assignedAgent.phone && (
+                  <div className="flex items-start gap-3">
+                    <Phone className="h-4 w-4 mt-0.5 text-muted-foreground" />
+                    <div className="flex items-center justify-between w-full">
+                      <span>{ticket.assignedAgent.phone}</span>
+                       <Button variant="ghost" size="icon" onClick={() => window.open(`https://wa.me/${ticket.assignedAgent?.phone?.replace(/\D/g, '')}`, '_blank')}>
+                        <FaWhatsapp className="h-5 w-5 text-green-500" />
+                      </Button>
+                    </div>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          )}
 
         </div>
       </ScrollArea>

--- a/src/components/tickets/TicketListItem.tsx
+++ b/src/components/tickets/TicketListItem.tsx
@@ -3,6 +3,7 @@ import { Ticket } from '@/types/tickets';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
+import { FaWhatsapp } from 'react-icons/fa';
 
 interface TicketListItemProps {
   ticket: Ticket;
@@ -38,11 +39,14 @@ const getInitials = (nombre_usuario: string) => {
             <p className="text-xs text-muted-foreground">{ticket.nro_ticket}</p>
           </div>
         </div>
-        <span className="text-xs text-muted-foreground">
-          {new Date(ticket.fecha).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
-        </span>
+        <div className="flex items-center gap-2">
+          {ticket.channel === 'whatsapp' && <FaWhatsapp className="h-4 w-4 text-green-500" />}
+          <span className="text-xs text-muted-foreground">
+            {new Date(ticket.fecha).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+          </span>
+        </div>
       </div>
-      <p className="font-semibold text-sm ml-13 mb-2">{ticket.asunto}</p>
+      <p className="font-semibold text-sm ml-13 mb-2">{ticket.asunto || 'Sin asunto'}</p>
       <p className="text-sm text-muted-foreground truncate ml-13">{ticket.lastMessage || '...'}</p>
       <div className="flex items-center justify-between mt-2 ml-13">
          <Badge variant={ticket.estado === 'nuevo' ? 'default' : 'outline'}

--- a/src/services/exportService.ts
+++ b/src/services/exportService.ts
@@ -8,39 +8,74 @@ const formatDate = (dateString: string) => {
 };
 
 const getTicketData = (ticket: Ticket) => {
-  return {
+  const data: { [key: string]: any } = {
     'Ticket ID': ticket.nro_ticket,
     'Asunto': ticket.asunto,
     'Estado': ticket.estado,
     'Categoría': ticket.categoria || 'N/A',
     'Fecha de Creación': formatDate(ticket.fecha),
-    'Cliente': ticket.name || 'Usuario Desconocido',
-    'Email': ticket.email || 'N/A',
+    'Cliente': ticket.nombre_usuario || 'Usuario Desconocido',
+    'Email': ticket.email_usuario || ticket.email || 'N/A',
     'Teléfono': ticket.telefono || 'N/A',
     'Dirección': ticket.direccion || 'N/A',
+    'Canal': ticket.channel || 'N/A',
+    'Descripción': ticket.description || 'N/A',
   };
+
+  if (ticket.assignedAgent) {
+    data['Agente Asignado'] = ticket.assignedAgent.nombre_usuario;
+    data['Email Agente'] = ticket.assignedAgent.email || 'N/A';
+    data['Teléfono Agente'] = ticket.assignedAgent.phone || 'N/A';
+  }
+
+  return data;
 };
 
+const addPdfHeader = (doc: jsPDF, title: string) => {
+  // const logo = '... a base64 string ...'; // we will ask the user for this
+  // doc.addImage(logo, 'PNG', 14, 12, 40, 15);
+  doc.setFontSize(22);
+  doc.setFont('helvetica', 'bold');
+  doc.setTextColor(45, 55, 72);
+  doc.text(title, doc.internal.pageSize.width / 2, 20, { align: 'center' });
+  doc.setLineWidth(0.5);
+  doc.line(14, 28, doc.internal.pageSize.width - 14, 28);
+};
+
+const addPdfFooter = (doc: jsPDF) => {
+    const pageCount = (doc as any).internal.getNumberOfPages();
+    doc.setFontSize(10);
+    doc.setTextColor(150);
+    for (let i = 1; i <= pageCount; i++) {
+        doc.setPage(i);
+        doc.text(`Página ${i} de ${pageCount}`, doc.internal.pageSize.width - 20, doc.internal.pageSize.height - 10);
+        doc.text('© Chatboc', 14, doc.internal.pageSize.height - 10);
+    }
+}
+
+
 export const exportToPdf = (ticket: Ticket, messages: Message[]) => {
+  if (!ticket) return;
   const doc = new jsPDF();
   const ticketData = getTicketData(ticket);
 
-  // Header
-  doc.setFontSize(20);
-  doc.setTextColor(40);
-  doc.text('Detalles del Ticket', 14, 22);
+  addPdfHeader(doc, `Ticket #${ticket.nro_ticket}`);
 
   // Ticket Details
   autoTable(doc, {
-    startY: 30,
+    startY: 40,
     head: [['Campo', 'Valor']],
     body: Object.entries(ticketData),
-    theme: 'striped',
-    headStyles: { fillColor: [22, 160, 133] },
+    theme: 'grid',
+    headStyles: { fillColor: [79, 129, 189], textColor: 255 },
+    styles: {
+      font: 'helvetica',
+      fontSize: 10
+    }
   });
 
   // Messages History
-  if (messages.length > 0) {
+  if (messages && messages.length > 0) {
     doc.addPage();
     doc.setFontSize(20);
     doc.setTextColor(40);
@@ -59,25 +94,18 @@ export const exportToPdf = (ticket: Ticket, messages: Message[]) => {
     });
   }
 
-  // Footer
-  const pageCount = (doc as any).internal.getNumberOfPages();
-  for (let i = 1; i <= pageCount; i++) {
-    doc.setPage(i);
-    doc.setFontSize(10);
-    doc.setTextColor(150);
-    doc.text(`Página ${i} de ${pageCount}`, doc.internal.pageSize.width - 20, doc.internal.pageSize.height - 10);
-  }
-
+  addPdfFooter(doc);
   doc.save(`ticket_${ticket.nro_ticket}.pdf`);
 };
 
 export const exportToXlsx = (ticket: Ticket, messages: Message[]) => {
+  if (!ticket) return;
   const ticketData = getTicketData(ticket);
-  const ticketWorksheet = XLSX.utils.json_to_sheet(ticketData.map(item => ({ Campo: item.title, Valor: item.data })));
+  const ticketWorksheet = XLSX.utils.json_to_sheet(Object.entries(ticketData).map(([key, value]) => ({ Campo: key, Valor: value })));
   const workbook = XLSX.utils.book_new();
   XLSX.utils.book_append_sheet(workbook, ticketWorksheet, 'Detalles del Ticket');
 
-  if (messages.length > 0) {
+  if (messages && messages.length > 0) {
     const messagesWorksheet = XLSX.utils.json_to_sheet(
       messages.map(msg => ({
         Fecha: formatDate(msg.timestamp),
@@ -103,18 +131,32 @@ export const exportToExcel = (tickets: Ticket[]) => {
     'Asunto': ticket.asunto,
     'Estado': ticket.estado,
     'Fecha': new Date(ticket.fecha).toLocaleString(),
-    'Cliente': ticket.name || 'Desconocido',
-    'Email': ticket.email || '',
+    'Cliente': ticket.nombre_usuario || 'Desconocido',
+    'Email': ticket.email_usuario || ticket.email || '',
     'Teléfono': ticket.telefono || '',
     'Dirección': ticket.direccion || '',
+    'Canal': ticket.channel || '',
+    'Descripción': ticket.description || '',
+    'Agente Asignado': ticket.assignedAgent?.nombre_usuario || '',
   }));
 
   const worksheet = XLSX.utils.json_to_sheet(sheetData);
 
+  // Add a title row
+  const title = 'Reporte de Tickets';
+  const titleRow = [[title]];
+  XLSX.utils.sheet_add_aoa(worksheet, titleRow, { origin: 'A1' });
+  worksheet['!merges'] = [{ s: { r: 0, c: 0 }, e: { r: 0, c: Object.keys(sheetData[0]).length - 1 } }];
+  worksheet['A1'].s = {
+    font: { bold: true, sz: 16, color: { rgb: "FFFFFF" } },
+    fill: { fgColor: { rgb: "2F5496" } },
+    alignment: { horizontal: "center", vertical: "center" },
+  };
+
   // Apply styles to header
   const header = Object.keys(sheetData[0]);
   for (let i = 0; i < header.length; i++) {
-    const cellRef = XLSX.utils.encode_cell({ c: i, r: 0 });
+    const cellRef = XLSX.utils.encode_cell({ c: i, r: 1 });
     if (worksheet[cellRef]) {
       worksheet[cellRef].s = headerStyle;
     }
@@ -137,30 +179,28 @@ export const exportToExcel = (tickets: Ticket[]) => {
 
 export const exportAllToPdf = (tickets: Ticket[]) => {
   const doc = new jsPDF();
-  doc.setFontSize(20);
-  doc.text('Resumen de Tickets', 14, 22);
+  addPdfHeader(doc, 'Resumen de Tickets');
 
   autoTable(doc, {
-    startY: 30,
-    head: [['ID', 'Asunto', 'Estado', 'Cliente', 'Fecha']],
+    startY: 40,
+    head: [['ID', 'Asunto', 'Estado', 'Cliente', 'Fecha', 'Canal', 'Agente']],
     body: tickets.map(ticket => [
       ticket.nro_ticket,
       ticket.asunto,
       ticket.estado,
-      ticket.name || 'N/A',
+      ticket.nombre_usuario || 'N/A',
       formatDate(ticket.fecha),
+      ticket.channel || 'N/A',
+      ticket.assignedAgent?.nombre_usuario || 'N/A',
     ]),
     theme: 'grid',
-    headStyles: { fillColor: [22, 160, 133] },
+    headStyles: { fillColor: [79, 129, 189], textColor: 255 },
+    styles: {
+        font: 'helvetica',
+        fontSize: 10
+    }
   });
 
-  const pageCount = (doc as any).internal.getNumberOfPages();
-  for (let i = 1; i <= pageCount; i++) {
-    doc.setPage(i);
-    doc.setFontSize(10);
-    doc.setTextColor(150);
-    doc.text(`Página ${i} de ${pageCount}`, doc.internal.pageSize.width - 20, doc.internal.pageSize.height - 10);
-  }
-
+  addPdfFooter(doc);
   doc.save('resumen_tickets.pdf');
 };

--- a/src/types/tickets.ts
+++ b/src/types/tickets.ts
@@ -77,4 +77,8 @@ export interface Ticket {
   nombre_usuario?: string;
   title?: string; // Keep for components that might still use it
   lastMessage?: string; // Keep for components that might still use it
+  description?: string;
+  channel?: 'whatsapp' | 'web' | 'email' | 'phone' | 'other';
+  assignedAgent?: User;
+  whatsapp_conversation_id?: string;
 }


### PR DESCRIPTION
This commit introduces a comprehensive set of improvements to the ticket management panel, based on your feedback.

- **Ticket List:** The ticket list now displays the ticket number, name, subject/category, status, time, and a WhatsApp icon for tickets from that channel.
- **Ticket Details:** The ticket details panel has been overhauled to show a complete picture of the ticket and customer. This includes the full description with a 'Ver más' toggle, a more descriptive category name, the channel, assigned agent, and prominent address. It also includes copy-to-clipboard buttons for customer info and description, and ensures 'No informado' is used for missing data.
- **Export Service:** The PDF and Excel export functionalities have been significantly improved to be more professional. They now include all the new fields, and the formatting has been enhanced with headers, footers, and better styling.