### PR TITLE
Ensure chat widget stays within viewport

### DIFF
--- a/next-themes.js
+++ b/next-themes.js
@@ -5,7 +5,7 @@ import {
 import {
   __toESM
 } from "./chunk-4MBMRILA.js";
-import { safeLocalStorageGetItem, safeLocalStorageSetItem } from "./utils/safeStorage.js";
+import { safeLocalStorageGetItem, safeLocalStorageSetItem } from "./utils/safeStorage";
 
 // node_modules/next-themes/dist/index.mjs
 var t = __toESM(require_react(), 1);

--- a/react-router-dom.js
+++ b/react-router-dom.js
@@ -7,7 +7,7 @@ import {
 import {
   __toESM
 } from "./chunk-4MBMRILA.js";
-import { safeSessionStorageGetItem, safeSessionStorageSetItem } from "./utils/safeStorage.js";
+import { safeSessionStorageGetItem, safeSessionStorageSetItem } from "./utils/safeStorage";
 
 // node_modules/react-router-dom/dist/index.js
 var React2 = __toESM(require_react());

--- a/src/utils/safeLocalStorage.ts
+++ b/src/utils/safeLocalStorage.ts
@@ -1,32 +1,13 @@
-import {
-  safeLocalStorageGetItem,
-  safeLocalStorageSetItem,
-  safeLocalStorageRemoveItem,
-  safeLocalStorageClear,
-} from '../../utils/safeStorage.js';
+// src/utils/safeLocalStorage.ts
+import { safeStorage } from "./safeStorage";
 
-export const safeLocalStorage = {
-  getItem(key: string): string | null {
-    if (typeof window === 'undefined') return null;
-    return safeLocalStorageGetItem(key);
-  },
-  setItem(key: string, value: string) {
-    if (typeof window === 'undefined') return;
-    safeLocalStorageSetItem(key, value);
-  },
-  removeItem(key: string) {
-    if (typeof window === 'undefined') return;
-    safeLocalStorageRemoveItem(key);
-  },
-  clear() {
-    if (typeof window === 'undefined') return;
-    safeLocalStorageClear();
-  },
-};
+// Export nombrado y default para compatibilidad
+export const safeLocalStorage = safeStorage;
+export default safeLocalStorage;
 
-export {
-  safeLocalStorageGetItem,
-  safeLocalStorageSetItem,
-  safeLocalStorageRemoveItem,
-  safeLocalStorageClear,
-};
+// Helpers opcionales
+export const getLS = (k: string) => safeLocalStorage.getItem(k);
+export const setLS = (k: string, v: string) => safeLocalStorage.setItem(k, v);
+export const delLS = (k: string) => safeLocalStorage.removeItem(k);
+export const clearLS = () => safeLocalStorage.clear();
+

--- a/src/utils/safeSessionStorage.ts
+++ b/src/utils/safeSessionStorage.ts
@@ -3,7 +3,7 @@ import {
   safeSessionStorageSetItem,
   safeSessionStorageRemoveItem,
   safeSessionStorageClear,
-} from '../../utils/safeStorage.js';
+} from './safeStorage';
 
 export const safeSessionStorage = {
   getItem(key: string): string | null {

--- a/src/utils/safeStorage.ts
+++ b/src/utils/safeStorage.ts
@@ -1,0 +1,97 @@
+// src/utils/safeStorage.ts
+
+type StorageLike = {
+  getItem: (k: string) => string | null;
+  setItem: (k: string, v: string) => void;
+  removeItem: (k: string) => void;
+  clear: () => void;
+};
+
+function isBrowser(): boolean {
+  return typeof window !== "undefined";
+}
+
+/* ===== Fallbacks en memoria ===== */
+const memLocal: Record<string, string> = {};
+const memSession: Record<string, string> = {};
+
+const memoryLocalStorage: StorageLike = {
+  getItem: (k) => (k in memLocal ? memLocal[k] : null),
+  setItem: (k, v) => {
+    memLocal[k] = v;
+  },
+  removeItem: (k) => {
+    delete memLocal[k];
+  },
+  clear: () => {
+    for (const k of Object.keys(memLocal)) delete memLocal[k];
+  },
+};
+
+const memorySessionStorage: StorageLike = {
+  getItem: (k) => (k in memSession ? memSession[k] : null),
+  setItem: (k, v) => {
+    memSession[k] = v;
+  },
+  removeItem: (k) => {
+    delete memSession[k];
+  },
+  clear: () => {
+    for (const k of Object.keys(memSession)) delete memSession[k];
+  },
+};
+
+/* ===== Storages reales, con try/catch ===== */
+function detectLocalStorage(): StorageLike | null {
+  if (!isBrowser()) return null;
+  try {
+    const ls = window.localStorage;
+    const t = "__safeStorage_test__";
+    ls.setItem(t, "1");
+    ls.removeItem(t);
+    return {
+      getItem: (k) => ls.getItem(k),
+      setItem: (k, v) => ls.setItem(k, v),
+      removeItem: (k) => ls.removeItem(k),
+      clear: () => ls.clear(),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function detectSessionStorage(): StorageLike | null {
+  if (!isBrowser()) return null;
+  try {
+    const ss = window.sessionStorage;
+    const t = "__safeSession_test__";
+    ss.setItem(t, "1");
+    ss.removeItem(t);
+    return {
+      getItem: (k) => ss.getItem(k),
+      setItem: (k, v) => ss.setItem(k, v),
+      removeItem: (k) => ss.removeItem(k),
+      clear: () => ss.clear(),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/* ===== Exports principales ===== */
+export const safeStorage: StorageLike = detectLocalStorage() ?? memoryLocalStorage;
+export const safeSessionStorage: StorageLike = detectSessionStorage() ?? memorySessionStorage;
+
+/* ===== Helpers (exports UNA sola vez) ===== */
+export const safeLocalStorageGetItem = (k: string) => safeStorage.getItem(k);
+export const safeLocalStorageSetItem = (k: string, v: string) => safeStorage.setItem(k, v);
+export const safeLocalStorageRemoveItem = (k: string) => safeStorage.removeItem(k);
+export const safeLocalStorageClear = () => safeStorage.clear();
+
+export const safeSessionStorageGetItem = (k: string) => safeSessionStorage.getItem(k);
+export const safeSessionStorageSetItem = (k: string, v: string) => safeSessionStorage.setItem(k, v);
+export const safeSessionStorageRemoveItem = (k: string) => safeSessionStorage.removeItem(k);
+export const safeSessionStorageClear = () => safeSessionStorage.clear();
+
+/* Default (por si en algún lado lo importaste así) */
+export default safeStorage;

--- a/widget.js
+++ b/widget.js
@@ -82,6 +82,8 @@
       const iframeId = `chatboc-dynamic-iframe-${Math.random().toString(36).substring(2, 9)}`;
       let iframeIsCurrentlyOpen = defaultOpen;
 
+      const parsePx = (val) => parseInt(val, 10) || 0;
+
       function computeResponsiveDims(base, isOpen) {
         const isMobile = window.innerWidth < SCRIPT_CONFIG.MOBILE_BREAKPOINT_PX;
         if (isOpen && isMobile) {
@@ -90,10 +92,25 @@
             height: "calc(100dvh - env(safe-area-inset-top) - env(safe-area-inset-bottom))",
           };
         }
-        if (isMobile) { // Closed on mobile
-            return WIDGET_DIMENSIONS.CLOSED;
+        if (isMobile) {
+          // Closed on mobile
+          return WIDGET_DIMENSIONS.CLOSED;
         }
-        // Desktop
+        // Desktop: ensure widget fits within viewport when open
+        if (isOpen) {
+          const desiredWidth = parsePx(base.width);
+          const desiredHeight = parsePx(base.height);
+          const maxWidth = window.innerWidth - parsePx(initialRight) - 16;
+          const maxHeight =
+            window.innerHeight - parsePx(initialBottom) - 16;
+          const finalWidth = !isNaN(desiredWidth)
+            ? Math.min(desiredWidth, maxWidth) + "px"
+            : base.width;
+          const finalHeight = !isNaN(desiredHeight)
+            ? Math.min(desiredHeight, maxHeight) + "px"
+            : base.height;
+          return { width: finalWidth, height: finalHeight };
+        }
         return base;
       }
 
@@ -236,16 +253,27 @@
             iframeIsCurrentlyOpen ? WIDGET_DIMENSIONS.OPEN : WIDGET_DIMENSIONS.CLOSED,
             iframeIsCurrentlyOpen
           );
+          const isMobile = window.innerWidth <= SCRIPT_CONFIG.MOBILE_BREAKPOINT_PX;
           if (iframeIsCurrentlyOpen) {
-            Object.assign(widgetContainer.style, {
+            const style = {
               width: newDims.width,
               height: newDims.height,
-              borderRadius: window.innerWidth <= SCRIPT_CONFIG.MOBILE_BREAKPOINT_PX ? "16px 16px 0 0" : "16px",
+              borderRadius: isMobile ? "16px 16px 0 0" : "16px",
               boxShadow: "0 8px 40px rgba(0, 0, 0, 0.2)",
               background: "white",
               transform: "scale(1)",
               cursor: "default",
-            });
+              right: isMobile ? "0" : initialRight,
+              left: isMobile ? "0" : "auto",
+            };
+            if (isMobile) {
+              style.bottom = "env(safe-area-inset-bottom)";
+              style.top = "env(safe-area-inset-top)";
+            } else {
+              style.bottom = initialBottom;
+              style.top = "auto";
+            }
+            Object.assign(widgetContainer.style, style);
           } else {
             Object.assign(widgetContainer.style, {
               width: newDims.width,
@@ -254,6 +282,13 @@
               boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
               background: "#007aff",
               cursor: "pointer",
+              bottom:
+                window.innerWidth <= SCRIPT_CONFIG.MOBILE_BREAKPOINT_PX
+                  ? "env(safe-area-inset-bottom)"
+                  : initialBottom,
+              right: initialRight,
+              top: "auto",
+              left: "auto",
             });
           }
         }
@@ -263,13 +298,25 @@
       function resizeHandler() {
         if (!iframeIsCurrentlyOpen) return;
         const newDims = computeResponsiveDims(WIDGET_DIMENSIONS.OPEN, true);
-        Object.assign(widgetContainer.style, {
+        const isMobile = window.innerWidth < SCRIPT_CONFIG.MOBILE_BREAKPOINT_PX;
+        const style = {
           width: newDims.width,
           height: newDims.height,
-          borderRadius: window.innerWidth < SCRIPT_CONFIG.MOBILE_BREAKPOINT_PX ? "0" : "16px",
-        });
+          borderRadius: isMobile ? "0" : "16px",
+          right: isMobile ? "0" : initialRight,
+          left: isMobile ? "0" : "auto",
+        };
+        if (isMobile) {
+          style.bottom = "env(safe-area-inset-bottom)";
+          style.top = "env(safe-area-inset-top)";
+        } else {
+          style.bottom = initialBottom;
+          style.top = "auto";
+        }
+        Object.assign(widgetContainer.style, style);
       }
       window.addEventListener("resize", resizeHandler);
+      if (iframeIsCurrentlyOpen) resizeHandler();
 
       // Fallback click listener
       widgetContainer.addEventListener("click", () => {


### PR DESCRIPTION
## Summary
- export named and default `safeLocalStorage` wrapper referencing `safeStorage`
- clamp desktop widget height to viewport and streamline resize logic

## Testing
- `npm ci --omit=optional` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@maptiler%2fgeocoding-control)*
- `npm test` *(fails: vitest: not found)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae55e550d483229c4f70fbb8cd58c8