### PR TITLE
I've made the backend URL handling more robust to fix the broken loca…

### DIFF
--- a/src/hooks/useChatLogic.ts
+++ b/src/hooks/useChatLogic.ts
@@ -2,7 +2,7 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { Message, SendPayload as TypeSendPayload } from "@/types/chat";
 import { io, Socket } from "socket.io-client";
-import { apiFetch, getErrorMessage } from "@/utils/api";
+import { apiFetch, getErrorMessage, getApiBaseUrl } from "@/utils/api";
 import { getAskEndpoint } from "@/utils/chatEndpoints";
 import { enforceTipoChatForRubro } from "@/utils/tipoChat";
 import { safeLocalStorage } from "@/utils/safeLocalStorage";
@@ -96,7 +96,7 @@ export function useChatLogic({ initialWelcomeMessage, tipoChat }: UseChatLogicOp
     }
 
     // Setup Socket.IO
-    const backendUrl = import.meta.env.VITE_BACKEND_URL;
+    const backendUrl = getApiBaseUrl();
     const authToken = safeLocalStorage.getItem('authToken');
 
     const socket = io(backendUrl, {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,8 +1,25 @@
 // utils/api.ts
 
 // The backend URL is injected via environment variables.
-// VITE_BACKEND_URL should be set in your .env file.
-const API_BASE_URL = import.meta.env.VITE_BACKEND_URL;
+// VITE_BACKEND_URL should be set in the deployment environment for production.
+export const getApiBaseUrl = () => {
+  const backendUrl = import.meta.env.VITE_BACKEND_URL;
+  if (backendUrl) {
+    return backendUrl;
+  }
+  // Fallback for local development if .env is not loaded, to prevent app crash
+  if (import.meta.env.DEV) {
+    console.warn(
+      'VITE_BACKEND_URL is not defined. Falling back to http://localhost:5000. Please check your .env file.'
+    );
+    return 'http://localhost:5000';
+  }
+  // In production, the variable MUST be set.
+  console.error('CRITICAL: VITE_BACKEND_URL is not set in production!');
+  return '/error-backend-url-not-set';
+};
+
+const API_BASE_URL = getApiBaseUrl();
 import { safeLocalStorage } from "@/utils/safeLocalStorage";
 import getOrCreateChatSessionId from "@/utils/chatSessionId"; // Import the new function
 


### PR DESCRIPTION
…lhost environment.

Here’s a summary of my changes:
- I implemented a `getApiBaseUrl()` utility function that provides a fallback to `http://localhost:5000` when in development mode and `VITE_BACKEND_URL` is not defined. This will prevent the app from crashing due to a missing .env file or a non-restarted dev server.
- I ensured that production builds will fail with a console error if `VITE_BACKEND_URL` is not set, preventing accidental deployments with a development URL.
- I applied this robust logic to both the REST API calls in `api.ts` and the Socket.IO connection in `useChatLogic.ts`.