### PR TITLE
fix: send entity token in ticket lookup

### DIFF
--- a/src/services/ticketService.ts
+++ b/src/services/ticketService.ts
@@ -46,10 +46,15 @@ export const getTicketByNumber = async (nroTicket: string): Promise<Ticket> => {
     let lastError: unknown;
     for (const url of endpoints) {
         try {
-            const response = await apiFetch<Ticket>(url, { sendAnonId: true });
+            const response = await apiFetch<Ticket>(url, {
+                sendAnonId: true,
+                sendEntityToken: true,
+            });
             return {
                 ...response,
-                avatarUrl: response.avatarUrl || generateRandomAvatar(response.email || response.id.toString()),
+                avatarUrl:
+                    response.avatarUrl ||
+                    generateRandomAvatar(response.email || response.id.toString()),
             };
         } catch (err) {
             lastError = err;


### PR DESCRIPTION
## Summary
- include municipality entity token when fetching ticket by number

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af2c0400488322b3647d684e6048e3