### PR TITLE
Handle entity token URL params

### DIFF
--- a/src/pages/iframe.tsx
+++ b/src/pages/iframe.tsx
@@ -30,8 +30,9 @@ const Iframe = () => {
 
   useEffect(() => {
     const urlParams = new URLSearchParams(window.location.search);
-    const tokenFromUrl = urlParams.get("token");
-    const storedToken = safeLocalStorage.getItem('entityToken');
+    const tokenFromUrl =
+      urlParams.get("token") || urlParams.get("entityToken");
+    const storedToken = safeLocalStorage.getItem("entityToken");
     const currentToken = tokenFromUrl || storedToken;
     const rawEndpoint = urlParams.get("endpoint") || urlParams.get("tipo_chat");
     const endpointParam =
@@ -40,8 +41,11 @@ const Iframe = () => {
         : null;
 
     if (tokenFromUrl && tokenFromUrl !== storedToken) {
-      safeLocalStorage.setItem('entityToken', tokenFromUrl);
-      console.log('Chatboc Iframe: entityToken guardado en localStorage desde URL:', tokenFromUrl);
+      safeLocalStorage.setItem("entityToken", tokenFromUrl);
+      console.log(
+        "Chatboc Iframe: entityToken guardado en localStorage desde URL:",
+        tokenFromUrl
+      );
     }
 
     if (currentToken) {

--- a/widget.js
+++ b/widget.js
@@ -28,7 +28,10 @@
       return;
     }
 
-    const token = script.getAttribute("data-token") || SCRIPT_CONFIG.DEFAULT_TOKEN;
+    const token =
+      script.getAttribute("data-token") ||
+      script.getAttribute("data-entity-token") ||
+      SCRIPT_CONFIG.DEFAULT_TOKEN;
     const registry = (window.__chatbocWidgets = window.__chatbocWidgets || {});
 
     if (registry[token]) {
@@ -157,6 +160,7 @@
       // Use explicit .html path so integrations without rewrite rules work
       const iframeSrc = new URL(`${chatbocDomain}/iframe.html`);
       iframeSrc.searchParams.set("token", token);
+      iframeSrc.searchParams.set("entityToken", token);
       iframeSrc.searchParams.set("widgetId", iframeId);
       iframeSrc.searchParams.set("defaultOpen", String(defaultOpen));
       iframeSrc.searchParams.set("tipo_chat", tipoChat);


### PR DESCRIPTION
## Summary
- Support `entityToken` URL parameter and attribute for iframe widget
- Pass entity token from embed script to iframe

## Testing
- `npm test` *(fails: Failed to resolve import "../server/cart.cjs" from "tests/businessMetrics.test.cjs"...)*

------
https://chatgpt.com/codex/tasks/task_e_68a21c9f7bfc8322ae8d0dea8a1364ce