### PR TITLE
feat: show ticket timeline with message history

### DIFF
--- a/src/components/tickets/TicketTimeline.tsx
+++ b/src/components/tickets/TicketTimeline.tsx
@@ -1,37 +1,87 @@
 import React from 'react';
 import { formatDate } from '@/utils/fecha';
-import { CheckCircle, Clock } from 'lucide-react';
-import { TicketHistoryEvent } from '@/types/tickets';
+import { CheckCircle, Clock, MessageSquare } from 'lucide-react';
+import { TicketHistoryEvent, Message } from '@/types/tickets';
 
 interface TicketTimelineProps {
   history: TicketHistoryEvent[];
+  messages?: Message[];
 }
 
-const TicketTimeline: React.FC<TicketTimelineProps> = ({ history }) => {
-  if (!history || history.length === 0) {
-    return null;
+type TimelineEvent =
+  | { type: 'status'; status: string; date: string; notes?: string }
+  | { type: 'message'; date: string; author: string; content: string };
+
+const TicketTimeline: React.FC<TicketTimelineProps> = ({ history, messages = [] }) => {
+  const events: TimelineEvent[] = [
+    ...history.map((h) => ({ type: 'status', ...h })),
+    ...messages.map((m) => ({
+      type: 'message',
+      date: m.timestamp,
+      author: m.agentName || (m.author === 'agent' ? 'Agente' : 'Vecino'),
+      content: m.content,
+    })),
+  ].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+
+  if (events.length === 0) {
+    return <p className="text-sm text-muted-foreground">No hay historial disponible.</p>;
   }
 
+  const lastStatusIndex = events.reduce(
+    (last, evt, idx) => (evt.type === 'status' ? idx : last),
+    -1
+  );
+
   return (
-    <div className="space-y-8 relative before:absolute before:inset-0 before:ml-5 before:h-full before:w-0.5 before:bg-gray-200 dark:before:bg-gray-700">
-      {history.map((event, index) => {
-        const isLastEvent = index === history.length - 1;
+    <ol className="relative border-l border-gray-200 dark:border-gray-700">
+      {events.map((event, index) => {
+        const isStatus = event.type === 'status';
+        const isLastStatus = index === lastStatusIndex;
+        const icon = isStatus
+          ? isLastStatus
+            ? <CheckCircle size={16} />
+            : <Clock size={16} />
+          : <MessageSquare size={16} />;
+        const circleClass =
+          isStatus && isLastStatus
+            ? 'bg-green-500 text-white'
+            : 'bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-300';
         return (
-          <div key={index} className="relative flex items-start">
-            <div className={`flex-shrink-0 w-10 h-10 rounded-full flex items-center justify-center ${isLastEvent ? 'bg-green-500 text-white' : 'bg-gray-200 dark:bg-gray-700'}`}>
-              {isLastEvent ? <CheckCircle size={20} /> : <Clock size={20} />}
-            </div>
-            <div className="ml-4">
-              <h4 className="font-semibold text-lg">{event.status}</h4>
-              <p className="text-sm text-muted-foreground">
-                {formatDate(event.date, Intl.DateTimeFormat().resolvedOptions().timeZone, 'es-AR')}
-              </p>
-              {event.notes && <p className="mt-1 text-sm">{event.notes}</p>}
-            </div>
-          </div>
+          <li key={index} className="mb-8 ml-6">
+            <span className={`absolute -left-3 flex items-center justify-center w-6 h-6 rounded-full ring-8 ring-white dark:ring-gray-900 ${circleClass}`}>
+              {icon}
+            </span>
+            {isStatus ? (
+              <div className="flex flex-col gap-1">
+                <h4 className="font-semibold">{event.status}</h4>
+                <time className="text-sm text-muted-foreground">
+                  {formatDate(
+                    event.date,
+                    Intl.DateTimeFormat().resolvedOptions().timeZone,
+                    'es-AR'
+                  )}
+                </time>
+                {'notes' in event && event.notes && (
+                  <p className="text-sm mt-1">{event.notes}</p>
+                )}
+              </div>
+            ) : (
+              <div className="flex flex-col gap-1">
+                <h4 className="font-semibold">{event.author}</h4>
+                <p className="mt-1">{event.content}</p>
+                <time className="text-sm text-muted-foreground">
+                  {formatDate(
+                    event.date,
+                    Intl.DateTimeFormat().resolvedOptions().timeZone,
+                    'es-AR'
+                  )}
+                </time>
+              </div>
+            )}
+          </li>
         );
       })}
-    </div>
+    </ol>
   );
 };
 


### PR DESCRIPTION
## Summary
- parse backend history fields so ticket status changes appear
- render unified timeline of ticket history and chat messages
- make lookup form and timeline responsive for mobile

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden for maplibre-gl)*

------
https://chatgpt.com/codex/tasks/task_e_68af4b058fe48322934fc5ad95c65aa5