### PR TITLE
Fix widget token flow and clear service workers

### DIFF
--- a/iframe.html
+++ b/iframe.html
@@ -11,6 +11,43 @@
   <body style="background:transparent;margin:0;padding:0;">
     <div id="root"></div>
 
+    <script>
+      // Flag iframe environment so the app avoids registering service workers
+      window.__CHATBOC_IFRAME__ = true;
+
+      // Unregister any existing service workers and clear caches
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker
+          .getRegistrations()
+          .then((regs) => {
+            const hadRegs = regs.length > 0;
+            return Promise.all(regs.map((r) => r.unregister())).then(() => {
+              if (hadRegs) location.reload();
+            });
+          })
+          .catch(() => {});
+      }
+      if (window.caches?.keys) {
+        caches
+          .keys()
+          .then((keys) => Promise.all(keys.map((k) => caches.delete(k))))
+          .catch(() => {});
+      }
+    </script>
+
+    <script>
+      // Expose configuration from query parameters
+      const qs = new URLSearchParams(location.search);
+      window.CHATBOC_CONFIG = {
+        endpoint: qs.get('endpoint') || 'municipio',
+        entityToken: qs.get('entityToken') || '',
+        userToken: qs.get('userToken') || null,
+        defaultOpen: qs.get('defaultOpen') === 'true',
+        width: qs.get('width') || '460px',
+        height: qs.get('height') || '680px',
+      };
+    </script>
+
     <script type="module" src="/src/pages/iframe.tsx"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -42,13 +42,17 @@
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
     <script>
-      if ('serviceWorker' in navigator) {
+      // Only register the service worker when we are not inside the widget iframe
+      if ('serviceWorker' in navigator && !window.__CHATBOC_IFRAME__) {
         window.addEventListener('load', () => {
-          navigator.serviceWorker.register('/sw.js').then(registration => {
-            console.log('SW registered: ', registration);
-          }).catch(registrationError => {
-            console.log('SW registration failed: ', registrationError);
-          });
+          navigator.serviceWorker
+            .register('/sw.js')
+            .then((registration) => {
+              console.log('SW registered: ', registration);
+            })
+            .catch((registrationError) => {
+              console.log('SW registration failed: ', registrationError);
+            });
         });
       }
     </script>

--- a/public/iframe.html
+++ b/public/iframe.html
@@ -14,20 +14,28 @@
   <div id="root"></div>
 
   <script>
-    // Deshabilitar y limpiar cualquier SW previo del dominio del widget
+    // Marcar que estamos en el iframe del widget (para no registrar SW)
+    window.__CHATBOC_IFRAME__ = true;
+
+    // Desregistrar cualquier SW y limpiar caches en el dominio del widget
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker.getRegistrations()
-        .then(regs => regs.forEach(r => r.unregister()))
-        .catch(()=>{});
-      if (window.caches?.keys) {
-        caches.keys().then(keys => keys.forEach(k => caches.delete(k))).catch(()=>{});
-      }
+        .then(regs => {
+          const hadRegs = regs.length > 0;
+          return Promise.all(regs.map(r => r.unregister())).then(() => {
+            if (hadRegs) location.reload();
+          });
+        })
+        .catch(() => {});
+    }
+    if (window.caches?.keys) {
+      caches.keys()
+        .then(keys => Promise.all(keys.map(k => caches.delete(k))))
+        .catch(() => {});
     }
   </script>
 
   <script>
