### PR TITLE
fix: guard geocoding control events

### DIFF
--- a/src/components/MapLibreMap.tsx
+++ b/src/components/MapLibreMap.tsx
@@ -44,11 +44,22 @@ export default function MapLibreMap({
       keepOpen: false,
     });
 
-    geocoding.on("select", (item) => {
+    // `GeocodingControl` debería exponer un método `on`, pero algunas versiones
+    // solo implementan `addEventListener`. Para evitar que la app se rompa cuando
+    // no existe `on`, verificamos ambas opciones antes de registrar el evento.
+    const handleSelect = (item: any) => {
       const [lon, lat] = item.geometry.coordinates as [number, number];
       const address = item.place_name ?? item.text;
       onSelect?.(lat, lon, address);
-    });
+    };
+
+    if (typeof (geocoding as any).on === "function") {
+      (geocoding as any).on("select", handleSelect);
+    } else if (typeof (geocoding as any).addEventListener === "function") {
+      (geocoding as any).addEventListener("select", (e: any) =>
+        handleSelect(e.detail)
+      );
+    }
 
     map.addControl(geocoding, "top-left");
 


### PR DESCRIPTION
## Summary
- avoid calling `.on` on MapTiler GeocodingControl when the method doesn't exist

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af3c3bb8148322b261f8f6842699e2