### PR TITLE
Improve ticket lookup robustness

### DIFF
--- a/src/services/ticketService.ts
+++ b/src/services/ticketService.ts
@@ -38,8 +38,10 @@ export const getTicketById = async (id: string): Promise<Ticket> => {
 };
 
 export const getTicketByNumber = async (nroTicket: string): Promise<Ticket> => {
-    const clean = nroTicket.replace(/[^\d]/g, '');
+    const raw = nroTicket.trim();
+    const clean = raw.replace(/[^\d]/g, '');
     const endpoints = [
+        `/tickets/municipio/por_numero/${encodeURIComponent(raw)}`,
         `/tickets/municipio/por_numero/${encodeURIComponent(clean)}`,
         `/tickets/municipio/${encodeURIComponent(clean)}`,
     ];
@@ -47,6 +49,7 @@ export const getTicketByNumber = async (nroTicket: string): Promise<Ticket> => {
     for (const url of endpoints) {
         try {
             const response = await apiFetch<Ticket>(url, {
+                skipAuth: true,
                 sendAnonId: true,
                 sendEntityToken: true,
             });


### PR DESCRIPTION
## Summary
- handle ticket numbers with optional prefixes when fetching
- show friendly message when ticket is not found
- make ticket lookup URLs shareable and avoid auth header to prevent CORS issues

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af336ddec483229b939cc027350053