### PR TITLE
Add the `/api` prefix to all frontend API calls.

### DIFF
--- a/src/components/auth/GoogleLoginButton.tsx
+++ b/src/components/auth/GoogleLoginButton.tsx
@@ -31,7 +31,7 @@ const GoogleLoginButton: React.FC<Props> = ({
     console.log('Google login success:', cred);
     if (!cred || !cred.credential) return;
     try {
-      const data = await apiFetch<LoginResponse>('/google-login', {
+      const data = await apiFetch<LoginResponse>('/api/google-login', {
         method: 'POST',
         body: { id_token: cred.credential },
         sendAnonId: true,

--- a/src/components/chat/ChatUserPanel.tsx
+++ b/src/components/chat/ChatUserPanel.tsx
@@ -58,7 +58,7 @@ const ChatUserPanel: React.FC<Props> = ({ onClose }) => {
     setSaving(true);
     setError("");
     try {
-      await apiFetch("/me", { method: "PUT", body: { name, email, telefono: phone } });
+      await apiFetch("/api/api/me", { method: "PUT", body: { name, email, telefono: phone } });
       const stored = safeLocalStorage.getItem("user");
       if (stored) {
         try {

--- a/src/hooks/useUser.tsx
+++ b/src/hooks/useUser.tsx
@@ -47,7 +47,7 @@ export const UserProvider: React.FC<{ children: React.ReactNode }> = ({ children
     if (!token) return;
     setLoading(true);
     try {
-    const data = await apiFetch<any>('/me');
+    const data = await apiFetch<any>('/api/me');
     const rubroNorm = parseRubro(data.rubro) || '';
     if (!data.tipo_chat) {
       console.warn('tipo_chat faltante en respuesta de /me');

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -34,8 +34,8 @@ export default function CartPage() {
     setError(null);
     try {
       const [cartApiData, productsApiData] = await Promise.all([
-        apiFetch<CartApiItems>('/carrito'),
-        apiFetch<ProductDetails[]>('/productos'),
+        apiFetch<CartApiItems>('/api/carrito'),
+        apiFetch<ProductDetails[]>('/api/productos'),
       ]);
 
       const productMap: ProductMap = productsApiData.reduce((acc, p) => {
@@ -92,9 +92,9 @@ export default function CartPage() {
 
     try {
       if (newQuantity <= 0) {
-        await apiFetch('/carrito', { method: 'DELETE', body: { nombre: productName } });
+        await apiFetch('/api/carrito', { method: 'DELETE', body: { nombre: productName } });
       } else {
-        await apiFetch('/carrito', { method: 'PUT', body: { nombre: productName, cantidad: newQuantity } });
+        await apiFetch('/api/carrito', { method: 'PUT', body: { nombre: productName, cantidad: newQuantity } });
       }
       // No es necesario llamar a loadCartData() aquí si el backend confirma la acción,
       // la UI ya está actualizada optimisticamente. Si se quiere re-sincronizar:

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -34,7 +34,7 @@ const Login = () => {
     setIsLoading(true);
 
     try {
-      const data = await apiFetch<LoginResponse>("/login", {
+      const data = await apiFetch<LoginResponse>("/api/login", {
         method: "POST",
         body: { email, password },
       });

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -32,7 +32,7 @@ const Register = () => {
   useEffect(() => {
     const fetchRubros = async () => {
       try {
-        const data = await apiFetch<Rubro[]>('/rubros/', { skipAuth: true });
+        const data = await apiFetch<Rubro[]>('/api/rubros/', { skipAuth: true });
         if (Array.isArray(data)) setRubrosDisponibles(data);
       } catch (err) { setError("No se pudieron cargar los rubros."); }
     };
@@ -71,7 +71,7 @@ const Register = () => {
         acepto_terminos: accepted,
       };
 
-      const data = await apiFetch<RegisterResponse>("/register", {
+      const data = await apiFetch<RegisterResponse>("/api/register", {
         method: "POST",
         body: payload,
       });

--- a/src/services/ticketService.ts
+++ b/src/services/ticketService.ts
@@ -8,7 +8,7 @@ const generateRandomAvatar = (seed: string) => {
 
 export const getTickets = async (): Promise<{tickets: Ticket[]}> => {
   try {
-    const response = await apiFetch<{tickets: Ticket[]}>('/tickets');
+    const response = await apiFetch<{tickets: Ticket[]}>('/api/tickets');
     const tickets = response.tickets || [];
 
     const ticketsWithAvatars = tickets.map(ticket => ({
@@ -26,7 +26,7 @@ export const getTickets = async (): Promise<{tickets: Ticket[]}> => {
 
 export const getTicketById = async (id: string): Promise<Ticket> => {
     try {
-        const response = await apiFetch<Ticket>(`/tickets/municipio/${id}`);
+        const response = await apiFetch<Ticket>(`/api/tickets/municipio/${id}`);
         return {
             ...response,
             avatarUrl: response.avatarUrl || generateRandomAvatar(response.email || response.id.toString())
@@ -39,7 +39,7 @@ export const getTicketById = async (id: string): Promise<Ticket> => {
 
 export const getTicketMessages = async (ticketId: number, tipo: 'municipio' | 'pyme'): Promise<Message[]> => {
     try {
-        const endpoint = tipo === 'municipio' ? `/tickets/chat/${ticketId}/mensajes` : `/tickets/chat/pyme/${ticketId}/mensajes`;
+        const endpoint = tipo === 'municipio' ? `/api/tickets/chat/${ticketId}/mensajes` : `/api/tickets/chat/pyme/${ticketId}/mensajes`;
         const response = await apiFetch<{ mensajes: Message[] }>(endpoint);
         return response.mensajes || [];
     } catch (error) {
@@ -101,7 +101,7 @@ export const sendMessage = async (
             };
         }
 
-        const response = await apiFetch(`/tickets/${tipo}/${ticketId}/responder`, {
+        const response = await apiFetch(`/api/tickets/${tipo}/${ticketId}/responder`, {
             method: 'POST',
             // apiFetch se encargará de stringify el objeto body si es un JSON
             body: body,


### PR DESCRIPTION
The Vite development server is configured to proxy requests starting with `/api` to the backend server. However, the `apiFetch` calls throughout the codebase were using relative paths without this prefix (e.g., `/login` instead of `/api/login`). This caused the proxy to be bypassed, resulting in 404 Not Found errors during local development.

This commit fixes this by prepending `/api` to all relevant `apiFetch` call sites, ensuring they are correctly routed through the proxy. This resolves the login and other functionality issues on the local dev server.