### PR TITLE
fix: Improve calendar UI and modal width

### DIFF
--- a/src/components/admin/EventForm.tsx
+++ b/src/components/admin/EventForm.tsx
@@ -182,6 +182,7 @@ export const EventForm: React.FC<EventFormProps> = ({ onSubmit, onCancel, isSubm
                   </PopoverTrigger>
                   <PopoverContent className="w-auto p-0" align="start">
                     <Calendar
+                      locale={es}
                       mode="single"
                       selected={field.value}
                       onSelect={field.onChange}

--- a/src/pages/Perfil.tsx
+++ b/src/pages/Perfil.tsx
@@ -1397,7 +1397,7 @@ export default function Perfil() {
 
        {/* --- Modal para Crear Evento/Noticia --- */}
       <Dialog open={isEventModalOpen} onOpenChange={setIsEventModalOpen}>
-        <DialogContent className="sm:max-w-[625px]">
+        <DialogContent className="sm:max-w-3xl">
           <DialogHeader>
             <DialogTitle className="text-xl flex items-center">
               <PlusCircle className="w-5 h-5 mr-2 text-primary"/>


### PR DESCRIPTION
This commit addresses UI bugs reported for the event creation calendar.

- Ensures both start date and end date calendars are localized to Spanish by adding the missing `locale` prop to the end date calendar.
- Widens the dialog modal containing the form to `sm:max-w-3xl` to prevent the calendar from appearing misaligned or cramped.