### PR TITLE
Improve map initialization and ticket lookup PIN handling

### DIFF
--- a/src/components/MapLibreMap.tsx
+++ b/src/components/MapLibreMap.tsx
@@ -37,6 +37,12 @@ export default function MapLibreMap({
         zoom: initialZoom,
       });
 
+      // Algunos entornos pueden devolver un objeto sin el método `on`
+      if (typeof (map as any).on !== "function") {
+        console.error("MapLibreMap: map instance lacks .on method", map);
+        return;
+      }
+
       mapRef.current = map;
 
       map.addControl(new maplibregl.NavigationControl(), "top-right");
@@ -99,7 +105,7 @@ export default function MapLibreMap({
   }, [apiKey, initialCenter, initialZoom, heatmapData, onSelect]);
 
   useEffect(() => {
-    if (!mapRef.current) return;
+    if (!(mapRef.current instanceof maplibregl.Map)) return;
     const source = mapRef.current.getSource("puntos") as maplibregl.GeoJSONSource | undefined;
     if (!source) return;
     const features = (heatmapData ?? []).map((p) => ({

--- a/src/hooks/useEndpointAvailable.tsx
+++ b/src/hooks/useEndpointAvailable.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { apiFetch, ApiError } from '@/utils/api';
+import { safeLocalStorage } from '@/utils/safeLocalStorage';
 
 /**
  * Checks if an API endpoint exists. Returns:
@@ -11,6 +12,12 @@ export default function useEndpointAvailable(path: string) {
   const [available, setAvailable] = useState<boolean | null>(null);
 
   useEffect(() => {
+    const token = safeLocalStorage.getItem('authToken');
+    if (!token) {
+      setAvailable(false);
+      return;
+    }
+
     let canceled = false;
     (async () => {
       try {
@@ -18,7 +25,7 @@ export default function useEndpointAvailable(path: string) {
         if (!canceled) setAvailable(true);
       } catch (err: any) {
         if (!canceled) {
-          if (err instanceof ApiError && (err.status === 404 || err.status === 403)) {
+          if (err instanceof ApiError && (err.status === 404 || err.status === 403 || err.status === 401)) {
             setAvailable(false);
           } else {
             setAvailable(true);

--- a/src/pages/TicketLookup.tsx
+++ b/src/pages/TicketLookup.tsx
@@ -36,9 +36,14 @@ export default function TicketLookup() {
       }
     } catch (err) {
       const apiErr = err as ApiError;
-      const message = apiErr?.status === 404
-        ? 'No se encontró el ticket'
-        : getErrorMessage(err, 'No se encontró el ticket');
+      let message: string;
+      if (apiErr?.status === 404) {
+        message = 'No se encontró el ticket';
+      } else if (apiErr?.status === 400) {
+        message = 'El PIN es obligatorio para consultar el ticket';
+      } else {
+        message = getErrorMessage(err, 'No se encontró el ticket');
+      }
       setError(message);
     } finally {
       setLoading(false);


### PR DESCRIPTION
## Summary
- Guard map instantiation by verifying event methods before assigning the map reference
- Skip endpoint availability checks when no auth token to prevent unauthorized requests
- Clarify ticket lookup errors when PIN is required but absent

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden for maplibre-gl)*

------
https://chatgpt.com/codex/tasks/task_e_68af9145f4288322b70eec50ab9344ae