### PR TITLE
feat: support entity token in widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-trick
 
 ## Embedding the Chatboc widget
 
-You can embed the floating chat widget on any site by loading `widget.js` and passing your token. Example:
+You can embed the floating chat widget on any site by loading `widget.js` and passing your entity token. Example:
 
 ```html
 <script>
@@ -118,7 +118,7 @@ You can embed the floating chat widget on any site by loading `widget.js` and pa
     var s = document.createElement('script');
     s.src = 'https://www.chatboc.ar/widget.js';
     s.async = true;
-    s.setAttribute('data-token', 'TU_TOKEN_AQUI');
+    s.setAttribute('data-entity-token', 'TU_TOKEN_AQUI');
     // Choose the API endpoint. If omitted, the widget falls back
     // to `window.APP_TARGET` and then "pyme" if none is set
     s.setAttribute('data-endpoint', 'pyme'); // or "municipio"
@@ -142,7 +142,7 @@ If you host `widget.js` yourself, remember to add `data-domain="https://www.chat
 ```html
 <script async src="/widget.js"
   data-domain="https://www.chatboc.ar"
-  data-token="TU_TOKEN_AQUI"></script>
+  data-entity-token="TU_TOKEN_AQUI"></script>
 ```
 Using `widget.js` from another domain **without** this attribute causes the iframe
 to load its scripts from the wrong origin, leading to console errors and 403
