### PR TITLE
Add detailed logging for API and chat interactions

### DIFF
--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -35,8 +35,22 @@ async function apiFetch<T>(endpoint:string, options: RequestInit = {}): Promise<
     ...options,
     headers,
   };
+  const mask = (t: string | null) => (t ? `${t.slice(0, 8)}...` : null);
+  console.log('[apiService] Request', {
+    endpoint,
+    method: options.method || 'GET',
+    authToken: mask(userToken),
+    entityToken: mask(entityToken),
+    hasBody: !!options.body,
+    headers,
+  });
 
   const response = await fetch(`${API_URL}${endpoint}`, config);
+
+  console.log('[apiService] Response', {
+    endpoint,
+    status: response.status,
+  });
 
   if (!response.ok) {
     if (response.status === 401) throw new Error("401: Tu sesión ha expirado. Por favor, inicia sesión de nuevo.");

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -59,6 +59,18 @@ export async function apiFetch<T>(
   if (entityToken) {
     headers["X-Entity-Token"] = entityToken;
   }
+  // Log request details without exposing full tokens
+  const mask = (t: string | null) => (t ? `${t.slice(0, 8)}...` : null);
+  console.log("[apiFetch] Request", {
+    method,
+    url,
+    hasBody: !!body,
+    authToken: mask(token),
+    anonId: mask(anonId),
+    entityToken: mask(entityToken || null),
+    sendAnonId,
+    headers,
+  });
 
   try {
     const response = await fetch(url, {
@@ -76,6 +88,13 @@ export async function apiFetch<T>(
     } catch {
       // body no es JSON válido
     }
+
+    console.log("[apiFetch] Response", {
+      method,
+      url,
+      status: response.status,
+      data,
+    });
 
     if (response.status === 401) {
       // Sólo limpia sesión si no es skipAuth

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -59,6 +59,19 @@ export async function apiFetch<T>(
   if ((sendEntityToken || false) && entityToken) {
     headers["X-Entity-Token"] = entityToken;
   }
+  // Log request details without exposing full tokens
+  const mask = (t: string | null) => (t ? `${t.slice(0, 8)}...` : null);
+  console.log("[apiFetch] Request", {
+    method,
+    url,
+    hasBody: !!body,
+    authToken: mask(token),
+    anonId: mask(anonId),
+    entityToken: mask(entityToken),
+    sendAnonId,
+    sendEntityToken,
+    headers,
+  });
 
   try {
     const response = await fetch(url, {
@@ -77,6 +90,13 @@ export async function apiFetch<T>(
     } catch {
       // body no es JSON válido
     }
+
+    console.log("[apiFetch] Response", {
+      method,
+      url,
+      status: response.status,
+      data,
+    });
 
     if (response.status === 401) {
       // Sólo limpia sesión si no es skipAuth


### PR DESCRIPTION
## Summary
- log outgoing requests and responses in shared `apiFetch`
- log socket setup and message posts in chat logic
- trace ticket API calls with masked token information

## Testing
- `npm test` *(fails: Failed to resolve import "../server/cart.cjs" from tests/businessMetrics.test.cjs)*

------
https://chatgpt.com/codex/tasks/task_e_68a20d25f5548322a9d1ff0d537ee0d2