### PR TITLE
fix: inherit widget header radius

### DIFF
--- a/chat/ChatHeader.tsx
+++ b/chat/ChatHeader.tsx
@@ -30,13 +30,8 @@ const ChatHeader: React.FC<Props> = ({
         px-2 sm:px-4 py-3 border-b border-border
         bg-card/90 backdrop-blur-md
         text-card-foreground
-        transition-all
+        transition-all rounded-t-[inherit] overflow-hidden
       `}
-      style={{
-        // El header debe acompañar el radio del contenedor para evitar recortes.
-        borderTopLeftRadius: "inherit",
-        borderTopRightRadius: "inherit",
-      }}
     >
       {/* Logo y nombre sin cuadrado */}
       <div className="flex items-center gap-2 sm:gap-3"> {/* Reduced gap for mobile */}

--- a/chat/ChatHeader.tsx
+++ b/chat/ChatHeader.tsx
@@ -33,8 +33,9 @@ const ChatHeader: React.FC<Props> = ({
         transition-all
       `}
       style={{
-        // El header hereda el fondo sutilmente y no es “un recorte”.
-        borderRadius: "24px 24px 0 0", // This might need to be dynamic if widget is full screen on mobile (no border radius)
+        // El header debe acompañar el radio del contenedor para evitar recortes.
+        borderTopLeftRadius: "inherit",
+        borderTopRightRadius: "inherit",
       }}
     >
       {/* Logo y nombre sin cuadrado */}

--- a/src/components/chat/ChatHeader.tsx
+++ b/src/components/chat/ChatHeader.tsx
@@ -30,13 +30,8 @@ const ChatHeader: React.FC<Props> = ({
         px-2 sm:px-4 py-3 border-b border-border
         bg-card/90 backdrop-blur-md
         text-card-foreground
-        transition-all
+        transition-all rounded-t-[inherit] overflow-hidden
       `}
-      style={{
-        // El header debe acompañar el radio del contenedor para evitar recortes.
-        borderTopLeftRadius: "inherit",
-        borderTopRightRadius: "inherit",
-      }}
     >
       {/* Logo y nombre sin cuadrado */}
       <div className="flex items-center gap-2 sm:gap-3"> {/* Reduced gap for mobile */}

--- a/src/components/chat/ChatHeader.tsx
+++ b/src/components/chat/ChatHeader.tsx
@@ -33,8 +33,9 @@ const ChatHeader: React.FC<Props> = ({
         transition-all
       `}
       style={{
-        // El header hereda el fondo sutilmente y no es “un recorte”.
-        borderRadius: "24px 24px 0 0", // This might need to be dynamic if widget is full screen on mobile (no border radius)
+        // El header debe acompañar el radio del contenedor para evitar recortes.
+        borderTopLeftRadius: "inherit",
+        borderTopRightRadius: "inherit",
       }}
     >
       {/* Logo y nombre sin cuadrado */}


### PR DESCRIPTION
## Summary
- ensure chat header top border radius inherits from widget in both component copies to avoid clipping

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae350e8b9083228b9b1baca697f93c