### PR TITLE
feat: handle text confirmation and ticket links

### DIFF
--- a/src/components/tickets/TicketTimeline.tsx
+++ b/src/components/tickets/TicketTimeline.tsx
@@ -1,15 +1,10 @@
 import React from 'react';
 import { formatDate } from '@/utils/fecha';
 import { CheckCircle, Clock } from 'lucide-react';
-
-interface TimelineEvent {
-  status: string;
-  date: string;
-  notes?: string;
-}
+import { TicketHistoryEvent } from '@/types/tickets';
 
 interface TicketTimelineProps {
-  history: TimelineEvent[];
+  history: TicketHistoryEvent[];
 }
 
 const TicketTimeline: React.FC<TicketTimelineProps> = ({ history }) => {

--- a/src/routesConfig.tsx
+++ b/src/routesConfig.tsx
@@ -73,6 +73,7 @@ const routes: RouteConfig[] = [
   { path: '/demo', element: <Demo /> },
   { path: '/perfil', element: <Perfil /> },
   { path: '/chat', element: <ChatPage /> },
+  { path: '/chat/:ticketId', element: <TicketLookup /> },
   { path: '/checkout', element: <Checkout /> },
   { path: '/chatpos', element: <ChatPosPage /> },
   { path: '/chatcrm', element: <ChatCRMPage /> },

--- a/src/services/ticketService.ts
+++ b/src/services/ticketService.ts
@@ -37,6 +37,21 @@ export const getTicketById = async (id: string): Promise<Ticket> => {
     }
 };
 
+export const getTicketByNumber = async (nroTicket: string): Promise<Ticket> => {
+    try {
+        const response = await apiFetch<Ticket>(`/tickets/municipio/por_numero/${encodeURIComponent(nroTicket)}`, {
+            sendAnonId: true,
+        });
+        return {
+            ...response,
+            avatarUrl: response.avatarUrl || generateRandomAvatar(response.email || response.id.toString()),
+        };
+    } catch (error) {
+        console.error(`Error fetching ticket by number ${nroTicket}:`, error);
+        throw error;
+    }
+};
+
 export const sendTicketHistory = async (ticket: Ticket): Promise<void> => {
     try {
         await apiFetch(`/tickets/${ticket.tipo}/${ticket.id}/send-history`, {

--- a/src/types/tickets.ts
+++ b/src/types/tickets.ts
@@ -53,6 +53,12 @@ export interface InformacionPersonalVecino {
   dni?: string;
 }
 
+export interface TicketHistoryEvent {
+  status: string;
+  date: string;
+  notes?: string;
+}
+
 export interface Ticket {
   id: number;
   tipo: 'municipio' | 'pyme';
@@ -67,6 +73,7 @@ export interface Ticket {
   latitud?: number;
   longitud?: number;
   avatarUrl?: string;
+  history?: TicketHistoryEvent[];
 
   // Pyme specific fields
   telefono?: string;


### PR DESCRIPTION
## Summary
- Support free-text confirmations like "si" or "ok" during claim confirmation
- Add route to view ticket status via `/chat/:ticketId`
- Fetch ticket data from the API and auto-refresh the tracking page

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae99874e9083229e3a2d2d93f64bda