### PR TITLE
Configure Vite to properly proxy requests to the backend.

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -7,8 +7,7 @@
 export const ENV = import.meta.env.VITE_ENV || 'dev';
 
 export const BACKEND_URL =
-  import.meta.env.VITE_BACKEND_URL ||
-  (ENV === 'dev' ? 'http://localhost:8081' : window.location.origin);
+  import.meta.env.VITE_BACKEND_URL || (ENV === 'dev' ? '' : window.location.origin);
 
 export const PANEL_URL = import.meta.env.VITE_PANEL_URL;
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -53,16 +53,15 @@ export default defineConfig(({ mode }) => {
       })
     ],
     server: {
-      port: 8080,
+      port: 5173, // Puerto estándar de Vite para evitar conflictos con el backend
       proxy: {
         '/api': {
-          target: 'http://localhost:5000',
+          target: 'http://localhost:8080', // Apuntar al backend en 8080
           changeOrigin: true,
           secure: false,
-          rewrite: (path) => path.replace(/^\/api/, '')
         },
         '/socket.io': {
-          target: 'ws://localhost:5000',
+          target: 'ws://localhost:8080', // Apuntar al websocket del backend en 8080
           ws: true,
         },
       },


### PR DESCRIPTION
- The Vite dev server is moved to port 5173 to avoid conflicts with the backend running on 8080.
- The proxy is configured to forward `/api` and `/socket.io` requests to the backend at `http://localhost:8080`.
- The frontend application is configured to make relative requests in development, allowing the Vite proxy to handle them.

This resolves the `ECONNREFUSED` errors and allows the frontend to correctly communicate with the backend in a local development environment.