@@ -187,7 +187,7 @@ If your site blocks external JavaScript, you can embed the chatbot using an
 ```html
 <iframe
   id="chatboc-iframe"
-  src="https://www.chatboc.ar/iframe.html?token=TU_TOKEN_AQUI&endpoint=pyme&rubro=comercio" <!-- or "municipio"; `tipo_chat` also works -->
+  src="https://www.chatboc.ar/iframe.html?entityToken=TU_TOKEN_AQUI&endpoint=pyme&rubro=comercio" <!-- or "municipio"; `tipo_chat` also works -->
   style="position:fixed;bottom:24px;right:24px;border:none;border-radius:50%;z-index:9999;box-shadow:0 4px 32px rgba(0,0,0,0.2);background:transparent;overflow:hidden;width:96px!important;height:96px!important;display:block"
   allow="clipboard-write; geolocation"
   loading="lazy"

--- a/pruebaiframe.html
+++ b/pruebaiframe.html
@@ -1,6 +1,6 @@
 <iframe
   id="chatboc-iframe"
-  src="https://www.chatboc.ar/iframe?token=ef403b5b-e0df-4b35-be34-35b9dac0d6f1&tipo_chat=municipio"
+  src="https://www.chatboc.ar/iframe?entityToken=ef403b5b-e0df-4b35-be34-35b9dac0d6f1&tipo_chat=municipio"
   style="position:fixed; bottom:20px; right:20px; border:none; border-radius:50%; z-index:9999; box-shadow:0 4px 32px rgba(0,0,0,0.2); background:transparent; overflow:hidden; width:112px; height:112px; display:block; transition: width 0.3s ease, height 0.3s ease, border-radius 0.3s ease;"
   allow="clipboard-write; geolocation"
   loading="lazy"

--- a/pruebascr.html
+++ b/pruebascr.html
@@ -9,7 +9,7 @@ document.addEventListener('DOMContentLoaded', function () {
   var s = document.createElement('script');
   s.src = 'https://www.chatboc.ar/widget.js'; // URL del script del widget
   s.async = true; // Carga asíncrona para no bloquear el renderizado de la página
-  s.setAttribute('data-token', 'ef403b5b-e0df-4b35-be34-35b9dac0d6f1'); // Token de autenticación del usuario
+  s.setAttribute('data-entity-token', 'ef403b5b-e0df-4b35-be34-35b9dac0d6f1'); // Token de la entidad para el widget
   s.setAttribute('data-default-open', 'false'); // El widget comienza cerrado por defecto
   s.setAttribute('data-width', '460px'); // Ancho del widget abierto
   s.setAttribute('data-height', '680px'); // Alto del widget abierto

--- a/public/test-widget.html
+++ b/public/test-widget.html
@@ -49,7 +49,7 @@
 
     <!--
         The widget script.
-        - data-token can be a real token or "demo-anon" for testing.
+        - data-entity-token must be set to your widget token.
         - data-domain should point to the server where the iframe content is hosted.
           During local development, this will be the Vite dev server.
         - Other options like 'data-bottom' and 'data-right' are passed to the iframe.
@@ -57,10 +57,10 @@
     <script>
         document.addEventListener('DOMContentLoaded', function () {
             const urlParams = new URLSearchParams(window.location.search);
-            const token = urlParams.get('token');
+            const token = urlParams.get('entityToken');
 
             if (!token) {
-                console.error('No token provided in the URL. Please add a ?token=YOUR_TOKEN parameter.');
+                console.error('No token provided in the URL. Please add a ?entityToken=YOUR_TOKEN parameter.');
                 return;
             }
 
@@ -73,7 +73,7 @@
           var s = document.createElement('script');
           s.src = '/widget.js'; // URL del script del widget
           s.async = true; // Carga asíncrona para no bloquear el renderizado de la página
-          s.setAttribute('data-token', token); // Token de autenticación del usuario
+          s.setAttribute('data-entity-token', token); // Token de la entidad para el widget
           s.setAttribute('data-default-open', 'true'); // El widget comienza cerrado por defecto
           s.setAttribute('data-width', '460px'); // Ancho del widget abierto
           s.setAttribute('data-height', '680px'); // Alto del widget abierto

--- a/public/test.html
+++ b/public/test.html
@@ -10,7 +10,7 @@
     <p>This page is for testing the Chatboc widget with a real token.</p>
 
     <script src="/widget.js"
-            data-token="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJ0aXBvX2NoYXQiOiJtdW5pY2lwaW8ifQ.D4sN_tA-5_vE9-tA5_tA-5_vE9-tA5_tA-5_vE9-tA"
+            data-entity-token="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJ0aXBvX2NoYXQiOiJtdW5pY2lwaW8ifQ.D4sN_tA-5_vE9-tA5_tA-5_vE9-tA5_tA-5_vE9-tA"
             data-tipo-chat="municipio"
             data-rubro="servicios_publicos"
             data-default-open="true"

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -3,6 +3,7 @@ import ChatbocLogoAnimated from "./ChatbocLogoAnimated";
 import { getCurrentTipoChat } from "@/utils/tipoChat";
 import { cn } from "@/lib/utils";
 import { safeLocalStorage } from "@/utils/safeLocalStorage";
+import getOrCreateAnonId from "@/utils/anonId";
 import { motion, AnimatePresence } from "framer-motion";
 import { useUser } from "@/hooks/useUser";
 import { apiFetch, getErrorMessage } from "@/utils/api";
@@ -86,6 +87,10 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
     checkMobile();
     window.addEventListener("resize", checkMobile);
     return () => window.removeEventListener("resize", checkMobile);
+  }, []);
+
+  useEffect(() => {
+    getOrCreateAnonId();
   }, []);
 
   const [showCta, setShowCta] = useState(false);

--- a/src/components/chat/WidgetEmbed.tsx
+++ b/src/components/chat/WidgetEmbed.tsx
@@ -20,7 +20,7 @@ const WidgetEmbed = ({ token }: { token: string }) => {
     }
   }, []);
 
-  const embedCode = `<script>(function(){var s=document.createElement('script');s.src='https://www.chatboc.ar/widget.js';s.async=true;s.setAttribute('data-token','${token}');s.setAttribute('data-endpoint','${tipoChat}');document.head.appendChild(s);})();</script>`;
+  const embedCode = `<script>(function(){var s=document.createElement('script');s.src='https://www.chatboc.ar/widget.js';s.async=true;s.setAttribute('data-entity-token','${token}');s.setAttribute('data-endpoint','${tipoChat}');document.head.appendChild(s);})();</script>`;
 
   const copiar = () => {
     navigator.clipboard.writeText(embedCode)

--- a/src/pages/Integracion.tsx
+++ b/src/pages/Integracion.tsx
@@ -86,7 +86,7 @@ const Integracion = () => {
     return user.tipo_chat === "municipio" ? "municipio" : "pyme";
   }, [user?.tipo_chat]);
 
-  const userToken = useMemo(() => user?.token || "TU_TOKEN_DE_USUARIO", [user?.token]);
+  const entityToken = useMemo(() => user?.token || "TU_TOKEN_DEL_WIDGET", [user?.token]);
 
   const WIDGET_STD_WIDTH = "460px";
   const WIDGET_STD_HEIGHT = "680px";
@@ -99,14 +99,14 @@ const Integracion = () => {
 document.addEventListener('DOMContentLoaded', function () {
   // Asegura que el widget se destruya y se vuelva a crear si ya existe
   if (window.chatbocDestroyWidget) {
-    window.chatbocDestroyWidget('${userToken}');
+    window.chatbocDestroyWidget('${entityToken}');
   }
   window.APP_TARGET = '${endpoint}'; // Define el endpoint antes de cargar el script
 
   var s = document.createElement('script');
   s.src = 'https://www.chatboc.ar/widget.js'; // URL del script del widget
   s.async = true; // Carga asíncrona para no bloquear el renderizado de la página
-  s.setAttribute('data-token', '${userToken}'); // Token de autenticación del usuario
+  s.setAttribute('data-entity-token', '${entityToken}'); // Token de la entidad para el widget
   s.setAttribute('data-default-open', 'false'); // El widget comienza cerrado por defecto
   s.setAttribute('data-width', '${WIDGET_STD_WIDTH}'); // Ancho del widget abierto
   s.setAttribute('data-height', '${WIDGET_STD_HEIGHT}'); // Alto del widget abierto
@@ -133,9 +133,9 @@ document.addEventListener('DOMContentLoaded', function () {
     console.error('Error al cargar Chatboc Widget.');
   };
 });
-</script>`, [userToken, endpoint]);
+</script>`, [entityToken, endpoint]);
 
-  const iframeSrcUrl = useMemo(() => `https://www.chatboc.ar/iframe?token=${userToken}&tipo_chat=${endpoint}`, [userToken, endpoint]);
+  const iframeSrcUrl = useMemo(() => `https://www.chatboc.ar/iframe?entityToken=${entityToken}&tipo_chat=${endpoint}`, [entityToken, endpoint]);
   
   const codeIframe = useMemo(() => `<iframe
   id="chatboc-iframe"
@@ -308,7 +308,7 @@ document.addEventListener('DOMContentLoaded', function () {
             Ambos métodos de integración (Script y Iframe) están diseñados para ser seguros y eficientes. El método de Script es generalmente más flexible y recomendado.
           </p>
           <p>
-            <strong>Token de Usuario:</strong> Tu token de integración es <code>{userToken.substring(0,8)}...</code>. Ya está incluido en los códigos de abajo.
+            <strong>Token del Widget:</strong> Tu token de integración es <code>{entityToken.substring(0,8)}...</code>. Ya está incluido en los códigos de abajo.
           </p>
         </CardContent>
       </Card>

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -38,7 +38,9 @@ export async function apiFetch<T>(
 ): Promise<T> {
   const { method = "GET", body, skipAuth, sendAnonId, entityToken, cache } = options;
 
-  const token = safeLocalStorage.getItem("authToken");
+  const effectiveEntityToken = entityToken ?? getIframeToken();
+  const tokenKey = effectiveEntityToken ? "chatAuthToken" : "authToken";
+  const token = safeLocalStorage.getItem(tokenKey);
   const anonId = safeLocalStorage.getItem("anon_id");
   const chatSessionId = getOrCreateChatSessionId(); // Get or create the chat session ID
 
@@ -59,7 +61,6 @@ export async function apiFetch<T>(
   if (((!token && anonId) || sendAnonId) && anonId) {
     headers["Anon-Id"] = anonId;
   }
-  const effectiveEntityToken = entityToken ?? getIframeToken();
   if (effectiveEntityToken) {
     headers["X-Entity-Token"] = effectiveEntityToken;
   }


### PR DESCRIPTION
## Summary
- generate anonymous session token when no user token is provided
- allow widgets to send a separate data-entity-token instead of user token
- update integration docs and examples to reference data-entity-token
- isolate auth token so entity-based widgets stay anonymous
- generate a persistent anon_id when the widget loads so backend greets visitors generically

## Testing
- `npm test` *(fails: vitest not found)*
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68af4066eebc83228f8ae121130054b6