### PR TITLE
fix: inherit widget header radius

### DIFF
--- a/src/components/chat/ChatHeader.tsx
+++ b/src/components/chat/ChatHeader.tsx
@@ -33,8 +33,11 @@ const ChatHeader: React.FC<Props> = ({
         transition-all
       `}
       style={{
-        // El header hereda el fondo sutilmente y no es “un recorte”.
-        borderRadius: "24px 24px 0 0", // This might need to be dynamic if widget is full screen on mobile (no border radius)
+        // El header debe acompañar el radio del contenedor para evitar recortes.
+        borderTopLeftRadius: "inherit",
+        borderTopRightRadius: "inherit",
+        borderBottomLeftRadius: 0,
+        borderBottomRightRadius: 0,
       }}
     >
       {/* Logo y nombre sin cuadrado */}


### PR DESCRIPTION
## Summary
- align chat header border radius with widget container to prevent visual clipping

## Testing
- `npm test` *(fails: Failed to resolve import "../server/cart.cjs" ...)*

------
https://chatgpt.com/codex/tasks/task_e_68ae350e8b9083228b9b1baca697f93c