### PR TITLE
fix: simplify map init to avoid runtime errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "@radix-ui/react-tooltip": "^1.2.7",
         "@react-google-maps/api": "^2.20.7",
         "@react-oauth/google": "^0.12.2",
-        "@maptiler/geocoding-control": "1.4.1",
         "maplibre-gl": "4.7.1",
         "pmtiles": "4.3.0",
         "@tanstack/react-query": "^5.76.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@radix-ui/react-toast": "^1.2.14",
     "@radix-ui/react-tooltip": "^1.2.7",
     "@react-oauth/google": "^0.12.2",
-    "@maptiler/geocoding-control": "1.4.1",
     "maplibre-gl": "4.7.1",
     "pmtiles": "4.3.0",
     "@tanstack/react-query": "^5.76.1",

--- a/src/components/MapLibreMap.tsx
+++ b/src/components/MapLibreMap.tsx
@@ -1,8 +1,6 @@
 import { useEffect, useRef } from "react";
 import maplibregl from "maplibre-gl";
-import { GeocodingControl } from "@maptiler/geocoding-control/maplibregl";
 import "maplibre-gl/dist/maplibre-gl.css";
-import "@maptiler/geocoding-control/style.css";
 
 type HeatPoint = { lat: number; lng: number; weight?: number };
 
