### PR TITLE
Fix chat action handling and user greeting

### DIFF
--- a/chat/ChatButtons.tsx
+++ b/chat/ChatButtons.tsx
@@ -37,45 +37,36 @@ const ChatButtons: React.FC<ChatButtonsProps> = ({
     ].map(normalize);
 
     const handleButtonClick = (boton: Boton) => {
-        const normalizedAction = boton.action ? normalize(boton.action) : null;
-        const normalizedAccionInterna = boton.accion_interna ? normalize(boton.accion_interna) : null;
+        const actionToUse = boton.action;
+        const normalizedAction = actionToUse ? normalize(actionToUse) : null;
+        const accionInterna = boton.accion_interna;
+        const normalizedAccionInterna = accionInterna ? normalize(accionInterna) : null;
 
         // Priority 1: Handle internal auth actions (login/register) first and exclusively.
         if (normalizedAction && (loginActions.includes(normalizedAction) || registerActions.includes(normalizedAction))) {
-            if (onInternalAction) {
-                onInternalAction(normalizedAction);
-            }
+            onInternalAction?.(normalizedAction);
             return; // Stop further processing for these auth actions
         }
         if (normalizedAccionInterna && (loginActions.includes(normalizedAccionInterna) || registerActions.includes(normalizedAccionInterna))) {
-            if (onInternalAction) {
-                onInternalAction(normalizedAccionInterna);
-            }
+            onInternalAction?.(normalizedAccionInterna);
             return; // Stop further processing for these auth actions
         }
 
         // Priority 2: Handle other `boton.action` (non-auth internal actions or backend actions)
-        if (normalizedAction) { // Will be non-auth at this point
-            // Send to backend. The payload includes the action.
-            onButtonClick({ text: boton.texto, action: normalizedAction });
-            // If this non-auth action ALSO has a specific frontend internal behavior, trigger it.
-            // (e.g., action 'open_cart_details' might be a backend query + frontend UI update)
-            if (onInternalAction) {
-                // This ensures that if an action is primarily for the backend but also has a UI side-effect,
-                // the internal handler is still called.
-                onInternalAction(normalizedAction);
-            }
+        if (actionToUse) { // Will be non-auth at this point
+            // Send raw action to backend.
+            onButtonClick({ text: boton.texto, action: actionToUse });
+            // Trigger potential frontend side-effects.
+            onInternalAction?.(actionToUse);
             return;
         }
 
         // Priority 3: Handle other `boton.accion_interna` (non-auth internal actions or backend actions)
-        if (normalizedAccionInterna) { // Will be non-auth at this point
-            // Send to backend. The payload includes the action.
-            onButtonClick({ text: boton.texto, action: normalizedAccionInterna });
-            // Similar to above, handle potential UI side-effects for these actions too.
-            if (onInternalAction) {
-                onInternalAction(normalizedAccionInterna);
-            }
+        if (accionInterna) { // Will be non-auth at this point
+            // Send raw internal action to backend.
+            onButtonClick({ text: boton.texto, action: accionInterna });
+            // Handle potential UI side-effects for these actions too.
+            onInternalAction?.(accionInterna);
             return;
         }
 

--- a/chat/ChatPanel.tsx
+++ b/chat/ChatPanel.tsx
@@ -513,17 +513,20 @@ const ChatPanel = ({
       const isAdmin = user?.rol && user.rol !== "usuario";
 
       if (["login", "loginpanel", "chatuserloginpanel"].includes(normalized)) {
-        if (!isAdmin) onShowLogin?.(); return;
+        if (!isAdmin) onShowLogin?.();
+        return;
       }
       if (["register", "registerpanel", "chatuserregisterpanel"].includes(normalized)) {
-        if (!isAdmin) onShowRegister?.(); return;
+        if (!isAdmin) onShowRegister?.();
+        return;
       }
       if (["cart", "carrito", "opencart", "vercarrito"].includes(normalized)) {
-        onCart?.(); return;
+        onCart?.();
+        return;
       }
-      handleSendMessage({ text: action, action: normalized });
+      // Other actions are already sent to the backend by the button handler.
     },
-    [onShowLogin, onShowRegister, onCart, handleSendMessage, user]
+    [onShowLogin, onShowRegister, onCart, user]
   );
 
   const handleFileUploaded = useCallback(

--- a/src/components/chat/ChatButtons.tsx
+++ b/src/components/chat/ChatButtons.tsx
@@ -32,44 +32,34 @@ const ChatButtons: React.FC<ChatButtonsProps> = ({
     const handleButtonClick = (boton: Boton) => {
         const actionToUse = boton.action || boton.action_id;
         const normalizedAction = actionToUse ? normalize(actionToUse) : null;
-        const normalizedAccionInterna = boton.accion_interna ? normalize(boton.accion_interna) : null;
+        const accionInterna = boton.accion_interna;
+        const normalizedAccionInterna = accionInterna ? normalize(accionInterna) : null;
 
         // Priority 1: Handle internal auth actions (login/register) first and exclusively.
         if (normalizedAction && (loginActions.includes(normalizedAction) || registerActions.includes(normalizedAction))) {
-            if (onInternalAction) {
-                onInternalAction(normalizedAction);
-            }
+            onInternalAction?.(normalizedAction);
             return; // Stop further processing for these auth actions
         }
         if (normalizedAccionInterna && (loginActions.includes(normalizedAccionInterna) || registerActions.includes(normalizedAccionInterna))) {
-            if (onInternalAction) {
-                onInternalAction(normalizedAccionInterna);
-            }
+            onInternalAction?.(normalizedAccionInterna);
             return; // Stop further processing for these auth actions
         }
 
         // Priority 2: Handle other `boton.action` (non-auth internal actions or backend actions)
-        if (normalizedAction) { // Will be non-auth at this point
-            // Send to backend. The payload includes the action.
-            onButtonClick({ text: boton.texto, action: normalizedAction, payload: boton.payload });
-            // If this non-auth action ALSO has a specific frontend internal behavior, trigger it.
-            // (e.g., action 'open_cart_details' might be a backend query + frontend UI update)
-            if (onInternalAction) {
-                // This ensures that if an action is primarily for the backend but also has a UI side-effect,
-                // the internal handler is still called.
-                onInternalAction(normalizedAction);
-            }
+        if (actionToUse) { // Will be non-auth at this point
+            // Send raw action to backend so it can match exactly.
+            onButtonClick({ text: boton.texto, action: actionToUse, payload: boton.payload });
+            // Trigger potential frontend side-effects for this action.
+            onInternalAction?.(actionToUse);
             return;
         }
 
         // Priority 3: Handle other `boton.accion_interna` (non-auth internal actions or backend actions)
-        if (normalizedAccionInterna) { // Will be non-auth at this point
-            // Send to backend. The payload includes the action.
-            onButtonClick({ text: boton.texto, action: normalizedAccionInterna });
-            // Similar to above, handle potential UI side-effects for these actions too.
-            if (onInternalAction) {
-                onInternalAction(normalizedAccionInterna);
-            }
+        if (accionInterna) { // Will be non-auth at this point
+            // Send raw internal action to backend.
+            onButtonClick({ text: boton.texto, action: accionInterna });
+            // Handle potential UI side-effects for these actions too.
+            onInternalAction?.(accionInterna);
             return;
         }
 

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -156,7 +156,7 @@ const ChatPanel = ({
         onCart?.();
         return;
       }
-      if (normalized === "request_user_location") {
+      if (normalized === "requestuserlocation") {
         try {
           const position = await requestLocation();
           if (position) {
@@ -190,8 +190,7 @@ const ChatPanel = ({
         }
         return;
       }
-      // Default action: send to backend
-      handleSend({ text: action, action: normalized });
+      // For other actions, the backend request was already sent. No extra handling needed.
     },
     [handleSend, onShowLogin, onShowRegister, onCart, toast]
   );

--- a/src/hooks/useBusinessHours.ts
+++ b/src/hooks/useBusinessHours.ts
@@ -19,15 +19,17 @@ export const useBusinessHours = (): BusinessHours => {
         const profile = await apiFetch<any>('/auth/profile');
         if (profile && profile.horario) {
           const { start_hour, end_hour } = profile.horario as Horario;
-          const now = new Date();
-          const currentHour = now.getHours();
-          const isLiveChatEnabled = currentHour >= start_hour && currentHour < end_hour;
-          const horariosAtencion = `Lunes a Viernes de ${start_hour}:00 a ${end_hour}:00`;
+          if (typeof start_hour === 'number' && typeof end_hour === 'number') {
+            const now = new Date();
+            const currentHour = now.getHours();
+            const isLiveChatEnabled = currentHour >= start_hour && currentHour < end_hour;
+            const horariosAtencion = `Lunes a Viernes de ${start_hour}:00 a ${end_hour}:00`;
 
-          setBusinessHours({
-            isLiveChatEnabled,
-            horariosAtencion,
-          });
+            setBusinessHours({
+              isLiveChatEnabled,
+              horariosAtencion,
+            });
+          }
         }
       } catch (error) {
         console.error('Error fetching profile:', error);

--- a/src/hooks/useChatLogic.ts
+++ b/src/hooks/useChatLogic.ts
@@ -39,9 +39,10 @@ export function useChatLogic({ initialWelcomeMessage, tipoChat }: UseChatLogicOp
   };
 
   const generateWelcomeMessage = (user: any): Message => {
+    const nombreUsuario = user?.nombre || user?.name || "";
     const welcomeMessageText = isAnonimo
       ? "¡Hola! Soy JuniA, el asistente virtual de la Municipalidad de Junín.\nEstas son las cosas que puedo hacer por vos:"
-      : `¡Hola, ${user?.nombre}! Soy JuniA, tu Asistente Virtual. ¿Qué necesitas hoy?`;
+      : `¡Hola, ${nombreUsuario}! Soy JuniA, tu Asistente Virtual. ¿Qué necesitas hoy?`;
 
     return {
       id: generateClientMessageId(),


### PR DESCRIPTION
## Summary
- Prevent duplicate backend requests from chat buttons by handling internal actions only once and sending raw action IDs
- Display logged-in user name in welcome message and guard business hours when schedule is missing
- Correct internal action routing for location requests

## Testing
- `npm test` *(fails: Failed to resolve import "../server/cart.cjs" from tests)*

------
https://chatgpt.com/codex/tasks/task_e_689dd30154188322aff44d198bb15340