### PR TITLE
fix(chat): Use entityToken for Socket.IO authentication

### DIFF
--- a/src/hooks/useChatLogic.ts
+++ b/src/hooks/useChatLogic.ts
@@ -96,13 +96,17 @@ export function useChatLogic({ initialWelcomeMessage, tipoChat }: UseChatLogicOp
       setMessages([welcomeMessage]);
     }
 
+    if (!entityToken) {
+      console.log("useChatLogic: No entityToken, socket connection deferred.");
+      return;
+    };
+
     // Setup Socket.IO
-    const authToken = safeLocalStorage.getItem('authToken');
     const socket = io(BACKEND_URL, {
       transports: ['websocket', 'polling'],
       withCredentials: true,
       auth: {
-        token: authToken
+        token: entityToken
       }
     });
     socketRef.current = socket;
@@ -140,7 +144,7 @@ export function useChatLogic({ initialWelcomeMessage, tipoChat }: UseChatLogicOp
     return () => {
       socket.disconnect();
     };
-  }, []); // Empty dependency array ensures this runs only once
+  }, [entityToken]); // Effect now depends on entityToken
 
   useEffect(() => {
     if (contexto.estado_conversacion === 'confirmando_reclamo' && !activeTicketId) {


### PR DESCRIPTION
The Socket.IO connection was failing with an 'invalid token' error because the chat widget was attempting to authenticate using the user's `authToken` from local storage instead of the required `entityToken`.

This change modifies the `useChatLogic` hook to correctly use the `entityToken` prop for Socket.IO authentication. This aligns with the backend's expectation and resolves the connection and authentication errors.

The `useEffect` hook's dependency array has been updated to include `entityToken` to ensure the socket reconnects if the token changes. A guard has also been added to prevent connection attempts when the `entityToken` is not yet available.