@@ -21,86 +19,90 @@ export default function MapLibreMap({
 }: Props) {
   const ref = useRef<HTMLDivElement>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
+  const markerRef = useRef<maplibregl.Marker | null>(null);
 
   useEffect(() => {
-    const apiKey = import.meta.env.VITE_MAPTILER_KEY!;
-    const map = new maplibregl.Map({
-      container: ref.current!,
-      style: `https://api.maptiler.com/maps/streets-v2/style.json?key=${apiKey}`,
-      center: initialCenter,
-      zoom: initialZoom,
-    });
-
-    mapRef.current = map;
-
-    map.addControl(new maplibregl.NavigationControl(), "top-right");
-
-    const geocoding = new GeocodingControl({
-      apiKey,
-      language: "es",
-      country: "ar",
-      placeholder: "Buscar dirección o lugar…",
-      addMarker: true,
-      keepOpen: false,
-    });
-
-    geocoding.on("select", (item) => {
-      const [lon, lat] = item.geometry.coordinates as [number, number];
-      const address = item.place_name ?? item.text;
-      onSelect?.(lat, lon, address);
-    });
-
-    map.addControl(geocoding, "top-left");
-
-    map.on("load", () => {
-      const sourceData = heatmapData
-        ? {
-            type: "FeatureCollection",
-            features: heatmapData.map((p) => ({
-              type: "Feature",
-              properties: { weight: p.weight ?? 1 },
-              geometry: {
-                type: "Point",
-                coordinates: [p.lng, p.lat],
-              },
-            })),
-          }
-        : "/api/puntos";
-
-      map.addSource("puntos", {
-        type: "geojson",
-        data: sourceData as any,
+    if (!ref.current) return;
+    try {
+      const apiKey = import.meta.env.VITE_MAPTILER_KEY!;
+      const map = new maplibregl.Map({
+        container: ref.current,
+        style: `https://api.maptiler.com/maps/streets-v2/style.json?key=${apiKey}`,
+        center: initialCenter,
+        zoom: initialZoom,
       });
 
-      map.addLayer({
-        id: "heat",
-        type: "heatmap",
-        source: "puntos",
-        maxzoom: 16,
-        paint: {
-          "heatmap-intensity": ["interpolate", ["linear"], ["zoom"], 0, 1, 16, 3],
-          "heatmap-weight": ["interpolate", ["linear"], ["get", "weight"], 0, 0, 10, 1],
-          "heatmap-radius": ["interpolate", ["linear"], ["zoom"], 0, 2, 16, 35],
-          "heatmap-opacity": 0.8,
-        },
-      });
-    });
+      mapRef.current = map;
 
-    return () => map.remove();
+      map.addControl(new maplibregl.NavigationControl(), "top-right");
+
+      if (onSelect) {
+        map.on("click", (e) => {
+          const { lng, lat } = e.lngLat;
+          markerRef.current?.remove();
+          markerRef.current = new maplibregl.Marker().setLngLat([lng, lat]).addTo(map);
+          onSelect(lat, lng);
+        });
+      }
+
+      map.on("styleimagemissing", (e) => {
+        // Evita errores cuando una imagen no existe en el sprite.
+        console.warn(`Imagen faltante en el estilo: "${e.id}"`);
+      });
+
+      map.on("load", () => {
+        const sourceData = heatmapData
+          ? {
+              type: "FeatureCollection",
+              features: heatmapData.map((p) => ({
+                type: "Feature",
+                properties: { weight: p.weight ?? 1 },
+                geometry: {
+                  type: "Point",
+                  coordinates: [p.lng, p.lat],
+                },
+              })),
+            }
+          : "/api/puntos";
+
+        map.addSource("puntos", {
+          type: "geojson",
+          data: sourceData as any,
+        });
+
+        map.addLayer({
+          id: "heat",
+          type: "heatmap",
+          source: "puntos",
+          maxzoom: 16,
+          paint: {
+            "heatmap-intensity": ["interpolate", ["linear"], ["zoom"], 0, 1, 16, 3],
+            "heatmap-weight": ["interpolate", ["linear"], ["get", "weight"], 0, 0, 10, 1],
+            "heatmap-radius": ["interpolate", ["linear"], ["zoom"], 0, 2, 16, 35],
+            "heatmap-opacity": 0.8,
+          },
+        });
+      });
+
+      return () => {
+        markerRef.current?.remove();
+        map.remove();
+      };
+    } catch (err) {
+      console.error("Error initializing map", err);
+    }
   }, [initialCenter, initialZoom, heatmapData, onSelect]);
 
   useEffect(() => {
-    if (!mapRef.current || !heatmapData) return;
-    const source = mapRef.current.getSource("puntos") as maplibregl.GeoJSONSource;
+    if (!mapRef.current) return;
+    const source = mapRef.current.getSource("puntos") as maplibregl.GeoJSONSource | undefined;
     if (!source) return;
-    const geojson = {
-      type: "FeatureCollection",
-      features: heatmapData.map((p) => ({
-        type: "Feature",
-        properties: { weight: p.weight ?? 1 },
-        geometry: { type: "Point", coordinates: [p.lng, p.lat] },
-      })),
-    } as const;
+    const features = (heatmapData ?? []).map((p) => ({
+      type: "Feature",
+      properties: { weight: p.weight ?? 1 },
+      geometry: { type: "Point", coordinates: [p.lng, p.lat] },
+    }));
+    const geojson = { type: "FeatureCollection", features } as const;
     source.setData(geojson as any);
   }, [heatmapData]);
 

--- a/src/pages/Perfil.tsx
+++ b/src/pages/Perfil.tsx
@@ -976,11 +976,17 @@ export default function Perfil() {
                     </div>
                   </div>
                 )}
-                <LocationMap
-                  lat={mapCenter?.lat}
-                  lng={mapCenter?.lng}
-                  heatmapData={heatmapData}
-                />
+                {heatmapData.length > 0 ? (
+                  <LocationMap
+                    lat={mapCenter?.lat}
+                    lng={mapCenter?.lng}
+                    heatmapData={heatmapData}
+                  />
+                ) : (
+                  <p className="text-sm text-muted-foreground">
+                    No hay datos de ubicación disponibles.
+                  </p>
+                )}
               </CardContent>
             </Card>
           )}


### PR DESCRIPTION
## Summary
- remove MapTiler geocoding control and rely on click-to-add marker
- log missing sprite images and update heatmap source on load
- drop geocoding control dependency to unblock installs

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/maplibre-gl)*
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af3c3bb8148322b261f8f6842699e2