### PR TITLE
feat: support weighted heatmap

### DIFF
--- a/src/components/LocationMap.tsx
+++ b/src/components/LocationMap.tsx
@@ -1,84 +1,11 @@
 import React, { useEffect, useRef } from "react";
+import { loadGoogleMapsApi } from "@/utils/mapsLoader";
 
 interface LocationMapProps {
   lat?: number | null;
   lng?: number | null;
   onMove?: (lat: number, lng: number) => void;
-  heatmapData?: { lat: number; lng: number }[];
-}
-
-const Maps_API_KEY = import.meta.env.VITE_Maps_API_KEY || "";
-
-function ensureScriptLoaded(callback: () => void) {
-  if (typeof window === "undefined") return;
-
-  const checkReady = () => {
-    if (
-      window.google &&
-      window.google.maps &&
-      window.google.maps.Map &&
-      window.google.maps.marker &&
-      window.google.maps.marker.AdvancedMarkerElement &&
-      window.google.maps.visualization
-    ) {
-      callback();
-    } else {
-      // If script is loaded but libraries not ready, poll
-      const intervalId = setInterval(() => {
-        if (
-          window.google &&
-          window.google.maps &&
-          window.google.maps.Map &&
-          window.google.maps.marker &&
-          window.google.maps.marker.AdvancedMarkerElement &&
-          window.google.maps.visualization
-        ) {
-          clearInterval(intervalId);
-          callback();
-        }
-      }, 100);
-    }
-  };
-
-  if (
-    window.google &&
-    window.google.maps &&
-    window.google.maps.Map &&
-    window.google.maps.marker &&
-    window.google.maps.marker.AdvancedMarkerElement &&
-    window.google.maps.visualization
-  ) {
-    // Already loaded and ready
-    callback();
-    return;
-  }
-
-  const existingScript = document.getElementById("chatboc-google-maps");
-  if (existingScript && (existingScript as any)._isLoaded) {
-    // Script tag exists and has loaded, check if API objects are ready
-    checkReady();
-    return;
-  } if (existingScript) {
-    // Script tag exists but might still be loading, add listener and also poll
-    existingScript.addEventListener("load", checkReady);
-    checkReady(); // check immediately in case it loaded between getElementById and addEventListener
-    return;
-  }
-
-  const script = document.createElement("script");
-  script.id = "chatboc-google-maps";
-  script.src = `https://maps.googleapis.com/maps/api/js?key=${Maps_API_KEY}&v=weekly&libraries=places,marker,visualization`;
-  script.async = true;
-  script.defer = true; // Defer execution until HTML parsing is complete
-  script.onload = () => {
-    (script as any)._isLoaded = true; // Mark as loaded
-    checkReady();
-  };
-  script.onerror = () => {
-    console.error("Google Maps script failed to load.");
-    // Potentially call a user-facing error handler here
-  };
-  document.head.appendChild(script);
+  heatmapData?: { lat: number; lng: number; weight?: number }[];
 }
 
 const LocationMap: React.FC<LocationMapProps> = ({ lat, lng, onMove, heatmapData }) => {
@@ -88,58 +15,68 @@ const LocationMap: React.FC<LocationMapProps> = ({ lat, lng, onMove, heatmapData
   const heatmapRef = useRef<google.maps.visualization.HeatmapLayer | null>(null);
 
   useEffect(() => {
-    ensureScriptLoaded(() => {
-      if (!ref.current) return;
-      if (!mapRef.current) {
-        const center =
-          lat != null && lng != null ? { lat, lng } : { lat: -34.6037, lng: -58.3816 };
-        mapRef.current = new window.google.maps.Map(ref.current, {
-          center,
-          zoom: lat != null && lng != null ? 15 : 5,
-          mapId: "CHATBOC_MAP_ID", // Add Map ID for Advanced Markers
-        });
-        markerRef.current = new window.google.maps.marker.AdvancedMarkerElement({
-          position: lat != null && lng != null ? center : undefined,
-          map: mapRef.current!,
-          draggable: Boolean(onMove),
-        });
-        if (onMove && markerRef.current) {
-          markerRef.current.addListener("dragend", () => {
-            const pos = markerRef.current!.position;
-            if (pos) onMove(pos.lat(), pos.lng());
+    let cancelled = false;
+    loadGoogleMapsApi(["marker", "visualization"]) // ensure required libraries
+      .then(() => {
+        if (cancelled || !ref.current) return;
+        if (!mapRef.current) {
+          const center =
+            lat != null && lng != null ? { lat, lng } : { lat: -34.6037, lng: -58.3816 };
+          mapRef.current = new window.google.maps.Map(ref.current, {
+            center,
+            zoom: lat != null && lng != null ? 15 : 5,
+            mapId: "CHATBOC_MAP_ID",
           });
-        }
-
-        // Heatmap Layer Logic
-        if (heatmapData && heatmapData.length > 0) {
-          const points = heatmapData.map(p => new window.google.maps.LatLng(p.lat, p.lng));
-          if (!heatmapRef.current) {
-            heatmapRef.current = new window.google.maps.visualization.HeatmapLayer({
-              data: points,
-              map: mapRef.current!,
+          markerRef.current = new window.google.maps.marker.AdvancedMarkerElement({
+            position: lat != null && lng != null ? center : undefined,
+            map: mapRef.current!,
+            draggable: Boolean(onMove),
+          });
+          if (onMove && markerRef.current) {
+            markerRef.current.addListener("dragend", () => {
+              const pos = markerRef.current!.position;
+              if (pos) onMove(pos.lat(), pos.lng());
             });
-            heatmapRef.current.set("radius", 30);
-            heatmapRef.current.set("opacity", 0.8);
-          } else {
-            heatmapRef.current.setData(points);
-            heatmapRef.current.setMap(mapRef.current!);
           }
-        } else if (heatmapRef.current) {
-          // If no data, ensure heatmap is not shown
-          heatmapRef.current.setMap(null);
+        } else if (lat != null && lng != null) {
+          const pos = { lat, lng };
+          mapRef.current!.setCenter(pos);
+          mapRef.current!.setZoom(15);
+          if (markerRef.current) {
+            markerRef.current.position = pos;
+            markerRef.current.map = mapRef.current!;
+          }
         }
 
-      } else if (lat != null && lng != null) {
-        const pos = { lat, lng };
-        mapRef.current!.setCenter(pos);
-        mapRef.current!.setZoom(15);
-        if (markerRef.current) {
-          markerRef.current.position = pos;
-          markerRef.current.map = mapRef.current!;
+        if (mapRef.current) {
+          if (heatmapData && heatmapData.length > 0) {
+            const points = heatmapData.map((p) => ({
+              location: new window.google.maps.LatLng(p.lat, p.lng),
+              weight: p.weight ?? 1,
+            }));
+            if (!heatmapRef.current) {
+              heatmapRef.current = new window.google.maps.visualization.HeatmapLayer({
+                data: points,
+                map: mapRef.current!,
+              });
+              heatmapRef.current.set("radius", 30);
+              heatmapRef.current.set("opacity", 0.8);
+            } else {
+              heatmapRef.current.setData(points);
+              heatmapRef.current.setMap(mapRef.current!);
+            }
+          } else if (heatmapRef.current) {
+            heatmapRef.current.setMap(null);
+          }
         }
-      }
-    });
-  }, [lat, lng, onMove]);
+      })
+      .catch((err) => {
+        console.error("Google Maps script failed to load:", err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [lat, lng, onMove, heatmapData]);
 
   // Added flex-grow and min-h-[200px] (or other suitable min-height)
   return <div ref={ref} className="w-full rounded-md border border-border flex-grow min-h-[200px]" />; 

--- a/src/pages/Perfil.tsx
+++ b/src/pages/Perfil.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useCallback, FormEvent } from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -107,6 +108,14 @@ const DIAS = [
   "Domingo",
 ];
 
+interface TicketLocation {
+  lat: number;
+  lng: number;
+  weight: number;
+  categoria?: string;
+  barrio?: string;
+}
+
 export default function Perfil() {
   const navigate = useNavigate();
   const { user, refreshUser } = useUser(); // Usa refreshUser del hook
@@ -143,7 +152,15 @@ export default function Perfil() {
   const [horariosOpen, setHorariosOpen] = useState(false);
   const [isEventModalOpen, setIsEventModalOpen] = useState(false);
   const [isSubmittingEvent, setIsSubmittingEvent] = useState(false);
-  const [heatmapData, setHeatmapData] = useState([]);
+  const [ticketLocations, setTicketLocations] = useState<TicketLocation[]>([]);
+  const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
+  const [selectedBarrios, setSelectedBarrios] = useState<string[]>([]);
+  const [availableCategories, setAvailableCategories] = useState<string[]>([]);
+  const [availableBarrios, setAvailableBarrios] = useState<string[]>([]);
+  const [heatmapData, setHeatmapData] = useState<
+    { lat: number; lng: number; weight?: number }[]
+  >([]);
+  const [mapCenter, setMapCenter] = useState<{ lat: number; lng: number } | null>(null);
 
   // --- Estados para el nuevo modal de carga de catálogo ---
   const [isMappingModalOpen, setIsMappingModalOpen] = useState(false);
@@ -259,10 +276,27 @@ export default function Perfil() {
     // Fetch heatmap data
     const fetchHeatmapData = async () => {
       try {
-        const data = await apiFetch('/municipal/tickets/locations');
-        // The endpoint should return an array of {lat, lng} objects.
-        // No further transformation should be needed if the backend respects the contract.
-        setHeatmapData(data || []);
+        const tipo = getCurrentTipoChat();
+        const pluralTipo = tipo === "municipio" ? "municipios" : "pymes";
+        const data = await apiFetch<
+          { location: { lat: number; lng: number }; weight: number; categoria?: string; barrio?: string }[]
+        >(`/tickets/${pluralTipo}/mapa`);
+        const mapped: TicketLocation[] = (data || []).map((d) => ({
+          lat: d.location.lat,
+          lng: d.location.lng,
+          weight: d.weight,
+          categoria: d.categoria,
+          barrio: d.barrio,
+        }));
+        setTicketLocations(mapped);
+        const cats = Array.from(
+          new Set(mapped.map((d) => d.categoria).filter(Boolean))
+        ) as string[];
+        setAvailableCategories(cats);
+        const barrios = Array.from(
+          new Set(mapped.map((d) => d.barrio).filter(Boolean))
+        ) as string[];
+        setAvailableBarrios(barrios);
       } catch (error) {
         console.error("Error fetching heatmap data:", error);
         // Do not show a toast here to avoid spamming the user if the endpoint is not ready yet.
@@ -271,6 +305,34 @@ export default function Perfil() {
     };
     fetchHeatmapData();
   }, [fetchPerfil, navigate]);
+
+  useEffect(() => {
+    const filtered = ticketLocations.filter(
+      (t) =>
+        (selectedCategories.length === 0 ||
+          (t.categoria && selectedCategories.includes(t.categoria))) &&
+        (selectedBarrios.length === 0 ||
+          (t.barrio && selectedBarrios.includes(t.barrio)))
+    );
+    const points = filtered.map(({ lat, lng, weight }) => ({
+      lat,
+      lng,
+      weight,
+    }));
+    setHeatmapData(points);
+    if (filtered.length > 0) {
+      const totalWeight = filtered.reduce((sum, t) => sum + (t.weight || 0), 0);
+      if (totalWeight > 0) {
+        const avgLat =
+          filtered.reduce((sum, t) => sum + t.lat * (t.weight || 0), 0) /
+          totalWeight;
+        const avgLng =
+          filtered.reduce((sum, t) => sum + t.lng * (t.weight || 0), 0) /
+          totalWeight;
+        setMapCenter({ lat: avgLat, lng: avgLng });
+      }
+    }
+  }, [ticketLocations, selectedCategories, selectedBarrios]);
 
   // Función para cargar las configuraciones de mapeo
   const fetchMappingConfigs = useCallback(async () => {
@@ -813,7 +875,6 @@ export default function Perfil() {
                     <LocationMap
                       lat={perfil.latitud ?? undefined}
                       lng={perfil.longitud ?? undefined}
-                      heatmapData={heatmapData}
                       onMove={(la, ln) =>
                         setPerfil((prev) => ({ ...prev, latitud: la, longitud: ln }))
                       }
@@ -949,6 +1010,78 @@ export default function Perfil() {
               </form>
             </CardContent>
           </Card>
+          {ticketLocations.length > 0 && (
+            <Card className="bg-card shadow-xl rounded-xl border border-border backdrop-blur-sm">
+              <CardHeader>
+                <CardTitle className="text-xl font-semibold text-primary">
+                  Mapa de calor de reclamos
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {availableCategories.length > 0 && (
+                  <div>
+                    <Label className="text-muted-foreground text-sm mb-1 block">
+                      Categorías
+                    </Label>
+                    <div className="flex flex-wrap gap-2">
+                      {availableCategories.map((cat) => (
+                        <label
+                          key={cat}
+                          className="flex items-center gap-1 text-xs text-foreground"
+                        >
+                          <Checkbox
+                            checked={selectedCategories.includes(cat)}
+                            onCheckedChange={(checked) => {
+                              const isChecked = checked === true;
+                              setSelectedCategories((prev) =>
+                                isChecked
+                                  ? [...prev, cat]
+                                  : prev.filter((c) => c !== cat)
+                              );
+                            }}
+                          />
+                          {cat}
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+                )}
+                {availableBarrios.length > 0 && (
+                  <div>
+                    <Label className="text-muted-foreground text-sm mb-1 block">
+                      Barrios
+                    </Label>
+                    <div className="flex flex-wrap gap-2">
+                      {availableBarrios.map((barr) => (
+                        <label
+                          key={barr}
+                          className="flex items-center gap-1 text-xs text-foreground"
+                        >
+                          <Checkbox
+                            checked={selectedBarrios.includes(barr)}
+                            onCheckedChange={(checked) => {
+                              const isChecked = checked === true;
+                              setSelectedBarrios((prev) =>
+                                isChecked
+                                  ? [...prev, barr]
+                                  : prev.filter((b) => b !== barr)
+                              );
+                            }}
+                          />
+                          {barr}
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+                )}
+                <LocationMap
+                  lat={mapCenter?.lat}
+                  lng={mapCenter?.lng}
+                  heatmapData={heatmapData}
+                />
+              </CardContent>
+            </Card>
+          )}
         </div>
 
         {/* Columna Derecha: Plan, Catálogo, Integración */}

--- a/src/pages/Perfil.tsx
+++ b/src/pages/Perfil.tsx
@@ -278,9 +278,19 @@ export default function Perfil() {
       try {
         const tipo = getCurrentTipoChat();
         const pluralTipo = tipo === "municipio" ? "municipios" : "pymes";
-        const data = await apiFetch<
-          { location: { lat: number; lng: number }; weight: number; categoria?: string; barrio?: string }[]
-        >(`/tickets/${pluralTipo}/mapa`);
+        const resp = await fetch(
+          `${API_BASE_URL.replace(/\/$/, '')}/tickets/${pluralTipo}/mapa`,
+          {
+            headers: { Authorization: `Bearer ${token}`, 'Cache-Control': 'no-store' },
+            cache: 'no-store',
+          }
+        );
+        if (!resp.ok) {
+          console.error('Error fetching heatmap data:', resp.status);
+          return;
+        }
+        const data: { location: { lat: number; lng: number }; weight: number; categoria?: string; barrio?: string }[] =
+          await resp.json();
         const mapped: TicketLocation[] = (data || []).map((d) => ({
           lat: d.location.lat,
           lng: d.location.lng,

--- a/src/utils/mapsLoader.ts
+++ b/src/utils/mapsLoader.ts
@@ -1,4 +1,5 @@
-const MAPS_API_KEY = import.meta.env.VITE_MAPS_API_KEY || '';
+// Use the same env var name used across the app
+const MAPS_API_KEY = import.meta.env.VITE_Maps_API_KEY || '';
 const SCRIPT_ID = 'chatboc-google-maps-script';
 
 interface GoogleMapsApi {


### PR DESCRIPTION
## Summary
- fetch ticket heatmap data from new `/tickets/<tipo>/mapa` endpoint and track weights
- render Google Maps heatmap with weighted points and weighted map centering
- load Google Maps with visualization library via shared loader
- fix heatmap fetch to use plural endpoint paths for municipios and pymes

## Testing
- `npm test` *(fails: Failed to resolve import "../server/cart.cjs" from "tests/businessMetrics.test.cjs")*

------
https://chatgpt.com/codex/tasks/task_e_68ad1e10cf188322b60cf7cb4fca10d2