### PR TITLE
fix: include entityToken in chat logic hook

### DIFF
--- a/hooks/useChatLogic.ts
+++ b/hooks/useChatLogic.ts
@@ -25,9 +25,11 @@ interface SendPayload {
 interface UseChatLogicProps {
   initialWelcomeMessage: string;
   tipoChat: "pyme" | "municipio";
+  entityToken?: string;
 }
 
-export function useChatLogic({ initialWelcomeMessage, tipoChat }: UseChatLogicProps) {
+export function useChatLogic({ initialWelcomeMessage, tipoChat, entityToken: entityTokenProp }: UseChatLogicProps) {
+  const entityToken = entityTokenProp;
   const [messages, setMessages] = useState<Message[]>([]);
   const [isTyping, setIsTyping] = useState(false);
   const [contexto, setContexto] = useState({});

--- a/src/hooks/useChatLogic.ts
+++ b/src/hooks/useChatLogic.ts
@@ -18,7 +18,10 @@ interface UseChatLogicOptions {
   entityToken?: string;
 }
 
-export function useChatLogic({ initialWelcomeMessage, tipoChat }: UseChatLogicOptions) {
+// Rename the destructured param to avoid any accidental scope issues
+export function useChatLogic({ initialWelcomeMessage, tipoChat, entityToken: entityTokenProp }: UseChatLogicOptions) {
+  // Local constant used throughout the hook
+  const entityToken = entityTokenProp;
   const { user } = useUser();
   const [messages, setMessages] = useState<Message[]>([]);
   const [isTyping, setIsTyping] = useState(false);


### PR DESCRIPTION
## Summary
- fix missing entityToken parameter in useChatLogic
- ensure entityToken is locally scoped to avoid reference errors

## Testing
- `npm test` *(fails: Failed to resolve import "../server/cart.cjs" from "tests/businessMetrics.test.cjs"...)*

------
https://chatgpt.com/codex/tasks/task_e_68a1fc91707c8322b11d6f603dc3767b