### PR TITLE
Fix widget token flow and clear service workers

### DIFF
--- a/iframe.html
+++ b/iframe.html
@@ -11,6 +11,35 @@
   <body style="background:transparent;margin:0;padding:0;">
     <div id="root"></div>
 
+    <script>
+      // Flag iframe environment so the app avoids registering service workers
+      window.__CHATBOC_IFRAME__ = true;
+
+      // Unregister any existing service workers and clear caches
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker
+          .getRegistrations()
+          .then((regs) => regs.forEach((r) => r.unregister()))
+          .catch(() => {});
+      }
+      if (window.caches?.keys) {
+        caches.keys().then((keys) => keys.forEach((k) => caches.delete(k))).catch(() => {});
+      }
+    </script>
+
+    <script>
+      // Expose configuration from query parameters
+      const qs = new URLSearchParams(location.search);
+      window.CHATBOC_CONFIG = {
+        endpoint: qs.get('endpoint') || 'municipio',
+        entityToken: qs.get('entityToken') || '',
+        userToken: qs.get('userToken') || null,
+        defaultOpen: qs.get('defaultOpen') === 'true',
+        width: qs.get('width') || '460px',
+        height: qs.get('height') || '680px',
+      };
+    </script>
+
     <script type="module" src="/src/pages/iframe.tsx"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -42,13 +42,17 @@
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
     <script>
-      if ('serviceWorker' in navigator) {
+      // Only register the service worker when we are not inside the widget iframe
+      if ('serviceWorker' in navigator && !window.__CHATBOC_IFRAME__) {
         window.addEventListener('load', () => {
-          navigator.serviceWorker.register('/sw.js').then(registration => {
-            console.log('SW registered: ', registration);
-          }).catch(registrationError => {
-            console.log('SW registration failed: ', registrationError);
-          });
+          navigator.serviceWorker
+            .register('/sw.js')
+            .then((registration) => {
+              console.log('SW registered: ', registration);
+            })
+            .catch((registrationError) => {
+              console.log('SW registration failed: ', registrationError);
+            });
         });
       }
     </script>

--- a/public/iframe.html
+++ b/public/iframe.html
@@ -14,20 +14,21 @@
   <div id="root"></div>
 
   <script>
-    // Deshabilitar y limpiar cualquier SW previo del dominio del widget
+    // Marcar que estamos en el iframe del widget (para no registrar SW)
+    window.__CHATBOC_IFRAME__ = true;
+
+    // Desregistrar cualquier SW y limpiar caches en el dominio del widget
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker.getRegistrations()
         .then(regs => regs.forEach(r => r.unregister()))
         .catch(()=>{});
-      if (window.caches?.keys) {
-        caches.keys().then(keys => keys.forEach(k => caches.delete(k))).catch(()=>{});
-      }
+    }
+    if (window.caches?.keys) {
+      caches.keys().then(keys => keys.forEach(k => caches.delete(k))).catch(()=>{});
     }
   </script>
 
   <script>
