### PR TITLE
Improve map initialization and ticket lookup PIN handling

### DIFF
--- a/src/components/MapLibreMap.tsx
+++ b/src/components/MapLibreMap.tsx
@@ -37,61 +37,75 @@ export default function MapLibreMap({
         zoom: initialZoom,
       });
 
-      mapRef.current = map;
-
-      map.addControl(new maplibregl.NavigationControl(), "top-right");
-
-      if (onSelect) {
-        map.on("click", (e) => {
-          const { lng, lat } = e.lngLat;
-          markerRef.current?.remove();
-          markerRef.current = new maplibregl.Marker().setLngLat([lng, lat]).addTo(map);
-          onSelect(lat, lng);
-        });
+      // Algunos entornos pueden devolver un objeto sin el método `on`
+      if (typeof (map as any).on !== "function") {
+        console.error("MapLibreMap: map instance lacks .on method", map);
+        return;
       }
 
-      map.on("styleimagemissing", (e) => {
-        // Evita errores cuando una imagen no existe en el sprite.
-        console.warn(`Imagen faltante en el estilo: "${e.id}"`);
-      });
+      mapRef.current = map;
 
-      map.on("load", () => {
-        const sourceData = heatmapData
-          ? {
-              type: "FeatureCollection",
-              features: heatmapData.map((p) => ({
-                type: "Feature",
-                properties: { weight: p.weight ?? 1 },
-                geometry: {
-                  type: "Point",
-                  coordinates: [p.lng, p.lat],
-                },
-              })),
-            }
-          : "/api/puntos";
+      try {
+        map.addControl(new maplibregl.NavigationControl(), "top-right");
 
-        map.addSource("puntos", {
-          type: "geojson",
-          data: sourceData as any,
+        if (onSelect) {
+          map.on("click", (e) => {
+            const { lng, lat } = e.lngLat;
+            markerRef.current?.remove();
+            markerRef.current = new maplibregl.Marker().setLngLat([lng, lat]).addTo(map);
+            onSelect(lat, lng);
+          });
+        }
+
+        map.on("styleimagemissing", (e) => {
+          // Evita errores cuando una imagen no existe en el sprite.
+          console.warn(`Imagen faltante en el estilo: "${e.id}"`);
         });
 
-        map.addLayer({
-          id: "heat",
-          type: "heatmap",
-          source: "puntos",
-          maxzoom: 16,
-          paint: {
-            "heatmap-intensity": ["interpolate", ["linear"], ["zoom"], 0, 1, 16, 3],
-            "heatmap-weight": ["interpolate", ["linear"], ["get", "weight"], 0, 0, 10, 1],
-            "heatmap-radius": ["interpolate", ["linear"], ["zoom"], 0, 2, 16, 35],
-            "heatmap-opacity": 0.8,
-          },
+        map.on("load", () => {
+          const sourceData = heatmapData
+            ? {
+                type: "FeatureCollection",
+                features: heatmapData.map((p) => ({
+                  type: "Feature",
+                  properties: { weight: p.weight ?? 1 },
+                  geometry: {
+                    type: "Point",
+                    coordinates: [p.lng, p.lat],
+                  },
+                })),
+              }
+            : "/api/puntos";
+
+          map.addSource("puntos", {
+            type: "geojson",
+            data: sourceData as any,
+          });
+
+          map.addLayer({
+            id: "heat",
+            type: "heatmap",
+            source: "puntos",
+            maxzoom: 16,
+            paint: {
+              "heatmap-intensity": ["interpolate", ["linear"], ["zoom"], 0, 1, 16, 3],
+              "heatmap-weight": ["interpolate", ["linear"], ["get", "weight"], 0, 0, 10, 1],
+              "heatmap-radius": ["interpolate", ["linear"], ["zoom"], 0, 2, 16, 35],
+              "heatmap-opacity": 0.8,
+            },
+          });
         });
-      });
+      } catch (err) {
+        console.error("MapLibreMap: failed to configure map", err);
+      }
 
       return () => {
         markerRef.current?.remove();
-        map.remove();
+        try {
+          map.remove();
+        } catch (err) {
+          console.error("MapLibreMap: failed to remove map", err);
+        }
       };
     } catch (err) {
       console.error("Error initializing map", err);
@@ -99,7 +113,7 @@ export default function MapLibreMap({
   }, [apiKey, initialCenter, initialZoom, heatmapData, onSelect]);
 
   useEffect(() => {
-    if (!mapRef.current) return;
+    if (!(mapRef.current instanceof maplibregl.Map)) return;
     const source = mapRef.current.getSource("puntos") as maplibregl.GeoJSONSource | undefined;
     if (!source) return;
     const features = (heatmapData ?? []).map((p) => ({

--- a/src/hooks/useEndpointAvailable.tsx
+++ b/src/hooks/useEndpointAvailable.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { apiFetch, ApiError } from '@/utils/api';
+import { safeLocalStorage } from '@/utils/safeLocalStorage';
 
 /**
  * Checks if an API endpoint exists. Returns:
@@ -11,6 +12,12 @@ export default function useEndpointAvailable(path: string) {
   const [available, setAvailable] = useState<boolean | null>(null);
 
   useEffect(() => {
+    const token = safeLocalStorage.getItem('authToken');
+    if (!token) {
+      setAvailable(false);
+      return;
+    }
+
     let canceled = false;
     (async () => {
       try {
@@ -18,7 +25,7 @@ export default function useEndpointAvailable(path: string) {
         if (!canceled) setAvailable(true);
       } catch (err: any) {
         if (!canceled) {
-          if (err instanceof ApiError && (err.status === 404 || err.status === 403)) {
+          if (err instanceof ApiError && (err.status === 404 || err.status === 403 || err.status === 401)) {
             setAvailable(false);
           } else {
             setAvailable(true);

--- a/src/pages/TicketLookup.tsx
+++ b/src/pages/TicketLookup.tsx
@@ -36,9 +36,14 @@ export default function TicketLookup() {
       }
     } catch (err) {
       const apiErr = err as ApiError;
-      const message = apiErr?.status === 404
-        ? 'No se encontró el ticket'
-        : getErrorMessage(err, 'No se encontró el ticket');
+      let message: string;
+      if (apiErr?.status === 404) {
+        message = 'No se encontró el ticket';
+      } else if (apiErr?.status === 400) {
+        message = 'El PIN es obligatorio para consultar el ticket';
+      } else {
+        message = getErrorMessage(err, 'No se encontró el ticket');
+      }
       setError(message);
     } finally {
       setLoading(false);

--- a/src/services/ticketService.ts
+++ b/src/services/ticketService.ts
@@ -43,9 +43,12 @@ export const getTicketByNumber = async (
     nroTicket: string,
     pin?: string
 ): Promise<Ticket> => {
+    if (!pin) {
+        throw new ApiError('El PIN es obligatorio', 400, null);
+    }
     const raw = nroTicket.trim();
     const clean = raw.replace(/[^\d]/g, '');
-    const pinParam = pin ? `?pin=${encodeURIComponent(pin)}` : '';
+    const pinParam = `?pin=${encodeURIComponent(pin)}`;
     const endpoints = [
         `/tickets/municipio/por_numero/${encodeURIComponent(raw)}${pinParam}`,
         `/tickets/municipio/por_numero/${encodeURIComponent(clean)}${pinParam}`,


### PR DESCRIPTION
## Summary
- Wrap map setup and teardown in try/catch to avoid crashes when MapLibre is missing event hooks
- Require PIN before hitting ticket lookup endpoints so links without a PIN fail fast on the client

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/maplibre-gl)*


------
https://chatgpt.com/codex/tasks/task_e_68af9145f4288322b70eec50ab9344ae