### PR TITLE
Handle missing backend URL and guard service worker requests

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,8 @@
 
 export const ENV = import.meta.env.VITE_ENV || 'dev';
 
-export const BACKEND_URL = import.meta.env.VITE_BACKEND_URL;
+export const BACKEND_URL =
+  import.meta.env.VITE_BACKEND_URL || window.location.origin;
 
 export const PANEL_URL = import.meta.env.VITE_PANEL_URL;
 
@@ -25,6 +26,8 @@ export const APP_TARGET = (import.meta.env.VITE_APP_TARGET || 'pyme') as
   | 'municipio';
 
 // --- Validation for critical variables ---
-if (!BACKEND_URL) {
-  throw new Error('CRITICAL: VITE_BACKEND_URL is not defined. The application cannot start without it. Please check your .env file or environment variables.');
+if (!import.meta.env.VITE_BACKEND_URL) {
+  console.warn(
+    'VITE_BACKEND_URL is not defined. Defaulting to window.location.origin.'
+  );
 }


### PR DESCRIPTION
## Summary
- Default `BACKEND_URL` to `window.location.origin` when env var is missing and log a warning
- Skip non-http requests in service worker to avoid caching errors

## Testing
- `npm test` *(fails: Failed to resolve import "../server/cart.cjs" from tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b59f0bb8832294dd9b6433b5129f