### PR TITLE
Ensure chat widget stays within viewport

### DIFF
--- a/widget.js
+++ b/widget.js
@@ -93,7 +93,17 @@
         if (isMobile) { // Closed on mobile
             return WIDGET_DIMENSIONS.CLOSED;
         }
-        // Desktop
+        // Desktop: ensure widget fits within viewport when open
+        if (isOpen) {
+          const parsePx = (val) => parseInt(val, 10) || 0;
+          const desiredWidth = parsePx(base.width);
+          const desiredHeight = parsePx(base.height);
+          const maxWidth = window.innerWidth - parsePx(initialRight) - 16;
+          const maxHeight = window.innerHeight - parsePx(initialBottom) - 16;
+          const finalWidth = !isNaN(desiredWidth) ? Math.min(desiredWidth, maxWidth) + "px" : base.width;
+          const finalHeight = !isNaN(desiredHeight) ? Math.min(desiredHeight, maxHeight) + "px" : base.height;
+          return { width: finalWidth, height: finalHeight };
+        }
         return base;
       }
 
@@ -236,15 +246,20 @@
             iframeIsCurrentlyOpen ? WIDGET_DIMENSIONS.OPEN : WIDGET_DIMENSIONS.CLOSED,
             iframeIsCurrentlyOpen
           );
+          const isMobile = window.innerWidth <= SCRIPT_CONFIG.MOBILE_BREAKPOINT_PX;
           if (iframeIsCurrentlyOpen) {
             Object.assign(widgetContainer.style, {
               width: newDims.width,
               height: newDims.height,
-              borderRadius: window.innerWidth <= SCRIPT_CONFIG.MOBILE_BREAKPOINT_PX ? "16px 16px 0 0" : "16px",
+              borderRadius: isMobile ? "16px 16px 0 0" : "16px",
               boxShadow: "0 8px 40px rgba(0, 0, 0, 0.2)",
               background: "white",
               transform: "scale(1)",
               cursor: "default",
+              bottom: isMobile ? "env(safe-area-inset-bottom)" : initialBottom,
+              right: isMobile ? "0" : initialRight,
+              top: isMobile ? "env(safe-area-inset-top)" : "auto",
+              left: isMobile ? "0" : "auto",
             });
           } else {
             Object.assign(widgetContainer.style, {
@@ -254,6 +269,10 @@
               boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
               background: "#007aff",
               cursor: "pointer",
+              bottom: initialBottom,
+              right: initialRight,
+              top: "auto",
+              left: "auto",
             });
           }
         }
@@ -263,10 +282,15 @@
       function resizeHandler() {
         if (!iframeIsCurrentlyOpen) return;
         const newDims = computeResponsiveDims(WIDGET_DIMENSIONS.OPEN, true);
+        const isMobile = window.innerWidth < SCRIPT_CONFIG.MOBILE_BREAKPOINT_PX;
         Object.assign(widgetContainer.style, {
           width: newDims.width,
           height: newDims.height,
-          borderRadius: window.innerWidth < SCRIPT_CONFIG.MOBILE_BREAKPOINT_PX ? "0" : "16px",
+          borderRadius: isMobile ? "0" : "16px",
+          bottom: isMobile ? "env(safe-area-inset-bottom)" : initialBottom,
+          right: isMobile ? "0" : initialRight,
+          top: isMobile ? "env(safe-area-inset-top)" : "auto",
+          left: isMobile ? "0" : "auto",
         });
       }
       window.addEventListener("resize", resizeHandler);


### PR DESCRIPTION
## Summary
- prevent oversized chat widget on desktop by clamping open dimensions to viewport
- anchor open mobile widget to safe area insets so header remains visible

## Testing
- `npm ci --omit=optional` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@maptiler%2fgeocoding-control)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae55e550d483229c4f70fbb8cd58c8