### PR TITLE
feat: show ticket timeline with message history

### DIFF
--- a/src/components/tickets/TicketTimeline.tsx
+++ b/src/components/tickets/TicketTimeline.tsx
@@ -1,32 +1,84 @@
 import React from 'react';
 import { formatDate } from '@/utils/fecha';
-import { CheckCircle, Clock } from 'lucide-react';
-import { TicketHistoryEvent } from '@/types/tickets';
+import { CheckCircle, Clock, MessageSquare } from 'lucide-react';
+import { TicketHistoryEvent, Message } from '@/types/tickets';
 
 interface TicketTimelineProps {
   history: TicketHistoryEvent[];
+  messages?: Message[];
 }
 
-const TicketTimeline: React.FC<TicketTimelineProps> = ({ history }) => {
-  if (!history || history.length === 0) {
+type TimelineEvent =
+  | { type: 'status'; status: string; date: string; notes?: string }
+  | { type: 'message'; date: string; author: string; content: string };
+
+const TicketTimeline: React.FC<TicketTimelineProps> = ({ history, messages = [] }) => {
+  const events: TimelineEvent[] = [
+    ...history.map((h) => ({ type: 'status', ...h })),
+    ...messages.map((m) => ({
+      type: 'message',
+      date: m.timestamp,
+      author: m.agentName || (m.author === 'agent' ? 'Agente' : 'Vecino'),
+      content: m.content,
+    })),
+  ].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+
+  if (events.length === 0) {
     return null;
   }
 
   return (
     <div className="space-y-8 relative before:absolute before:inset-0 before:ml-5 before:h-full before:w-0.5 before:bg-gray-200 dark:before:bg-gray-700">
-      {history.map((event, index) => {
-        const isLastEvent = index === history.length - 1;
+      {events.map((event, index) => {
+        const isLastEvent = index === events.length - 1;
+        const isStatus = event.type === 'status';
+        const circleClass =
+          isStatus && isLastEvent
+            ? 'bg-green-500 text-white'
+            : 'bg-gray-200 dark:bg-gray-700';
         return (
           <div key={index} className="relative flex items-start">
-            <div className={`flex-shrink-0 w-10 h-10 rounded-full flex items-center justify-center ${isLastEvent ? 'bg-green-500 text-white' : 'bg-gray-200 dark:bg-gray-700'}`}>
-              {isLastEvent ? <CheckCircle size={20} /> : <Clock size={20} />}
+            <div
+              className={`flex-shrink-0 w-10 h-10 rounded-full flex items-center justify-center ${circleClass}`}
+            >
+              {isStatus ? (
+                isLastEvent ? (
+                  <CheckCircle size={20} />
+                ) : (
+                  <Clock size={20} />
+                )
+              ) : (
+                <MessageSquare size={20} />
+              )}
             </div>
             <div className="ml-4">
-              <h4 className="font-semibold text-lg">{event.status}</h4>
-              <p className="text-sm text-muted-foreground">
-                {formatDate(event.date, Intl.DateTimeFormat().resolvedOptions().timeZone, 'es-AR')}
-              </p>
-              {event.notes && <p className="mt-1 text-sm">{event.notes}</p>}
+              {isStatus ? (
+                <>
+                  <h4 className="font-semibold text-lg">{event.status}</h4>
+                  <p className="text-sm text-muted-foreground">
+                    {formatDate(
+                      event.date,
+                      Intl.DateTimeFormat().resolvedOptions().timeZone,
+                      'es-AR'
+                    )}
+                  </p>
+                  {'notes' in event && event.notes && (
+                    <p className="mt-1 text-sm">{event.notes}</p>
+                  )}
+                </>
+              ) : (
+                <>
+                  <h4 className="font-semibold text-lg">{event.author}</h4>
+                  <p className="mt-1">{event.content}</p>
+                  <p className="text-sm text-muted-foreground">
+                    {formatDate(
+                      event.date,
+                      Intl.DateTimeFormat().resolvedOptions().timeZone,
+                      'es-AR'
+                    )}
+                  </p>
+                </>
+              )}
             </div>
           </div>
         );

--- a/src/pages/TicketLookup.tsx
+++ b/src/pages/TicketLookup.tsx
@@ -2,8 +2,8 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { getTicketByNumber } from '@/services/ticketService';
-import { Ticket } from '@/types/tickets';
+import { getTicketByNumber, getTicketMessages } from '@/services/ticketService';
+import { Ticket, Message } from '@/types/tickets';
 import { formatDate } from '@/utils/fecha';
 import TicketTimeline from '@/components/tickets/TicketTimeline';
 import { Separator } from '@/components/ui/separator';
@@ -16,14 +16,22 @@ export default function TicketLookup() {
   const [ticket, setTicket] = useState<Ticket | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [messages, setMessages] = useState<Message[]>([]);
 
   const performSearch = useCallback(async (searchId: string) => {
     if (!searchId) return;
     setLoading(true);
     setError(null);
+    setMessages([]);
     try {
       const data = await getTicketByNumber(searchId);
       setTicket(data);
+      try {
+        const msgs = await getTicketMessages(data.id, data.tipo);
+        setMessages(msgs);
+      } catch (msgErr) {
+        console.error('Error fetching messages for ticket', msgErr);
+      }
     } catch (err) {
       const apiErr = err as ApiError;
       const message = apiErr?.status === 404
@@ -113,7 +121,7 @@ export default function TicketLookup() {
 
           <div>
             <h3 className="text-xl font-semibold mb-4">Historial del Reclamo</h3>
-            <TicketTimeline history={ticket.history || []} />
+            <TicketTimeline history={ticket.history || []} messages={messages} />
           </div>
 
         </div>


### PR DESCRIPTION
## Summary
- combine ticket status history and chat messages into a unified timeline
- fetch messages when looking up a ticket and display them in the timeline

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden for maplibre-gl)*

------
https://chatgpt.com/codex/tasks/task_e_68af4b058fe48322934fc5ad95c65aa5