### PR TITLE
Avoid map load when MapTiler key is missing

### DIFF
--- a/src/components/MapLibreMap.tsx
+++ b/src/components/MapLibreMap.tsx
@@ -20,11 +20,16 @@ export default function MapLibreMap({
   const ref = useRef<HTMLDivElement>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
   const markerRef = useRef<maplibregl.Marker | null>(null);
+  const apiKey = import.meta.env.VITE_MAPTILER_KEY;
 
   useEffect(() => {
-    if (!ref.current) return;
+    if (!ref.current || !apiKey) {
+      if (!apiKey) {
+        console.warn("MapLibreMap: missing VITE_MAPTILER_KEY; skipping map initialization.");
+      }
+      return;
+    }
     try {
-      const apiKey = import.meta.env.VITE_MAPTILER_KEY!;
       const map = new maplibregl.Map({
         container: ref.current,
         style: `https://api.maptiler.com/maps/streets-v2/style.json?key=${apiKey}`,
@@ -91,7 +96,7 @@ export default function MapLibreMap({
     } catch (err) {
       console.error("Error initializing map", err);
     }
-  }, [initialCenter, initialZoom, heatmapData, onSelect]);
+  }, [apiKey, initialCenter, initialZoom, heatmapData, onSelect]);
 
   useEffect(() => {
     if (!mapRef.current) return;


### PR DESCRIPTION
## Summary
- Skip MapLibre initialization if `VITE_MAPTILER_KEY` is absent to prevent runtime errors

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install maplibre-gl --loglevel=error` *(fails: 403 Forbidden - GET https://registry.npmjs.org/maplibre-gl)*

------
https://chatgpt.com/codex/tasks/task_e_68af88ec614883229738165da467d36e