### PR TITLE
fix: make ticket tracking endpoint more robust

### DIFF
--- a/src/components/tickets/TicketTimeline.tsx
+++ b/src/components/tickets/TicketTimeline.tsx
@@ -1,15 +1,10 @@
 import React from 'react';
 import { formatDate } from '@/utils/fecha';
 import { CheckCircle, Clock } from 'lucide-react';
-
-interface TimelineEvent {
-  status: string;
-  date: string;
-  notes?: string;
-}
+import { TicketHistoryEvent } from '@/types/tickets';
 
 interface TicketTimelineProps {
-  history: TimelineEvent[];
+  history: TicketHistoryEvent[];
 }
 
 const TicketTimeline: React.FC<TicketTimelineProps> = ({ history }) => {

--- a/src/pages/Perfil.tsx
+++ b/src/pages/Perfil.tsx
@@ -250,10 +250,7 @@ export default function Perfil() {
         weight: number;
         categoria?: string;
         barrio?: string;
-      }[] = await apiFetch(`/tickets/${tipo}/mapa`, {
-        headers: { 'Cache-Control': 'no-store' },
-        cache: 'no-store',
-      });
+      }[] = await apiFetch(`/tickets/${tipo}/mapa`);
       const mapped: TicketLocation[] = (data || []).map((d) => ({
         lat: d.location.lat,
         lng: d.location.lng,

--- a/src/routesConfig.tsx
+++ b/src/routesConfig.tsx
@@ -73,6 +73,7 @@ const routes: RouteConfig[] = [
   { path: '/demo', element: <Demo /> },
   { path: '/perfil', element: <Perfil /> },
   { path: '/chat', element: <ChatPage /> },
+  { path: '/chat/:ticketId', element: <TicketLookup /> },
   { path: '/checkout', element: <Checkout /> },
   { path: '/chatpos', element: <ChatPosPage /> },
   { path: '/chatcrm', element: <ChatCRMPage /> },

--- a/src/services/ticketService.ts
+++ b/src/services/ticketService.ts
@@ -37,6 +37,28 @@ export const getTicketById = async (id: string): Promise<Ticket> => {
     }
 };
 
+export const getTicketByNumber = async (nroTicket: string): Promise<Ticket> => {
+    const clean = nroTicket.replace(/[^\d]/g, '');
+    const endpoints = [
+        `/tickets/municipio/por_numero/${encodeURIComponent(clean)}`,
+        `/tickets/municipio/${encodeURIComponent(clean)}`,
+    ];
+    let lastError: unknown;
+    for (const url of endpoints) {
+        try {
+            const response = await apiFetch<Ticket>(url, { sendAnonId: true });
+            return {
+                ...response,
+                avatarUrl: response.avatarUrl || generateRandomAvatar(response.email || response.id.toString()),
+            };
+        } catch (err) {
+            lastError = err;
+        }
+    }
+    console.error(`Error fetching ticket by number ${nroTicket}:`, lastError);
+    throw lastError;
+};
+
 export const sendTicketHistory = async (ticket: Ticket): Promise<void> => {
     try {
         await apiFetch(`/tickets/${ticket.tipo}/${ticket.id}/send-history`, {

--- a/src/types/tickets.ts
+++ b/src/types/tickets.ts
@@ -53,6 +53,12 @@ export interface InformacionPersonalVecino {
   dni?: string;
 }
 
+export interface TicketHistoryEvent {
+  status: string;
+  date: string;
+  notes?: string;
+}
+
 export interface Ticket {
   id: number;
   tipo: 'municipio' | 'pyme';
@@ -67,6 +73,7 @@ export interface Ticket {
   latitud?: number;
   longitud?: number;
   avatarUrl?: string;
+  history?: TicketHistoryEvent[];
 
   // Pyme specific fields
   telefono?: string;


### PR DESCRIPTION
## Summary
- handle multiple API paths when looking up tickets by number
- sanitize ticket numbers before querying the backend
- remove custom cache header when loading ticket heatmap to avoid CORS errors

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae99874e9083229e3a2d2d93f64bda