### PR TITLE
feat: support weighted heatmap

### DIFF
--- a/src/components/LocationMap.tsx
+++ b/src/components/LocationMap.tsx
@@ -1,84 +1,11 @@
 import React, { useEffect, useRef } from "react";
+import { loadGoogleMapsApi } from "@/utils/mapsLoader";
 
 interface LocationMapProps {
   lat?: number | null;
   lng?: number | null;
   onMove?: (lat: number, lng: number) => void;
-  heatmapData?: { lat: number; lng: number }[];
-}
-
-const Maps_API_KEY = import.meta.env.VITE_Maps_API_KEY || "";
-
-function ensureScriptLoaded(callback: () => void) {
-  if (typeof window === "undefined") return;
-
-  const checkReady = () => {
-    if (
-      window.google &&
-      window.google.maps &&
-      window.google.maps.Map &&
-      window.google.maps.marker &&
-      window.google.maps.marker.AdvancedMarkerElement &&
-      window.google.maps.visualization
-    ) {
-      callback();
-    } else {
-      // If script is loaded but libraries not ready, poll
-      const intervalId = setInterval(() => {
-        if (
-          window.google &&
-          window.google.maps &&
-          window.google.maps.Map &&
-          window.google.maps.marker &&
-          window.google.maps.marker.AdvancedMarkerElement &&
-          window.google.maps.visualization
-        ) {
-          clearInterval(intervalId);
-          callback();
-        }
-      }, 100);
-    }
-  };
-
-  if (
-    window.google &&
-    window.google.maps &&
-    window.google.maps.Map &&
-    window.google.maps.marker &&
-    window.google.maps.marker.AdvancedMarkerElement &&
-    window.google.maps.visualization
-  ) {
-    // Already loaded and ready
-    callback();
-    return;
-  }
-
-  const existingScript = document.getElementById("chatboc-google-maps");
-  if (existingScript && (existingScript as any)._isLoaded) {
-    // Script tag exists and has loaded, check if API objects are ready
-    checkReady();
-    return;
-  } if (existingScript) {
-    // Script tag exists but might still be loading, add listener and also poll
-    existingScript.addEventListener("load", checkReady);
-    checkReady(); // check immediately in case it loaded between getElementById and addEventListener
-    return;
-  }
-
-  const script = document.createElement("script");
-  script.id = "chatboc-google-maps";
-  script.src = `https://maps.googleapis.com/maps/api/js?key=${Maps_API_KEY}&v=weekly&libraries=places,marker,visualization`;
-  script.async = true;
-  script.defer = true; // Defer execution until HTML parsing is complete
-  script.onload = () => {
-    (script as any)._isLoaded = true; // Mark as loaded
-    checkReady();
-  };
-  script.onerror = () => {
-    console.error("Google Maps script failed to load.");
-    // Potentially call a user-facing error handler here
-  };
-  document.head.appendChild(script);
+  heatmapData?: { lat: number; lng: number; weight?: number }[];
 }
 
 const LocationMap: React.FC<LocationMapProps> = ({ lat, lng, onMove, heatmapData }) => {
@@ -88,58 +15,68 @@ const LocationMap: React.FC<LocationMapProps> = ({ lat, lng, onMove, heatmapData
   const heatmapRef = useRef<google.maps.visualization.HeatmapLayer | null>(null);
 
   useEffect(() => {
-    ensureScriptLoaded(() => {
-      if (!ref.current) return;
-      if (!mapRef.current) {
-        const center =
-          lat != null && lng != null ? { lat, lng } : { lat: -34.6037, lng: -58.3816 };
-        mapRef.current = new window.google.maps.Map(ref.current, {
-          center,
-          zoom: lat != null && lng != null ? 15 : 5,
-          mapId: "CHATBOC_MAP_ID", // Add Map ID for Advanced Markers
-        });
-        markerRef.current = new window.google.maps.marker.AdvancedMarkerElement({
-          position: lat != null && lng != null ? center : undefined,
-          map: mapRef.current!,
-          draggable: Boolean(onMove),
-        });
-        if (onMove && markerRef.current) {
-          markerRef.current.addListener("dragend", () => {
-            const pos = markerRef.current!.position;
-            if (pos) onMove(pos.lat(), pos.lng());
+    let cancelled = false;
+    loadGoogleMapsApi(["marker", "visualization"]) // ensure required libraries
+      .then(() => {
+        if (cancelled || !ref.current) return;
+        if (!mapRef.current) {
+          const center =
+            lat != null && lng != null ? { lat, lng } : { lat: -34.6037, lng: -58.3816 };
+          mapRef.current = new window.google.maps.Map(ref.current, {
+            center,
+            zoom: lat != null && lng != null ? 15 : 5,
+            mapId: "CHATBOC_MAP_ID",
           });
-        }
-
-        // Heatmap Layer Logic
-        if (heatmapData && heatmapData.length > 0) {
-          const points = heatmapData.map(p => new window.google.maps.LatLng(p.lat, p.lng));
-          if (!heatmapRef.current) {
-            heatmapRef.current = new window.google.maps.visualization.HeatmapLayer({
-              data: points,
-              map: mapRef.current!,
+          markerRef.current = new window.google.maps.marker.AdvancedMarkerElement({
+            position: lat != null && lng != null ? center : undefined,
+            map: mapRef.current!,
+            draggable: Boolean(onMove),
+          });
+          if (onMove && markerRef.current) {
+            markerRef.current.addListener("dragend", () => {
+              const pos = markerRef.current!.position;
+              if (pos) onMove(pos.lat(), pos.lng());
             });
-            heatmapRef.current.set("radius", 30);
-            heatmapRef.current.set("opacity", 0.8);
-          } else {
-            heatmapRef.current.setData(points);
-            heatmapRef.current.setMap(mapRef.current!);
           }
-        } else if (heatmapRef.current) {
-          // If no data, ensure heatmap is not shown
-          heatmapRef.current.setMap(null);
+        } else if (lat != null && lng != null) {
+          const pos = { lat, lng };
+          mapRef.current!.setCenter(pos);
+          mapRef.current!.setZoom(15);
+          if (markerRef.current) {
+            markerRef.current.position = pos;
+            markerRef.current.map = mapRef.current!;
+          }
         }
 
-      } else if (lat != null && lng != null) {
-        const pos = { lat, lng };
-        mapRef.current!.setCenter(pos);
-        mapRef.current!.setZoom(15);
-        if (markerRef.current) {
-          markerRef.current.position = pos;
-          markerRef.current.map = mapRef.current!;
+        if (mapRef.current) {
+          if (heatmapData && heatmapData.length > 0) {
+            const points = heatmapData.map((p) => ({
+              location: new window.google.maps.LatLng(p.lat, p.lng),
+              weight: p.weight ?? 1,
+            }));
+            if (!heatmapRef.current) {
+              heatmapRef.current = new window.google.maps.visualization.HeatmapLayer({
+                data: points,
+                map: mapRef.current!,
+              });
+              heatmapRef.current.set("radius", 30);
+              heatmapRef.current.set("opacity", 0.8);
+            } else {
+              heatmapRef.current.setData(points);
+              heatmapRef.current.setMap(mapRef.current!);
+            }
+          } else if (heatmapRef.current) {
+            heatmapRef.current.setMap(null);
+          }
         }
-      }
-    });
-  }, [lat, lng, onMove]);
+      })
+      .catch((err) => {
+        console.error("Google Maps script failed to load:", err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [lat, lng, onMove, heatmapData]);
 
   // Added flex-grow and min-h-[200px] (or other suitable min-height)
   return <div ref={ref} className="w-full rounded-md border border-border flex-grow min-h-[200px]" />; 

--- a/src/pages/Perfil.tsx
+++ b/src/pages/Perfil.tsx
@@ -267,13 +267,12 @@ export default function Perfil() {
   const fetchHeatmapData = useCallback(async () => {
     try {
       const tipo = getCurrentTipoChat();
-      const pluralTipo = tipo === "municipio" ? "municipios" : "pymes";
       const data: {
         location: { lat: number; lng: number };
         weight: number;
         categoria?: string;
         barrio?: string;
-      }[] = await apiFetch(`/tickets/${pluralTipo}/mapa`, {
+      }[] = await apiFetch(`/tickets/${tipo}/mapa`, {
         headers: { 'Cache-Control': 'no-store' },
         cache: 'no-store',
       });

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -24,6 +24,7 @@ interface ApiFetchOptions {
   skipAuth?: boolean;
   sendAnonId?: boolean;
   entityToken?: string | null;
+  cache?: RequestCache;
 }
 
 /**
@@ -35,7 +36,7 @@ export async function apiFetch<T>(
   path: string,
   options: ApiFetchOptions = {}
 ): Promise<T> {
-  const { method = "GET", body, skipAuth, sendAnonId, entityToken } = options;
+  const { method = "GET", body, skipAuth, sendAnonId, entityToken, cache } = options;
 
   const token = safeLocalStorage.getItem("authToken");
   const anonId = safeLocalStorage.getItem("anon_id");
@@ -81,6 +82,7 @@ export async function apiFetch<T>(
       headers,
       body: isForm ? body : body ? JSON.stringify(body) : undefined,
       credentials: 'include', // ensure cookies like session are sent
+      cache,
     });
 
     // Puede devolver vacío (204 No Content)

--- a/src/utils/mapsLoader.ts
+++ b/src/utils/mapsLoader.ts
@@ -1,4 +1,5 @@
-const MAPS_API_KEY = import.meta.env.VITE_MAPS_API_KEY || '';
+// Use the same env var name used across the app
+const MAPS_API_KEY = import.meta.env.VITE_Maps_API_KEY || '';
 const SCRIPT_ID = 'chatboc-google-maps-script';
 
 interface GoogleMapsApi {


### PR DESCRIPTION
## Summary
- fetch ticket heatmap data from new `/tickets/<tipo>/mapa` endpoint and track weights
- render Google Maps heatmap with weighted points and weighted map centering
- load Google Maps with visualization library via shared loader
- include auth token and disable caching on heatmap request so points load on first profile view
- wait for profile refresh before loading heatmap data to ensure correct chat type
- allow `apiFetch` to pass through cache directives and request heatmap data with `cache: 'no-store'`

## Testing
- `npm test` *(fails: Failed to resolve import "../server/cart.cjs" from "tests/businessMetrics.test.cjs" and similar missing server modules)*


------
https://chatgpt.com/codex/tasks/task_e_68ad1e10cf188322b60cf7cb4fca10d2