### PR TITLE
feat: show ticket timeline with message history

### DIFF
--- a/src/components/tickets/TicketTimeline.tsx
+++ b/src/components/tickets/TicketTimeline.tsx
@@ -1,37 +1,87 @@
 import React from 'react';
 import { formatDate } from '@/utils/fecha';
-import { CheckCircle, Clock } from 'lucide-react';
-import { TicketHistoryEvent } from '@/types/tickets';
+import { CheckCircle, Clock, MessageSquare } from 'lucide-react';
+import { TicketHistoryEvent, Message } from '@/types/tickets';
 
 interface TicketTimelineProps {
   history: TicketHistoryEvent[];
+  messages?: Message[];
 }
 
-const TicketTimeline: React.FC<TicketTimelineProps> = ({ history }) => {
-  if (!history || history.length === 0) {
-    return null;
+type TimelineEvent =
+  | { type: 'status'; status: string; date: string; notes?: string }
+  | { type: 'message'; date: string; author: string; content: string };
+
+const TicketTimeline: React.FC<TicketTimelineProps> = ({ history, messages = [] }) => {
+  const events: TimelineEvent[] = [
+    ...history.map((h) => ({ type: 'status', ...h })),
+    ...messages.map((m) => ({
+      type: 'message',
+      date: m.timestamp,
+      author: m.agentName || (m.author === 'agent' ? 'Agente' : 'Vecino'),
+      content: m.content,
+    })),
+  ].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+
+  if (events.length === 0) {
+    return <p className="text-sm text-muted-foreground">No hay historial disponible.</p>;
   }
 
+  const lastStatusIndex = events.reduce(
+    (last, evt, idx) => (evt.type === 'status' ? idx : last),
+    -1
+  );
+
   return (
-    <div className="space-y-8 relative before:absolute before:inset-0 before:ml-5 before:h-full before:w-0.5 before:bg-gray-200 dark:before:bg-gray-700">
-      {history.map((event, index) => {
-        const isLastEvent = index === history.length - 1;
+    <ol className="relative border-l border-gray-200 dark:border-gray-700">
+      {events.map((event, index) => {
+        const isStatus = event.type === 'status';
+        const isLastStatus = index === lastStatusIndex;
+        const icon = isStatus
+          ? isLastStatus
+            ? <CheckCircle size={16} />
+            : <Clock size={16} />
+          : <MessageSquare size={16} />;
+        const circleClass =
+          isStatus && isLastStatus
+            ? 'bg-green-500 text-white'
+            : 'bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-300';
         return (
-          <div key={index} className="relative flex items-start">
-            <div className={`flex-shrink-0 w-10 h-10 rounded-full flex items-center justify-center ${isLastEvent ? 'bg-green-500 text-white' : 'bg-gray-200 dark:bg-gray-700'}`}>
-              {isLastEvent ? <CheckCircle size={20} /> : <Clock size={20} />}
-            </div>
-            <div className="ml-4">
-              <h4 className="font-semibold text-lg">{event.status}</h4>
-              <p className="text-sm text-muted-foreground">
-                {formatDate(event.date, Intl.DateTimeFormat().resolvedOptions().timeZone, 'es-AR')}
-              </p>
-              {event.notes && <p className="mt-1 text-sm">{event.notes}</p>}
-            </div>
-          </div>
+          <li key={index} className="mb-8 ml-6">
+            <span className={`absolute -left-3 flex items-center justify-center w-6 h-6 rounded-full ring-8 ring-white dark:ring-gray-900 ${circleClass}`}>
+              {icon}
+            </span>
+            {isStatus ? (
+              <div className="flex flex-col gap-1">
+                <h4 className="font-semibold">{event.status}</h4>
+                <time className="text-sm text-muted-foreground">
+                  {formatDate(
+                    event.date,
+                    Intl.DateTimeFormat().resolvedOptions().timeZone,
+                    'es-AR'
+                  )}
+                </time>
+                {'notes' in event && event.notes && (
+                  <p className="text-sm mt-1">{event.notes}</p>
+                )}
+              </div>
+            ) : (
+              <div className="flex flex-col gap-1">
+                <h4 className="font-semibold">{event.author}</h4>
+                <p className="mt-1">{event.content}</p>
+                <time className="text-sm text-muted-foreground">
+                  {formatDate(
+                    event.date,
+                    Intl.DateTimeFormat().resolvedOptions().timeZone,
+                    'es-AR'
+                  )}
+                </time>
+              </div>
+            )}
+          </li>
         );
       })}
-    </div>
+    </ol>
   );
 };
 

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -105,7 +105,7 @@ const Carousel = React.forwardRef<
     }, [api, setApi])
 
     React.useEffect(() => {
-      if (!api) {
+      if (!api || typeof (api as any).on !== "function") {
         return
       }
 
@@ -114,7 +114,7 @@ const Carousel = React.forwardRef<
       api.on("select", onSelect)
 
       return () => {
-        api?.off("select", onSelect)
+        api.off("select", onSelect)
       }
     }, [api, onSelect])
 

--- a/src/services/ticketService.ts
+++ b/src/services/ticketService.ts
@@ -1,5 +1,5 @@
 import { apiFetch, ApiError } from '@/utils/api';
-import { Ticket, Message } from '@/types/tickets';
+import { Ticket, Message, TicketHistoryEvent } from '@/types/tickets';
 import { AttachmentInfo } from '@/types/chat';
 
 const generateRandomAvatar = (seed: string) => {
@@ -26,9 +26,11 @@ export const getTickets = async (): Promise<{tickets: Ticket[]}> => {
 
 export const getTicketById = async (id: string): Promise<Ticket> => {
     try {
-        const response = await apiFetch<Ticket>(`/tickets/municipio/${id}`);
+        const response = await apiFetch<Ticket & { historial?: TicketHistoryEvent[] }>(`/tickets/municipio/${id}`);
+        const history = (response as any).history || response.historial || [];
         return {
             ...response,
+            history,
             avatarUrl: response.avatarUrl || generateRandomAvatar(response.email || response.id.toString())
         };
     } catch (error) {
@@ -37,24 +39,30 @@ export const getTicketById = async (id: string): Promise<Ticket> => {
     }
 };
 
-export const getTicketByNumber = async (nroTicket: string): Promise<Ticket> => {
+export const getTicketByNumber = async (
+    nroTicket: string,
+    pin?: string
+): Promise<Ticket> => {
     const raw = nroTicket.trim();
     const clean = raw.replace(/[^\d]/g, '');
+    const pinParam = pin ? `?pin=${encodeURIComponent(pin)}` : '';
     const endpoints = [
-        `/tickets/municipio/por_numero/${encodeURIComponent(raw)}`,
-        `/tickets/municipio/por_numero/${encodeURIComponent(clean)}`,
-        `/tickets/municipio/${encodeURIComponent(clean)}`,
+        `/tickets/municipio/por_numero/${encodeURIComponent(raw)}${pinParam}`,
+        `/tickets/municipio/por_numero/${encodeURIComponent(clean)}${pinParam}`,
+        `/tickets/municipio/${encodeURIComponent(clean)}${pinParam}`,
     ];
     let lastError: unknown;
     for (const url of endpoints) {
         try {
-            const response = await apiFetch<Ticket>(url, {
+            const response = await apiFetch<Ticket & { historial?: TicketHistoryEvent[] }>(url, {
                 skipAuth: true,
                 sendAnonId: true,
                 sendEntityToken: true,
             });
+            const history = (response as any).history || response.historial || [];
             return {
                 ...response,
+                history,
                 avatarUrl:
                     response.avatarUrl ||
                     generateRandomAvatar(response.email || response.id.toString()),


### PR DESCRIPTION
## Summary
- parse backend history fields so ticket status changes appear
- render unified timeline of ticket history and chat messages
- make lookup form and timeline responsive for mobile
- require a pin or direct link for ticket lookup, forwarding pin to backend
- defer ticket lookup requests until a PIN is provided to avoid 400 errors
- guard carousel event listeners to avoid runtime errors when API is missing

## Testing
- `npm install` *(403 Forbidden - GET https://registry.npmjs.org/maplibre-gl)*
- `npm test` *(vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af4b058fe48322934fc5ad95c65aa5