### PR TITLE
feat: add language support to widget

### DIFF
--- a/docs/widget-embedding.md
+++ b/docs/widget-embedding.md
@@ -13,6 +13,7 @@ You can customize the chat widget by adding the following attributes to the scri
 *   `data-primary-color`: The primary color of the widget (in hex format).
 *   `data-logo-url`: The URL of the logo to display in the widget launcher.
 *   `data-position`: The position of the widget on the screen ('left' or 'right').
+*   `data-lang`: ISO language code (for example, `es` or `en`) used to request localized widget content.
 
 Example:
 
@@ -22,6 +23,7 @@ Example:
   data-primary-color="#ff0000"
   data-logo-url="https://example.com/logo.png"
   data-position="left"
+  data-lang="es"
 ></script>
 ```
 

--- a/widget.js
+++ b/widget.js
@@ -65,8 +65,14 @@
     const theme = script.getAttribute("data-theme") || "";
     const rubroAttr = script.getAttribute("data-rubro") || "";
     const ctaMessageAttr = script.getAttribute("data-cta-message") || "";
+    const langAttr = script.getAttribute("data-lang") || "";
     const endpointAttr = script.getAttribute("data-endpoint");
-    const tipoChat = endpointAttr === "municipio" || endpointAttr === "pyme" ? endpointAttr : (window.APP_TARGET === "municipio" ? "municipio" : "pyme");
+    const tipoChat =
+      endpointAttr === "municipio" || endpointAttr === "pyme"
+        ? endpointAttr
+        : window.APP_TARGET === "municipio"
+        ? "municipio"
+        : "pyme";
 
     function buildWidget(finalCta) {
       const zIndexBase = parseInt(script.getAttribute("data-z") || SCRIPT_CONFIG.DEFAULT_Z_INDEX, 10);
@@ -161,7 +167,10 @@
       if (theme) iframeSrc.searchParams.set("theme", theme);
       if (rubroAttr) iframeSrc.searchParams.set("rubro", rubroAttr);
       if (finalCta) iframeSrc.searchParams.set("ctaMessage", finalCta);
+      if (langAttr) iframeSrc.searchParams.set("lang", langAttr);
       iframe.src = iframeSrc.toString();
+
+      if (langAttr) iframe.setAttribute("lang", langAttr);
 
       Object.assign(iframe.style, {
         border: "none",


### PR DESCRIPTION
## Summary
- allow setting widget language via `data-lang` attribute
- document widget language option

## Testing
- `npm test` *(fails: Failed to resolve import "../server/cart.cjs" from "tests/businessMetrics.test.cjs")*

------
https://chatgpt.com/codex/tasks/task_e_689dea0a328c83228d88a6240c4c0d81