### PR TITLE
Respect endpoint param in iframe

### DIFF
--- a/src/pages/iframe.tsx
+++ b/src/pages/iframe.tsx
@@ -33,6 +33,7 @@ const Iframe = () => {
     const tokenFromUrl = urlParams.get("token");
     const storedToken = safeLocalStorage.getItem('entityToken');
     const currentToken = tokenFromUrl || storedToken;
+    const endpointParam = urlParams.get("endpoint") as 'pyme' | 'municipio' | null;
 
     if (tokenFromUrl && tokenFromUrl !== storedToken) {
       safeLocalStorage.setItem('entityToken', tokenFromUrl);
@@ -56,11 +57,17 @@ const Iframe = () => {
       closedHeight: urlParams.get("closedHeight") || DEFAULTS.closedHeight,
       ctaMessage: urlParams.get("ctaMessage") || undefined,
       rubro: urlParams.get("rubro") || undefined,
+      endpoint: endpointParam || undefined,
     });
+
+    if (endpointParam) {
+      setTipoChat(endpointParam);
+      setIsLoading(false);
+    }
   }, []);
 
   useEffect(() => {
-    if (entityToken) {
+    if (entityToken && !tipoChat) {
       const fetchTokenInfo = async () => {
         try {
           setIsLoading(true);
@@ -76,7 +83,7 @@ const Iframe = () => {
       };
       fetchTokenInfo();
     }
-  }, [entityToken]);
+  }, [entityToken, tipoChat]);
 
   // Muestra un loader mientras se determina el tipo de chat
   if (isLoading || !widgetParams) {
@@ -90,7 +97,7 @@ const Iframe = () => {
         entityToken={entityToken}
         defaultOpen={widgetParams.defaultOpen}
         widgetId={widgetParams.widgetId}
-        tipoChat={tipoChat}
+        tipoChat={tipoChat || undefined}
         openWidth={widgetParams.openWidth}
         openHeight={widgetParams.openHeight}
         closedWidth={widgetParams.closedWidth}


### PR DESCRIPTION
## Summary
- Read `endpoint` query parameter and use it to set the chat type
- Skip token-info call when `endpoint` is provided to avoid CORS issues

## Testing
- `npm test` *(fails: Failed to resolve import "../server/cart.cjs" from tests/businessMetrics.test.cjs)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c09dc0a883229ac827200e72bfee