### PR TITLE
fix: improve ticket tracking and confirmation flow

### DIFF
--- a/src/components/tickets/TicketTimeline.tsx
+++ b/src/components/tickets/TicketTimeline.tsx
@@ -1,15 +1,10 @@
 import React from 'react';
 import { formatDate } from '@/utils/fecha';
 import { CheckCircle, Clock } from 'lucide-react';
-
-interface TimelineEvent {
-  status: string;
-  date: string;
-  notes?: string;
-}
+import { TicketHistoryEvent } from '@/types/tickets';
 
 interface TicketTimelineProps {
-  history: TimelineEvent[];
+  history: TicketHistoryEvent[];
 }
 
 const TicketTimeline: React.FC<TicketTimelineProps> = ({ history }) => {

--- a/src/hooks/useChatLogic.ts
+++ b/src/hooks/useChatLogic.ts
@@ -181,11 +181,27 @@ export function useChatLogic({ tipoChat, entityToken: propToken, tokenKey = 'aut
     const { text: userMessageText, attachmentInfo, ubicacion_usuario, action, location } = actualPayload;
     const actionPayload = 'payload' in actualPayload ? actualPayload.payload : undefined;
 
+    // Allow confirming/cancelling a claim with free text when awaiting confirmation
+    let resolvedAction = action;
+    const awaitingConfirmation =
+      contexto.estado_conversacion === 'confirmando_reclamo' ||
+      contexto.reclamo_flow_v2?.state === 'ESPERANDO_CONFIRMACION';
+    if (!resolvedAction && awaitingConfirmation) {
+      const normalized = sanitizedText.toLowerCase();
+      const confirmWords = ['1', 'si', 'sí', 's', 'ok', 'okay', 'acepto', 'aceptar', 'confirmar', 'confirmo'];
+      const cancelWords = ['2', 'no', 'n', 'cancelar', 'cancel', 'rechazo', 'rechazar'];
+      if (confirmWords.includes(normalized)) {
+        resolvedAction = 'confirmar_reclamo';
+      } else if (cancelWords.includes(normalized)) {
+        resolvedAction = 'cancelar_reclamo';
+      }
+    }
 
-    if (!userMessageText && !attachmentInfo && !ubicacion_usuario && !action && !actualPayload.archivo_url && !location) return;
+
+    if (!userMessageText && !attachmentInfo && !ubicacion_usuario && !resolvedAction && !actualPayload.archivo_url && !location) return;
     if (isTyping) return;
 
-    if (action === 'iniciar_creacion_reclamo') {
+    if (resolvedAction === 'iniciar_creacion_reclamo') {
       // Check for existing user data
       const userData = user || JSON.parse(safeLocalStorage.getItem('user') || 'null');
       if (userData?.name && userData?.email) { // Assume phone and DNI are not available in user object
@@ -224,7 +240,7 @@ export function useChatLogic({ tipoChat, entityToken: propToken, tokenKey = 'aut
       return;
     }
 
-    if (action === 'submit_personal_data' && actionPayload) {
+    if (resolvedAction === 'submit_personal_data' && actionPayload) {
       setContexto(prev => ({
         ...prev,
         estado_conversacion: 'confirmando_reclamo',
@@ -273,7 +289,7 @@ export function useChatLogic({ tipoChat, entityToken: propToken, tokenKey = 'aut
       const rubro = storedUser?.rubro?.clave || storedUser?.rubro?.nombre || safeLocalStorage.getItem("rubroSeleccionado") || null;
       const tipoChatFinal = enforceTipoChatForRubro(tipoChat, rubro);
 
-      const updatedContext = updateMunicipioContext(contexto, { userInput: userMessageText, action });
+      const updatedContext = updateMunicipioContext(contexto, { userInput: userMessageText, action: resolvedAction });
       setContexto(updatedContext);
 
       const requestBody: Record<string, any> = {
@@ -283,12 +299,12 @@ export function useChatLogic({ tipoChat, entityToken: propToken, tokenKey = 'aut
         ...(rubro && { rubro_clave: rubro }),
         ...(attachmentInfo && { attachment_info: attachmentInfo }),
         ...(location && { location: location }),
-        ...(action && { action }),
+        ...(resolvedAction && { action: resolvedAction }),
         ...(actionPayload && { payload: actionPayload }),
-        ...(action === "confirmar_reclamo" && currentClaimIdempotencyKey && { idempotency_key: currentClaimIdempotencyKey }),
+        ...(resolvedAction === "confirmar_reclamo" && currentClaimIdempotencyKey && { idempotency_key: currentClaimIdempotencyKey }),
       };
 
-      if (action === 'confirmar_reclamo') {
+      if (resolvedAction === 'confirmar_reclamo') {
         requestBody.datos_personales = {
           nombre: contexto.datos_reclamo.nombre_ciudadano,
           email: contexto.datos_reclamo.email_ciudadano,

--- a/src/hooks/useTicketUpdates.tsx
+++ b/src/hooks/useTicketUpdates.tsx
@@ -34,6 +34,14 @@ export default function useTicketUpdates() {
           withCredentials: true, // Para enviar cookies si es necesario
         });
 
+        // Si por algún motivo la librería no devuelve una instancia válida,
+        // evitamos que la aplicación se rompa al llamar a `.on` sobre algo que
+        // no implementa el EventEmitter de Socket.io.
+        if (!socket || typeof (socket as any).on !== 'function') {
+          console.error('Socket.io returned an invalid client:', socket);
+          return;
+        }
+
         socket.on('connect', () => {
           console.log('Socket.io connected successfully');
         });

--- a/src/pages/Perfil.tsx
+++ b/src/pages/Perfil.tsx
@@ -245,18 +245,17 @@ export default function Perfil() {
   const fetchHeatmapData = useCallback(async () => {
     try {
       const tipo = getCurrentTipoChat();
-      const data: {
-        location: { lat: number; lng: number };
-        weight: number;
-        categoria?: string;
-        barrio?: string;
-      }[] = await apiFetch(`/tickets/${tipo}/mapa`, {
-        headers: { 'Cache-Control': 'no-store' },
-        cache: 'no-store',
-      });
-      const mapped: TicketLocation[] = (data || []).map((d) => ({
-        lat: d.location.lat,
-        lng: d.location.lng,
+      const raw = await apiFetch<any>(`/tickets/${tipo}/mapa`);
+      const arrayData = Array.isArray(raw)
+        ? raw
+        : Array.isArray(raw?.data)
+          ? raw.data
+          : Array.isArray(raw?.tickets)
+            ? raw.tickets
+            : [];
+      const mapped: TicketLocation[] = arrayData.map((d: any) => ({
+        lat: d.location?.lat ?? 0,
+        lng: d.location?.lng ?? 0,
         weight: d.weight,
         categoria: d.categoria,
         barrio: d.barrio,

--- a/src/pages/TicketLookup.tsx
+++ b/src/pages/TicketLookup.tsx
@@ -2,32 +2,12 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { useParams } from 'react-router-dom';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { apiFetch } from '@/utils/api';
+import { getTicketByNumber } from '@/services/ticketService';
+import { Ticket } from '@/types/tickets';
 import { formatDate } from '@/utils/fecha';
-import TicketTimeline from '@/components/tickets/TicketTimeline'; // Importar el nuevo componente
+import TicketTimeline from '@/components/tickets/TicketTimeline';
 import { Separator } from '@/components/ui/separator';
-
-// Definir la interfaz para un evento en la línea de tiempo
-interface TimelineEvent {
-  status: string;
-  date: string;
-  notes?: string;
-}
-
-// Actualizar la interfaz del Ticket para incluir el historial
-interface Ticket {
-  id: number;
-  nro_ticket: number | string;
-  asunto?: string;
-  detalles?: string;
-  estado: string;
-  fecha: string;
-  nombre_usuario?: string;
-  direccion?: string | null;
-  latitud?: number | null;
-  longitud?: number | null;
-  history?: TimelineEvent[]; // Añadir historial
-}
+import { getErrorMessage } from '@/utils/api';
 
 export default function TicketLookup() {
   const { ticketId } = useParams<{ ticketId: string }>();
@@ -40,38 +20,12 @@ export default function TicketLookup() {
     if (!searchId) return;
     setLoading(true);
     setError(null);
-    setTicket(null);
     try {
-      // Simulación de una respuesta de API con historial
-      // En un caso real, la API /tickets/municipio/por_numero/.. debería devolver esto.
-      const mockTicketData: Ticket = {
-        id: 12345,
-        nro_ticket: searchId,
-        asunto: 'Rama de árbol peligrosa',
-        detalles: 'Una rama muy grande está sobre mi techo y parece que va a caer.',
-        estado: 'En Proceso',
-        fecha: '2024-08-15T10:30:00Z',
-        direccion: 'Don Bosco 55, Junín',
-        history: [
-          { status: 'Recibido', date: '2024-08-15T10:30:00Z', notes: 'Reclamo generado a través del chatbot.' },
-          { status: 'Asignado', date: '2024-08-15T11:00:00Z', notes: 'Asignado al equipo de Espacios Verdes.' },
-          { status: 'En Proceso', date: '2024-08-16T09:00:00Z', notes: 'El equipo de Espacios Verdes ha programado la visita.' },
-        ],
-      };
-
-      // const data = await apiFetch<Ticket>(
-      //   `/tickets/municipio/por_numero/${encodeURIComponent(searchId)}`,
-      //   { sendEntityToken: true }
-      // );
-
-      // Usar datos mockeados por ahora
-      setTimeout(() => {
-        setTicket(mockTicketData);
-        setLoading(false);
-      }, 1000);
-
-    } catch (err: any) {
-      setError(err.message || 'No se encontró el ticket');
+      const data = await getTicketByNumber(searchId);
+      setTicket(data);
+    } catch (err) {
+      setError(getErrorMessage(err, 'No se encontró el ticket'));
+    } finally {
       setLoading(false);
     }
   }, []);
@@ -81,6 +35,14 @@ export default function TicketLookup() {
       performSearch(ticketId);
     }
   }, [ticketId, performSearch]);
+
+  useEffect(() => {
+    if (!ticket) return;
+    const interval = setInterval(() => {
+      performSearch(ticket.nro_ticket);
+    }, 30000);
+    return () => clearInterval(interval);
+  }, [ticket, performSearch]);
 
   const handleFormSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -116,6 +78,22 @@ export default function TicketLookup() {
             </p>
             {ticket.direccion && (
               <p className="text-sm text-muted-foreground mt-1">Dirección: {ticket.direccion}</p>
+            )}
+            {(ticket.telefono || ticket.email || ticket.dni || ticket.informacion_personal_vecino) && (
+              <div className="mt-4 text-sm space-y-1">
+                {(ticket.informacion_personal_vecino?.nombre || ticket.display_name) && (
+                  <p>Nombre: {ticket.informacion_personal_vecino?.nombre || ticket.display_name}</p>
+                )}
+                {(ticket.informacion_personal_vecino?.dni || ticket.dni) && (
+                  <p>DNI: {ticket.informacion_personal_vecino?.dni || ticket.dni}</p>
+                )}
+                {(ticket.informacion_personal_vecino?.email || ticket.email) && (
+                  <p>Email: {ticket.informacion_personal_vecino?.email || ticket.email}</p>
+                )}
+                {(ticket.informacion_personal_vecino?.telefono || ticket.telefono) && (
+                  <p>Teléfono: {ticket.informacion_personal_vecino?.telefono || ticket.telefono}</p>
+                )}
+              </div>
             )}
           </div>
 

--- a/src/routesConfig.tsx
+++ b/src/routesConfig.tsx
@@ -73,6 +73,7 @@ const routes: RouteConfig[] = [
   { path: '/demo', element: <Demo /> },
   { path: '/perfil', element: <Perfil /> },
   { path: '/chat', element: <ChatPage /> },
+  { path: '/chat/:ticketId', element: <TicketLookup /> },
   { path: '/checkout', element: <Checkout /> },
   { path: '/chatpos', element: <ChatPosPage /> },
   { path: '/chatcrm', element: <ChatCRMPage /> },

--- a/src/services/ticketService.ts
+++ b/src/services/ticketService.ts
@@ -37,6 +37,28 @@ export const getTicketById = async (id: string): Promise<Ticket> => {
     }
 };
 
+export const getTicketByNumber = async (nroTicket: string): Promise<Ticket> => {
+    const clean = nroTicket.replace(/[^\d]/g, '');
+    const endpoints = [
+        `/tickets/municipio/por_numero/${encodeURIComponent(clean)}`,
+        `/tickets/municipio/${encodeURIComponent(clean)}`,
+    ];
+    let lastError: unknown;
+    for (const url of endpoints) {
+        try {
+            const response = await apiFetch<Ticket>(url, { sendAnonId: true });
+            return {
+                ...response,
+                avatarUrl: response.avatarUrl || generateRandomAvatar(response.email || response.id.toString()),
+            };
+        } catch (err) {
+            lastError = err;
+        }
+    }
+    console.error(`Error fetching ticket by number ${nroTicket}:`, lastError);
+    throw lastError;
+};
+
 export const sendTicketHistory = async (ticket: Ticket): Promise<void> => {
     try {
         await apiFetch(`/tickets/${ticket.tipo}/${ticket.id}/send-history`, {

--- a/src/types/tickets.ts
+++ b/src/types/tickets.ts
@@ -53,6 +53,12 @@ export interface InformacionPersonalVecino {
   dni?: string;
 }
 
+export interface TicketHistoryEvent {
+  status: string;
+  date: string;
+  notes?: string;
+}
+
 export interface Ticket {
   id: number;
   tipo: 'municipio' | 'pyme';
@@ -67,6 +73,7 @@ export interface Ticket {
   latitud?: number;
   longitud?: number;
   avatarUrl?: string;
+  history?: TicketHistoryEvent[];
 
   // Pyme specific fields
   telefono?: string;


### PR DESCRIPTION
## Summary
- handle multiple API paths when looking up tickets by number
- sanitize ticket numbers before querying the backend
- remove custom cache header when loading ticket heatmap to avoid CORS errors
- detect text-based confirmations and cancellations when finalizing claims
- expose saved contact data, including DNI, on the public ticket page
- guard Socket.IO initialization to avoid crashes when the client fails to connect
- parse heatmap responses flexibly so malformed payloads no longer break the profile map

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae99874e9083229e3a2d2d93f64bda