### PR TITLE
fix(widget): Remove localStorage token fallback on load

### DIFF
--- a/src/pages/iframe.tsx
+++ b/src/pages/iframe.tsx
@@ -33,26 +33,29 @@ const Iframe = () => {
     const urlParams = new URLSearchParams(window.location.search);
     const tokenFromUrl =
       urlParams.get("token") || urlParams.get("entityToken");
-    const storedToken = safeLocalStorage.getItem("entityToken");
-    const currentToken = tokenFromUrl || storedToken;
+
+    // The token from the URL is the only source of truth. We remove the fallback to
+    // localStorage to prevent using stale, expired tokens.
+    const currentToken = tokenFromUrl;
+
     const rawEndpoint = urlParams.get("endpoint") || urlParams.get("tipo_chat");
     const endpointParam =
       rawEndpoint === 'pyme' || rawEndpoint === 'municipio'
         ? (rawEndpoint as 'pyme' | 'municipio')
         : null;
 
-    if (tokenFromUrl && tokenFromUrl !== storedToken) {
+    // If a token is provided in the URL, we save it. This allows other parts of the
+    // iframe application to access it if needed, but it won't be used for initial
+    // authentication anymore.
+    if (tokenFromUrl) {
       safeLocalStorage.setItem("entityToken", tokenFromUrl);
-      console.log(
-        "Chatboc Iframe: entityToken guardado en localStorage desde URL:",
-        tokenFromUrl
-      );
     }
 
     if (currentToken) {
       setEntityToken(currentToken);
     } else {
-      console.warn('Chatboc Iframe: No se encontró token en la URL ni en localStorage.');
+      // This is a fatal error for the widget. It cannot function without a token.
+      console.error('Chatboc Iframe: No entity token was provided in the URL. Widget cannot be loaded.');
       setIsLoading(false);
     }
 


### PR DESCRIPTION
The chat widget was incorrectly using expired authentication tokens from `localStorage`. This occurred because the token retrieval logic included a fallback to `localStorage` if a token wasn't present in the iframe's URL upon loading. This behavior led to API calls failing with a "Signature has expired" error when the stored token was stale.

This change removes the `localStorage` fallback for the initial token authentication. The widget now exclusively relies on the token provided in the iframe's URL parameters. This makes the parent/host page the single source of truth for providing a valid token, ensuring the widget always uses a fresh token and preventing authentication errors.