### PR TITLE
fix(pedidos): Resolve crash on Pedidos page

### DIFF
--- a/src/pages/PedidosPage.tsx
+++ b/src/pages/PedidosPage.tsx
@@ -271,11 +271,14 @@ export default function PedidosPage() {
           return acc;
         }, {});
         setCategorizedPedidos(categorized);
+        // Move this line inside the if-block to ensure 'categorized' is defined
+        setOpenCategories(new Set(Object.keys(categorized).filter((e) => !['satisfecho', 'cancelado'].includes(e))));
       } else {
         console.error('Error: La respuesta de la API de pedidos no es un array', data);
         setCategorizedPedidos({});
+        // Also handle the 'else' case by setting open categories to empty
+        setOpenCategories(new Set());
       }
-      setOpenCategories(new Set(Object.keys(categorized).filter((e) => !['satisfecho', 'cancelado'].includes(e))));
     } catch (err) {
       console.error('Error fetching pedidos:', err);
       setError(getErrorMessage(err, 'Error al cargar los pedidos.'));


### PR DESCRIPTION
This commit fixes a `ReferenceError: categorized is not defined` in `src/pages/PedidosPage.tsx`.

The error occurred when the `/pedidos` API endpoint returned a non-array response, causing a variable to be accessed outside of its defined scope.

The fix involves moving the logic that uses the `categorized` variable into the `if` block where it is defined. It also adds proper handling for the `else` case to prevent the application from crashing when the API response is not in the expected format.