### PR TITLE
fix(frontend): Handle action_id in chat buttons

### DIFF
--- a/src/components/chat/ChatButtons.tsx
+++ b/src/components/chat/ChatButtons.tsx
@@ -37,7 +37,8 @@ const ChatButtons: React.FC<ChatButtonsProps> = ({
     ].map(normalize);
 
     const handleButtonClick = (boton: Boton) => {
-        const normalizedAction = boton.action ? normalize(boton.action) : null;
+        const actionToUse = boton.action || boton.action_id;
+        const normalizedAction = actionToUse ? normalize(actionToUse) : null;
         const normalizedAccionInterna = boton.accion_interna ? normalize(boton.accion_interna) : null;
 
         // Priority 1: Handle internal auth actions (login/register) first and exclusively.

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -11,6 +11,7 @@ export interface Boton {
   url?: string;
   accion_interna?: string; // Para acciones que el frontend debe interpretar sin enviar al backend (ej. abrir panel)
   action?: string; // Valor que se envía al backend cuando se hace clic en el botón
+  action_id?: string; // Compatibilidad con 'action_id' enviado desde algunos endpoints del backend
 }
 
 // Nuevo: Define la estructura para una categoría de botones


### PR DESCRIPTION
The chat widget buttons were not working because the backend was sending an `action_id` property, but the frontend component was expecting an `action` property.

This commit aligns the frontend with the backend in two ways:
1.  The `Boton` type in `src/types/chat.ts` is updated to include the optional `action_id` field.
2.  The `ChatButtons.tsx` component is updated to recognize and use `action_id` as an alias for `action`.

This ensures that when a button with an `action_id` is clicked, the correct action is sent to the backend, resolving the error and making the buttons functional.