-    window.__CHATBOC_IFRAME__ = true;
-
     // Config que llega por query
     const qs = new URLSearchParams(location.search);
     window.CHATBOC_CONFIG = {

--- a/services/apiService.ts
+++ b/services/apiService.ts
@@ -1,6 +1,7 @@
 // --- src/services/apiService.ts (CORREGIDO Y COMPLETO) ---
 import type { Ticket, Comment, TicketStatus } from '@/types'; // CAMBIO: Se agrega TicketStatus a la importación
 import { safeLocalStorage } from '@/utils/safeLocalStorage';
+import { getIframeToken } from '@/utils/config';
 
 // Use the same base URL resolution as api.ts. Default to the Vite dev
 // proxy path when no env variable is provided.
@@ -11,7 +12,7 @@ interface CommentsApiResponse { ok: boolean; comentarios: Comment[]; error?: str
 
 async function apiFetch<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
   const token = safeLocalStorage.getItem("authToken");
-  const entityToken = safeLocalStorage.getItem("entityToken");
+  const entityToken = getIframeToken();
   const headers: HeadersInit = {
     "Content-Type": "application/json",
     ...(token && { Authorization: `Bearer ${token}` }),

--- a/src/hooks/useChatLogic.ts
+++ b/src/hooks/useChatLogic.ts
@@ -8,7 +8,7 @@ import { getAskEndpoint } from "@/utils/chatEndpoints";
 import { enforceTipoChatForRubro } from "@/utils/tipoChat";
 import { safeLocalStorage } from "@/utils/safeLocalStorage";
 import getOrCreateChatSessionId from "@/utils/chatSessionId";
-import { getChatbocConfig } from "@/utils/config";
+import { getIframeToken } from "@/utils/config";
 import { v4 as uuidv4 } from 'uuid';
 import { MunicipioContext, updateMunicipioContext, getInitialMunicipioContext } from "@/utils/contexto_municipio";
 import { useUser } from './useUser';
@@ -19,8 +19,7 @@ interface UseChatLogicOptions {
 }
 
 export function useChatLogic({ tipoChat, entityToken: propToken }: UseChatLogicOptions) {
-  const { entityToken: iframeToken } = getChatbocConfig();
-  const entityToken = propToken || iframeToken;
+  const entityToken = propToken || getIframeToken();
   const { user } = useUser();
   const [messages, setMessages] = useState<Message[]>([]);
   const [isTyping, setIsTyping] = useState(false);
@@ -43,8 +42,12 @@ export function useChatLogic({ tipoChat, entityToken: propToken }: UseChatLogicO
   const socketRef = useRef<Socket | null>(null);
 
   useEffect(() => {
-    if (!entityToken || !tipoChat) {
-      console.log("useChatLogic: Deferring socket connection until entityToken and tipoChat are available.", { hasToken: !!entityToken, hasTipoChat: !!tipoChat });
+    if (!entityToken) {
+      console.log("useChatLogic: No entityToken, socket connection deferred.");
+      return;
+    }
+    if (!tipoChat) {
+      console.log("useChatLogic: Deferring socket connection until tipoChat is available.");
       return;
     }
 

--- a/src/pages/iframe.tsx
+++ b/src/pages/iframe.tsx
@@ -3,9 +3,9 @@ import { createRoot } from 'react-dom/client';
 import React, { useEffect, useState } from "react";
 import ChatWidget from "../components/chat/ChatWidget";
 import { GoogleOAuthProvider } from "@react-oauth/google";
-import { safeLocalStorage } from "@/utils/safeLocalStorage";
 import ErrorBoundary from '../components/ErrorBoundary';
 import { MemoryRouter } from "react-router-dom";
+import { getChatbocConfig } from "@/utils/config";
 
 const DEFAULTS = {
   openWidth: "460px",
@@ -30,38 +30,25 @@ const Iframe = () => {
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
+    const cfg = getChatbocConfig();
     const urlParams = new URLSearchParams(window.location.search);
-    const tokenFromUrl =
-      urlParams.get("token") || urlParams.get("entityToken");
-    const storedToken = safeLocalStorage.getItem("entityToken");
-    const currentToken = tokenFromUrl || storedToken;
-    const rawEndpoint = urlParams.get("endpoint") || urlParams.get("tipo_chat");
+
+    setEntityToken(cfg.entityToken || null);
+
     const endpointParam =
-      rawEndpoint === 'pyme' || rawEndpoint === 'municipio'
-        ? (rawEndpoint as 'pyme' | 'municipio')
+      cfg.endpoint === 'pyme' || cfg.endpoint === 'municipio'
+        ? (cfg.endpoint as 'pyme' | 'municipio')
         : null;
-
-    if (tokenFromUrl && tokenFromUrl !== storedToken) {
-      safeLocalStorage.setItem("entityToken", tokenFromUrl);
-      console.log(
-        "Chatboc Iframe: entityToken guardado en localStorage desde URL:",
-        tokenFromUrl
-      );
-    }
-
-    if (currentToken) {
-      setEntityToken(currentToken);
-    } else {
-      console.warn('Chatboc Iframe: No se encontró token en la URL ni en localStorage.');
-      setIsLoading(false);
+    if (endpointParam) {
+      setTipoChat(endpointParam);
     }
 
     setWidgetParams({
-      defaultOpen: urlParams.get("defaultOpen") === "true",
+      defaultOpen: cfg.defaultOpen,
       widgetId: urlParams.get("widgetId") || "chatboc-iframe-unknown",
       view: urlParams.get("view") || 'chat',
-      openWidth: urlParams.get("openWidth") || DEFAULTS.openWidth,
-      openHeight: urlParams.get("openHeight") || DEFAULTS.openHeight,
+      openWidth: urlParams.get("openWidth") || cfg.width || DEFAULTS.openWidth,
+      openHeight: urlParams.get("openHeight") || cfg.height || DEFAULTS.openHeight,
       closedWidth: urlParams.get("closedWidth") || DEFAULTS.closedWidth,
       closedHeight: urlParams.get("closedHeight") || DEFAULTS.closedHeight,
       ctaMessage: urlParams.get("ctaMessage") || undefined,
@@ -69,10 +56,7 @@ const Iframe = () => {
       endpoint: endpointParam || undefined,
     });
 
-    if (endpointParam) {
-      setTipoChat(endpointParam);
-      setIsLoading(false);
-    }
+    setIsLoading(false);
   }, []);
 
   useEffect(() => {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -3,6 +3,7 @@
 import { BASE_API_URL } from '@/config';
 import { safeLocalStorage } from "@/utils/safeLocalStorage";
 import getOrCreateChatSessionId from "@/utils/chatSessionId"; // Import the new function
+import { getIframeToken } from "@/utils/config";
 
 export class ApiError extends Error {
   public readonly status: number;
@@ -57,8 +58,9 @@ export async function apiFetch<T>(
   if (((!token && anonId) || sendAnonId) && anonId) {
     headers["Anon-Id"] = anonId;
   }
-  if (entityToken) {
-    headers["X-Entity-Token"] = entityToken;
+  const effectiveEntityToken = entityToken ?? getIframeToken();
+  if (effectiveEntityToken) {
+    headers["X-Entity-Token"] = effectiveEntityToken;
   }
   // Log request details without exposing full tokens
   const mask = (t: string | null) => (t ? `${t.slice(0, 8)}...` : null);
@@ -68,7 +70,7 @@ export async function apiFetch<T>(
     hasBody: !!body,
     authToken: mask(token),
     anonId: mask(anonId),
-    entityToken: mask(entityToken || null),
+    entityToken: mask(effectiveEntityToken || null),
     sendAnonId,
     headers,
   });

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -3,6 +3,13 @@ export function getChatbocConfig() {
   return {
     endpoint: g.endpoint || 'municipio',
     entityToken: g.entityToken || '',
-    userToken: g.userToken || null
+    userToken: g.userToken || null,
+    defaultOpen: !!g.defaultOpen,
+    width: g.width || '460px',
+    height: g.height || '680px'
   };
+}
+
+export function getIframeToken(): string {
+  return (window as any).CHATBOC_CONFIG?.entityToken || '';
 }


### PR DESCRIPTION
## Summary
- Clear any widget service workers and expose iframe config via query parameters
- Pass entity token through loader, config, and React logic for consistent socket/API use
- Include entity token on all API requests and service calls
- Skip service worker registration inside widget iframe

## Testing
- `npm test` *(fails: Failed to resolve import "../server/cart.cjs" from tests; file missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ad08ef630883229b1aa32dc7d49202