### PR TITLE
feat: Implement `menu_principal` action and accordion UI

### DIFF
--- a/src/hooks/useChatLogic.ts
+++ b/src/hooks/useChatLogic.ts
@@ -44,18 +44,38 @@ export function useChatLogic({ initialWelcomeMessage, tipoChat }: UseChatLogicOp
       text: welcomeMessageText,
       isBot: true,
       timestamp: new Date(),
-      botones: [
-        { texto: "RECLAMOS", action: "show_reclamos_menu" },
-        { texto: "LICENCIA DE CONDUCIR", action: "licencia_de_conducir" },
-        { texto: "PAGO DE TASAS VIGENTES", action: "consultar_deudas" },
-        { texto: "DEFENSA DEL CONSUMIDOR", action: "defensa_del_consumidor" },
-        { texto: "VETERINARIA Y BROMATOLOGÍA", action: "veterinaria_y_bromatologia" },
-        { texto: "CONSULTAR OTROS TRÁMITES", action: "consultar_tramites" },
-        { texto: "SOLICITAR TURNOS", action: "solicitar_turnos" },
-        { texto: "MULTAS DE TRÁNSITO", action: "consultar_multas" },
-        { texto: "DENUNCIAS", action: "hacer_denuncia" },
-        { texto: "AGENDA CULTURAL Y TURÍSTICA", action: "agenda_cultural" },
-        { texto: "NOVEDADES", action: "ver_novedades" },
+      categorias: [
+        {
+          titulo: "Reclamos y Denuncias",
+          botones: [
+            { texto: "Hacer un Reclamo", action: "show_reclamos_menu" },
+            { texto: "Realizar una Denuncia", action: "hacer_denuncia" },
+          ],
+        },
+        {
+          titulo: "Trámites Frecuentes",
+          botones: [
+            { texto: "Licencia de Conducir", action: "licencia_de_conducir" },
+            { texto: "Pago de Tasas", action: "consultar_deudas" },
+            { texto: "Defensa del Consumidor", action: "defensa_del_consumidor" },
+            { texto: "Veterinaria y Bromatología", action: "veterinaria_y_bromatologia" },
+            { texto: "Consultar Multas de Tránsito", action: "consultar_multas" },
+          ],
+        },
+        {
+          titulo: "Consultas y Turnos",
+          botones: [
+              { texto: "Consultar otros trámites", action: "consultar_tramites" },
+              { texto: "Solicitar Turnos", action: "solicitar_turnos" },
+          ]
+        },
+        {
+          titulo: "Información y Novedades",
+          botones: [
+            { texto: "Agenda Cultural y Turística", action: "agenda_cultural" },
+            { texto: "Últimas Novedades", action: "ver_novedades" },
+          ]
+        }
       ],
     };
   };
@@ -159,7 +179,7 @@ export function useChatLogic({ initialWelcomeMessage, tipoChat }: UseChatLogicOp
       return;
     }
 
-    if (action === 'show_main_menu') {
+    if (action === 'show_main_menu' || action === 'menu_principal') {
       const user = JSON.parse(safeLocalStorage.getItem('user') || 'null');
       const welcomeMessage = generateWelcomeMessage(user);
       setMessages(prev => [...prev, welcomeMessage]);


### PR DESCRIPTION
This commit introduces two improvements to the chat widget:

1.  **`menu_principal` Action:** The chat logic now handles the `menu_principal` action from the backend, which resets the chat to the main menu. This allows for a smoother conversational flow.

2.  **Accordion Menu:** The initial welcome message now displays its options in an accordion menu. This provides a cleaner and more organized user interface, as you requested.

**Note for future improvement:**
The content of the welcome menu is currently hardcoded in `src/hooks/useChatLogic.ts`. To better align with the project's backend-driven UI principles, this menu should be fetched from the backend in the future.