### PR TITLE
fix: include entityToken in chat logic hook

### DIFF
--- a/src/hooks/useChatLogic.ts
+++ b/src/hooks/useChatLogic.ts
@@ -18,7 +18,7 @@ interface UseChatLogicOptions {
   entityToken?: string;
 }
 
-export function useChatLogic({ initialWelcomeMessage, tipoChat }: UseChatLogicOptions) {
+export function useChatLogic({ initialWelcomeMessage, tipoChat, entityToken }: UseChatLogicOptions) {
   const { user } = useUser();
   const [messages, setMessages] = useState<Message[]>([]);
   const [isTyping, setIsTyping] = useState(false);


### PR DESCRIPTION
## Summary
- fix missing entityToken parameter in `useChatLogic`

## Testing
- `npm test` *(fails: Failed to resolve import "../server/cart.cjs" from "tests/businessMetrics.test.cjs"...)*


------
https://chatgpt.com/codex/tasks/task_e_68a1fc91707c8322b11d6f603dc3767b