### PR TITLE
Fix chat widget socket events

### DIFF
--- a/src/hooks/useChatLogic.ts
+++ b/src/hooks/useChatLogic.ts
@@ -113,7 +113,7 @@ export function useChatLogic({ initialWelcomeMessage, tipoChat }: UseChatLogicOp
       socket.emit('join', { room: sessionId });
     });
 
-    socket.on('bot_response', (data: any) => {
+    const handleBotMessage = (data: any) => {
       console.log('Bot response received:', data);
       const botMessage: Message = {
         id: data.id || generateClientMessageId(),
@@ -130,7 +130,10 @@ export function useChatLogic({ initialWelcomeMessage, tipoChat }: UseChatLogicOp
       };
       setMessages(prev => [...prev, botMessage]);
       setIsTyping(false);
-    });
+    };
+
+    socket.on('bot_response', handleBotMessage);
+    socket.on('message', handleBotMessage);
 
     socket.on('disconnect', () => {
       console.log('Socket.IO disconnected.');
@@ -138,6 +141,8 @@ export function useChatLogic({ initialWelcomeMessage, tipoChat }: UseChatLogicOp
 
     // Cleanup on component unmount
     return () => {
+      socket.off('bot_response', handleBotMessage);
+      socket.off('message', handleBotMessage);
       socket.disconnect();
     };
   }, []); // Empty dependency array ensures this runs only once


### PR DESCRIPTION
## Summary
- Connect ChatPanel socket to configured backend URL and listen for both `message` and `new_chat_message` events
- Handle backend `message` events in useChatLogic hook for bot responses and clean up listeners

## Testing
- `npm test` *(fails: Failed to resolve import "../server/cart.cjs" from tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c5d250d08322b8ed73e59a2d1a35