### PR TITLE
Improve map initialization and ticket lookup PIN handling

### DIFF
--- a/src/components/MapLibreMap.tsx
+++ b/src/components/MapLibreMap.tsx
@@ -39,6 +39,12 @@ export default function MapLibreMap({
 
       mapRef.current = map;
 
+      // Algunos entornos pueden devolver un objeto sin el método `on`
+      if (typeof (map as any).on !== "function") {
+        console.error("MapLibreMap: map instance lacks .on method", map);
+        return;
+      }
+
       map.addControl(new maplibregl.NavigationControl(), "top-right");
 
       if (onSelect) {

--- a/src/pages/TicketLookup.tsx
+++ b/src/pages/TicketLookup.tsx
@@ -36,9 +36,14 @@ export default function TicketLookup() {
       }
     } catch (err) {
       const apiErr = err as ApiError;
-      const message = apiErr?.status === 404
-        ? 'No se encontró el ticket'
-        : getErrorMessage(err, 'No se encontró el ticket');
+      let message: string;
+      if (apiErr?.status === 404) {
+        message = 'No se encontró el ticket';
+      } else if (apiErr?.status === 400) {
+        message = 'El PIN es obligatorio para consultar el ticket';
+      } else {
+        message = getErrorMessage(err, 'No se encontró el ticket');
+      }
       setError(message);
     } finally {
       setLoading(false);


### PR DESCRIPTION
## Summary
- Guard MapLibre initialization when `.on` is missing to prevent runtime crashes
- Clarify ticket lookup errors when PIN is required but absent

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden for maplibre-gl)*

------
https://chatgpt.com/codex/tasks/task_e_68af9145f4288322b70eec50ab9344ae