-    window.__CHATBOC_IFRAME__ = true;
-
     // Config que llega por query
     const qs = new URLSearchParams(location.search);
     window.CHATBOC_CONFIG = {

--- a/public/widget.js
+++ b/public/widget.js
@@ -1,69 +1,78 @@
 (function () {
   "use strict";
 
-  // Determine the domain that serves the widget. In production this allows the
-  // same script to run on different hosts without hardcoding localhost.
   const script =
     document.currentScript ||
     Array.from(document.getElementsByTagName("script")).find((s) =>
       s.src && s.src.includes("widget.js")
     );
+
   const DEFAULT_DOMAIN = "https://www.chatboc.ar";
   const chatbocDomain =
     (script &&
       (script.getAttribute("data-domain") || new URL(script.src).origin)) ||
     DEFAULT_DOMAIN;
+
+  // Ensure only one widget container exists
+  const existingRoot = document.getElementById('chatboc-widget-root');
+  if (existingRoot) existingRoot.remove();
+
   const randomId = Math.random().toString(36).substring(2, 9);
   const iframeId = `chatboc-iframe-${randomId}`;
-  const containerId = `chatboc-widget-container-${randomId}`;
+  const containerId = 'chatboc-widget-root';
 
-  const params = new URLSearchParams();
-  if (script) {
-    for (const attr of script.attributes) {
-      if (attr.name.startsWith('data-')) {
-        const key = attr.name.replace('data-', '');
-        const value = attr.value;
-        params.set(key, value);
-        console.log(`Widget.js: Param set: ${key} = ${value}`);
-      }
-    }
-  }
+  const ds = script ? script.dataset : {};
 
-  if (!params.has('token')) {
-    params.set('token', 'demo-anon');
-    console.log("Widget.js: No data-token found, using 'demo-anon'");
-  }
+  const cfg = {
+    host: chatbocDomain,
+    iframePath: ds.iframePath || "/iframe",
+    endpoint: ds.endpoint || "municipio",
+    entityToken: ds.token || ds.entityToken || "demo-anon",
+    defaultOpen: ds.defaultOpen === "true",
+    width: ds.width || "460px",
+    height: ds.height || "680px",
+    closedWidth: ds.closedWidth || "72px",
+    closedHeight: ds.closedHeight || "72px",
+    bottom: ds.bottom || "20px",
+    right: ds.right || "20px",
+  };
 
-  params.set('widgetId', iframeId);
-  params.set('hostDomain', window.location.origin);
+  const qs = new URLSearchParams({
+    endpoint: cfg.endpoint,
+    entityToken: cfg.entityToken,
+    defaultOpen: String(cfg.defaultOpen),
+    width: cfg.width,
+    height: cfg.height,
+    widgetId: iframeId,
+    hostDomain: window.location.origin,
+  });
 
-  const iframeSrc = `${chatbocDomain}/iframe?${params.toString()}`;
-  console.log("Widget.js: Iframe source:", iframeSrc);
+  const iframeSrc = `${cfg.host}${cfg.iframePath}?${qs.toString()}`;
 
-  const container = document.createElement('div');
+  const container = document.createElement("div");
   container.id = containerId;
   document.body.appendChild(container);
 
-  const shadow = container.attachShadow({ mode: 'open' });
+  const shadow = container.attachShadow({ mode: "open" });
 
-  const iframe = document.createElement('iframe');
+  const iframe = document.createElement("iframe");
   iframe.id = iframeId;
-  iframe.title = 'Chatboc Widget';
+  iframe.title = "Chatboc Widget";
   iframe.src = iframeSrc;
-  iframe.style.cssText = 'width: 100%; height: 100%; border: none; background: transparent;';
-  iframe.allow = 'clipboard-write; geolocation';
+  iframe.style.cssText =
+    "width: 100%; height: 100%; border: none; background: transparent;";
+  iframe.allow = "microphone; geolocation; clipboard-write";
+  iframe.sandbox =
+    "allow-forms allow-popups allow-modals allow-scripts allow-same-origin allow-downloads";
 
-  const closedWidth = params.get('closed-width') || '100px';
-  const closedHeight = params.get('closed-height') || '100px';
-
-  const style = document.createElement('style');
+  const style = document.createElement("style");
   style.textContent = `
     :host {
       position: fixed;
-      bottom: ${params.get('bottom') || '20px'};
-      right: ${params.get('right') || '20px'};
-      width: ${closedWidth};
-      height: ${closedHeight};
+      bottom: ${cfg.bottom};
+      right: ${cfg.right};
+      width: ${cfg.closedWidth};
+      height: ${cfg.closedHeight};
       z-index: 2147483647;
       border: none;
       background: transparent;
@@ -75,22 +84,17 @@
   shadow.appendChild(style);
   shadow.appendChild(iframe);
 
-  window.addEventListener('message', (event) => {
-    if (event.source !== iframe.contentWindow || !event.data.widgetId || event.data.widgetId !== iframeId) {
+  window.addEventListener("message", (event) => {
+    if (event.source !== iframe.contentWindow || event.data.widgetId !== iframeId) {
       return;
     }
 
-    if (event.data.type === 'chatboc-state-change') {
-      const { dimensions, isOpen } = event.data;
+    if (event.data.type === "chatboc-state-change") {
+      const { dimensions } = event.data;
       const host = shadow.host;
-      if (isOpen) {
-        host.style.width = dimensions.width;
-        host.style.height = dimensions.height;
-      } else {
-        host.style.width = dimensions.width;
-        host.style.height = dimensions.height;
-      }
+      host.style.width = dimensions.width;
+      host.style.height = dimensions.height;
     }
   });
-
 })();
+

--- a/services/apiService.ts
+++ b/services/apiService.ts
@@ -1,6 +1,7 @@
 // --- src/services/apiService.ts (CORREGIDO Y COMPLETO) ---
 import type { Ticket, Comment, TicketStatus } from '@/types'; // CAMBIO: Se agrega TicketStatus a la importación
 import { safeLocalStorage } from '@/utils/safeLocalStorage';
+import { getIframeToken } from '@/utils/config';
 
 // Use the same base URL resolution as api.ts. Default to the Vite dev
 // proxy path when no env variable is provided.
@@ -11,7 +12,7 @@ interface CommentsApiResponse { ok: boolean; comentarios: Comment[]; error?: str
 
 async function apiFetch<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
   const token = safeLocalStorage.getItem("authToken");
-  const entityToken = safeLocalStorage.getItem("entityToken");
+  const entityToken = getIframeToken();
   const headers: HeadersInit = {
     "Content-Type": "application/json",
     ...(token && { Authorization: `Bearer ${token}` }),

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -257,6 +257,8 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
 
   useEffect(() => {
     async function fetchEntityProfile() {
+      // Wait until the token is resolved before deciding what to do.
+      if (entityToken == null) return;
       if (!entityToken) {
         console.log("ChatWidget: No hay entityToken, se asume configuración por defecto.");
         setProfileLoading(false);

--- a/src/hooks/useChatLogic.ts
+++ b/src/hooks/useChatLogic.ts
@@ -8,7 +8,7 @@ import { getAskEndpoint } from "@/utils/chatEndpoints";
 import { enforceTipoChatForRubro } from "@/utils/tipoChat";
 import { safeLocalStorage } from "@/utils/safeLocalStorage";
 import getOrCreateChatSessionId from "@/utils/chatSessionId";
-import { getChatbocConfig } from "@/utils/config";
+import { getIframeToken } from "@/utils/config";
 import { v4 as uuidv4 } from 'uuid';
 import { MunicipioContext, updateMunicipioContext, getInitialMunicipioContext } from "@/utils/contexto_municipio";
 import { useUser } from './useUser';
@@ -19,8 +19,7 @@ interface UseChatLogicOptions {
 }
 
 export function useChatLogic({ tipoChat, entityToken: propToken }: UseChatLogicOptions) {
-  const { entityToken: iframeToken } = getChatbocConfig();
-  const entityToken = propToken || iframeToken;
+  const entityToken = propToken || getIframeToken();
   const { user } = useUser();
   const [messages, setMessages] = useState<Message[]>([]);
   const [isTyping, setIsTyping] = useState(false);
@@ -43,8 +42,12 @@ export function useChatLogic({ tipoChat, entityToken: propToken }: UseChatLogicO
   const socketRef = useRef<Socket | null>(null);
 
   useEffect(() => {
-    if (!entityToken || !tipoChat) {
-      console.log("useChatLogic: Deferring socket connection until entityToken and tipoChat are available.", { hasToken: !!entityToken, hasTipoChat: !!tipoChat });
+    if (!entityToken) {
+      console.log("useChatLogic: No entityToken, socket connection deferred.");
+      return;
+    }
+    if (!tipoChat) {
+      console.log("useChatLogic: Deferring socket connection until tipoChat is available.");
       return;
     }
 

--- a/src/pages/iframe.tsx
+++ b/src/pages/iframe.tsx
@@ -3,9 +3,9 @@ import { createRoot } from 'react-dom/client';
 import React, { useEffect, useState } from "react";
 import ChatWidget from "../components/chat/ChatWidget";
 import { GoogleOAuthProvider } from "@react-oauth/google";
-import { safeLocalStorage } from "@/utils/safeLocalStorage";
 import ErrorBoundary from '../components/ErrorBoundary';
 import { MemoryRouter } from "react-router-dom";
+import { getChatbocConfig } from "@/utils/config";
 
 const DEFAULTS = {
   openWidth: "460px",
@@ -30,38 +30,25 @@ const Iframe = () => {
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
+    const cfg = getChatbocConfig();
     const urlParams = new URLSearchParams(window.location.search);
-    const tokenFromUrl =
-      urlParams.get("token") || urlParams.get("entityToken");
-    const storedToken = safeLocalStorage.getItem("entityToken");
-    const currentToken = tokenFromUrl || storedToken;
-    const rawEndpoint = urlParams.get("endpoint") || urlParams.get("tipo_chat");
+
+    setEntityToken(cfg.entityToken || null);
+
     const endpointParam =
-      rawEndpoint === 'pyme' || rawEndpoint === 'municipio'
-        ? (rawEndpoint as 'pyme' | 'municipio')
+      cfg.endpoint === 'pyme' || cfg.endpoint === 'municipio'
+        ? (cfg.endpoint as 'pyme' | 'municipio')
         : null;
-
-    if (tokenFromUrl && tokenFromUrl !== storedToken) {
-      safeLocalStorage.setItem("entityToken", tokenFromUrl);
-      console.log(
-        "Chatboc Iframe: entityToken guardado en localStorage desde URL:",
-        tokenFromUrl
-      );
-    }
-
-    if (currentToken) {
-      setEntityToken(currentToken);
-    } else {
-      console.warn('Chatboc Iframe: No se encontró token en la URL ni en localStorage.');
-      setIsLoading(false);
+    if (endpointParam) {
+      setTipoChat(endpointParam);
     }
 
     setWidgetParams({
-      defaultOpen: urlParams.get("defaultOpen") === "true",
+      defaultOpen: cfg.defaultOpen,
       widgetId: urlParams.get("widgetId") || "chatboc-iframe-unknown",
       view: urlParams.get("view") || 'chat',
-      openWidth: urlParams.get("openWidth") || DEFAULTS.openWidth,
-      openHeight: urlParams.get("openHeight") || DEFAULTS.openHeight,
+      openWidth: urlParams.get("openWidth") || cfg.width || DEFAULTS.openWidth,
+      openHeight: urlParams.get("openHeight") || cfg.height || DEFAULTS.openHeight,
       closedWidth: urlParams.get("closedWidth") || DEFAULTS.closedWidth,
       closedHeight: urlParams.get("closedHeight") || DEFAULTS.closedHeight,
       ctaMessage: urlParams.get("ctaMessage") || undefined,
@@ -69,10 +56,7 @@ const Iframe = () => {
       endpoint: endpointParam || undefined,
     });
 
-    if (endpointParam) {
-      setTipoChat(endpointParam);
-      setIsLoading(false);
-    }
+    setIsLoading(false);
   }, []);
 
   useEffect(() => {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -3,6 +3,7 @@
 import { BASE_API_URL } from '@/config';
 import { safeLocalStorage } from "@/utils/safeLocalStorage";
 import getOrCreateChatSessionId from "@/utils/chatSessionId"; // Import the new function
+import { getIframeToken } from "@/utils/config";
 
 export class ApiError extends Error {
   public readonly status: number;
@@ -57,8 +58,9 @@ export async function apiFetch<T>(
   if (((!token && anonId) || sendAnonId) && anonId) {
     headers["Anon-Id"] = anonId;
   }
-  if (entityToken) {
-    headers["X-Entity-Token"] = entityToken;
+  const effectiveEntityToken = entityToken ?? getIframeToken();
+  if (effectiveEntityToken) {
+    headers["X-Entity-Token"] = effectiveEntityToken;
   }
   // Log request details without exposing full tokens
   const mask = (t: string | null) => (t ? `${t.slice(0, 8)}...` : null);
@@ -68,7 +70,7 @@ export async function apiFetch<T>(
     hasBody: !!body,
     authToken: mask(token),
     anonId: mask(anonId),
-    entityToken: mask(entityToken || null),
+    entityToken: mask(effectiveEntityToken || null),
     sendAnonId,
     headers,
   });

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -3,6 +3,13 @@ export function getChatbocConfig() {
   return {
     endpoint: g.endpoint || 'municipio',
     entityToken: g.entityToken || '',
-    userToken: g.userToken || null
+    userToken: g.userToken || null,
+    defaultOpen: !!g.defaultOpen,
+    width: g.width || '460px',
+    height: g.height || '680px'
   };
+}
+
+export function getIframeToken(): string {
+  return (window as any).CHATBOC_CONFIG?.entityToken || '';
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,9 @@ export default defineConfig(({ mode }) => {
     plugins: [
       react(),
       VitePWA({
+        // We manually register the service worker in index.html to avoid
+        // unintentionally registering it inside the embeddable iframe.
+        injectRegister: null,
         registerType: 'autoUpdate',
         includeAssets: ['favicon.ico', 'apple-touch-icon.png', 'masked-icon.svg'],
         manifest: {


### PR DESCRIPTION
## Summary
- Clear any widget service workers and expose iframe config via query parameters
- Pass entity token through loader, config, and React logic for consistent socket/API use
- Include entity token on all API requests and service calls
- Skip service worker registration inside widget iframe
- Remove any existing widget container before bootstrapping to prevent duplicate overlays
- Disable automatic PWA injection and reload after unregistering service workers

## Testing
- `npm test` *(fails: Failed to resolve import "../server/cart.cjs" from tests/businessMetrics.test.cjs)*

------
https://chatgpt.com/codex/tasks/task_e_68ad08ef630883229b1aa32dc7d49202