### PR TITLE
Respect endpoint param in iframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ If your site blocks external JavaScript, you can embed the chatbot using an
 ```html
 <iframe
   id="chatboc-iframe"
-  src="https://www.chatboc.ar/iframe.html?token=TU_TOKEN_AQUI&tipo_chat=pyme&rubro=comercio" <!-- or "municipio" -->
+  src="https://www.chatboc.ar/iframe.html?token=TU_TOKEN_AQUI&endpoint=pyme&rubro=comercio" <!-- or "municipio"; `tipo_chat` also works -->
   style="position:fixed;bottom:24px;right:24px;border:none;border-radius:50%;z-index:9999;box-shadow:0 4px 32px rgba(0,0,0,0.2);background:transparent;overflow:hidden;width:96px!important;height:96px!important;display:block"
   allow="clipboard-write; geolocation"
   loading="lazy"

--- a/src/pages/iframe.tsx
+++ b/src/pages/iframe.tsx
@@ -33,6 +33,11 @@ const Iframe = () => {
     const tokenFromUrl = urlParams.get("token");
     const storedToken = safeLocalStorage.getItem('entityToken');
     const currentToken = tokenFromUrl || storedToken;
+    const rawEndpoint = urlParams.get("endpoint") || urlParams.get("tipo_chat");
+    const endpointParam =
+      rawEndpoint === 'pyme' || rawEndpoint === 'municipio'
+        ? (rawEndpoint as 'pyme' | 'municipio')
+        : null;
 
     if (tokenFromUrl && tokenFromUrl !== storedToken) {
       safeLocalStorage.setItem('entityToken', tokenFromUrl);
@@ -56,11 +61,17 @@ const Iframe = () => {
       closedHeight: urlParams.get("closedHeight") || DEFAULTS.closedHeight,
       ctaMessage: urlParams.get("ctaMessage") || undefined,
       rubro: urlParams.get("rubro") || undefined,
+      endpoint: endpointParam || undefined,
     });
+
+    if (endpointParam) {
+      setTipoChat(endpointParam);
+      setIsLoading(false);
+    }
   }, []);
 
   useEffect(() => {
-    if (entityToken) {
+    if (entityToken && !tipoChat) {
       const fetchTokenInfo = async () => {
         try {
           setIsLoading(true);
@@ -76,7 +87,7 @@ const Iframe = () => {
       };
       fetchTokenInfo();
     }
-  }, [entityToken]);
+  }, [entityToken, tipoChat]);
 
   // Muestra un loader mientras se determina el tipo de chat
   if (isLoading || !widgetParams) {
@@ -90,7 +101,7 @@ const Iframe = () => {
         entityToken={entityToken}
         defaultOpen={widgetParams.defaultOpen}
         widgetId={widgetParams.widgetId}
-        tipoChat={tipoChat}
+        tipoChat={tipoChat || undefined}
         openWidth={widgetParams.openWidth}
         openHeight={widgetParams.openHeight}
         closedWidth={widgetParams.closedWidth}


### PR DESCRIPTION
## Summary
- Allow iframe to read either `endpoint` or legacy `tipo_chat` query parameters and use them to set chat type
- Document the `endpoint` query param in README (keeping `tipo_chat` for compatibility)

## Testing
- `npm test` *(fails: Failed to resolve import "../server/cart.cjs" from tests/businessMetrics.test.cjs)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c09dc0a883229ac827200e72bfee