### PR TITLE
Guard event hookups and load missing map icons

### DIFF
--- a/src/components/MapLibreMap.tsx
+++ b/src/components/MapLibreMap.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 // MapLibre se importa de forma dinámica para evitar errores en entornos donde
 // la librería no esté disponible completamente o falten métodos como `on`.
 import "maplibre-gl/dist/maplibre-gl.css";
+import { safeOn, assertEventSource } from "@/utils/safeOn";
 
 type HeatPoint = { lat: number; lng: number; weight?: number };
 
@@ -64,26 +65,44 @@ export default function MapLibreMap({
         }
 
         mapRef.current = map;
+        assertEventSource(map, "map");
 
         try {
           map.addControl?.(new lib.NavigationControl(), "top-right");
 
-          if (onSelect) {
-            map.on?.("click", (e: any) => {
-              const { lng, lat } = e.lngLat || {};
-              if (typeof lng === "number" && typeof lat === "number") {
-                markerRef.current?.remove?.();
-                markerRef.current = new lib.Marker().setLngLat([lng, lat]).addTo(map);
-                onSelect(lat, lng);
+          const clickHandler = (e: any) => {
+            const { lng, lat } = e.lngLat || {};
+            if (typeof lng === "number" && typeof lat === "number") {
+              markerRef.current?.remove?.();
+              markerRef.current = new lib.Marker().setLngLat([lng, lat]).addTo(map);
+              onSelect?.(lat, lng);
+            }
+          };
+
+          const styleImageMissingHandler = (e: any) => {
+            const name = e.id;
+            if (!name) {
+              console.warn("Imagen faltante sin id válido");
+              return;
+            }
+            const url = `/icons/${name}.png`;
+            if (map.hasImage?.(name)) return;
+            map.loadImage?.(url, (err: any, image: any) => {
+              if (err || !image) {
+                console.warn("No pude cargar icono", name, url, err);
+                return;
+              }
+              map.addImage?.(name, image);
+            });
+          };
+
+          const loadHandler = () => {
+            map.loadImage?.("/icons/pin-blue.png", (err: any, image: any) => {
+              if (!err && image && !map.hasImage?.("pin-blue")) {
+                map.addImage?.("pin-blue", image);
               }
             });
-          }
 
-          map.on?.("styleimagemissing", (e: any) => {
-            console.warn(`Imagen faltante en el estilo: "${e.id}"`);
-          });
-
-          map.on?.("load", () => {
             const sourceData = heatmapData
               ? {
                   type: "FeatureCollection",
@@ -109,19 +128,28 @@ export default function MapLibreMap({
                 "circle-color": "#3b82f6",
               },
             });
-          });
+          };
+
+          if (onSelect) {
+            safeOn(map, "click", clickHandler);
+          }
+          safeOn(map, "styleimagemissing", styleImageMissingHandler);
+          safeOn(map, "load", loadHandler);
+
+          return () => {
+            markerRef.current?.remove?.();
+            map.off?.("click", clickHandler);
+            map.off?.("styleimagemissing", styleImageMissingHandler);
+            map.off?.("load", loadHandler);
+            try {
+              map.remove?.();
+            } catch (err) {
+              console.error("MapLibreMap: failed to remove map", err);
+            }
+          };
         } catch (err) {
           console.error("MapLibreMap: failed to configure map", err);
         }
-
-        return () => {
-          markerRef.current?.remove?.();
-          try {
-            map.remove?.();
-          } catch (err) {
-            console.error("MapLibreMap: failed to remove map", err);
-          }
-        };
       } catch (err) {
         console.error("Error initializing map", err);
       }

--- a/src/components/chat/ChatMessageBase.tsx
+++ b/src/components/chat/ChatMessageBase.tsx
@@ -19,6 +19,19 @@ import { getInitials, cn } from "@/lib/utils";
 import UserAvatarAnimated from "./UserAvatarAnimated";
 import { Badge } from "@/components/ui/badge";
 
+type RawAttachment = { url: string; name: string; mimeType?: string; size?: number };
+
+function normalizeAttachment(msg: any): RawAttachment | null {
+  if (msg?.attachmentInfo && msg.attachmentInfo.url && msg.attachmentInfo.name) {
+    return msg.attachmentInfo;
+  }
+  if (Array.isArray(msg?.attachments) && msg.attachments.length > 0) {
+    const first = msg.attachments[0];
+    if (first?.url && first?.name) return first;
+  }
+  return null;
+}
+
 // --- Avatares (reutilizados de ChatMessagePyme/Municipio) ---
 const AvatarBot: React.FC<{ isTyping: boolean }> = ({ isTyping }) => (
   <motion.div
@@ -152,21 +165,19 @@ const ChatMessageBase = React.forwardRef<HTMLDivElement, ChatMessageBaseProps>( 
 
   let processedAttachmentInfo: AttachmentInfo | null = null;
 
-  // Log para depurar message.attachmentInfo ANTES de procesarlo
-  if (message.id && !message.isBot) { // Log solo para mensajes de usuario para reducir ruido
-    console.log(`ChatMessageBase: message [${message.id}] received attachmentInfo:`, message.attachmentInfo);
-  }
-
-  if (message.attachmentInfo?.url && message.attachmentInfo?.name) {
-    processedAttachmentInfo = deriveAttachmentInfo(
-      message.attachmentInfo.url,
-      message.attachmentInfo.name,
-      message.attachmentInfo.mimeType,
-      message.attachmentInfo.size
-    );
-    // Log para depurar processedAttachmentInfo DESPUÉS de procesarlo
+  const normalized = normalizeAttachment(message);
+  if (normalized) {
     if (message.id && !message.isBot) {
-        console.log(`ChatMessageBase: message [${message.id}] processedAttachmentInfo:`, processedAttachmentInfo);
+      console.log(`ChatMessageBase: message [${message.id}] normalized attachment:`, normalized);
+    }
+    processedAttachmentInfo = deriveAttachmentInfo(
+      normalized.url,
+      normalized.name,
+      normalized.mimeType,
+      normalized.size
+    );
+    if (message.id && !message.isBot) {
+      console.log(`ChatMessageBase: message [${message.id}] processedAttachmentInfo:`, processedAttachmentInfo);
     }
   } else if (message.mediaUrl && isBot) {
     // Esto es para mediaUrl en mensajes de bot, no relevante para adjuntos de usuario ahora mismo

--- a/src/utils/safeOn.ts
+++ b/src/utils/safeOn.ts
@@ -1,0 +1,33 @@
+export function safeOn(
+  target: any,
+  event: string,
+  handler: (...args: any[]) => void
+): boolean {
+  if (!target) return false;
+  if (typeof (target as any).on === 'function') {
+    (target as any).on(event, handler);
+    return true;
+  }
+  if (typeof (target as any).addEventListener === 'function') {
+    (target as any).addEventListener(event, handler as EventListener);
+    return true;
+  }
+  return false;
+}
+
+export function assertEventSource(target: any, label = 'target') {
+  const hasOn = !!target && typeof (target as any).on === 'function';
+  const hasAdd = !!target && typeof (target as any).addEventListener === 'function';
+  // eslint-disable-next-line no-console
+  console.log(`[DEBUG] ${label}`, {
+    type: target?.constructor?.name,
+    hasOn,
+    hasAdd,
+    keys: target ? Object.keys(target) : null,
+    value: target,
+  });
+  if (!hasOn && !hasAdd) {
+    // eslint-disable-next-line no-console
+    console.error(`[FATAL] ${label} no soporta .on()/.addEventListener()`);
+  }
+}


### PR DESCRIPTION
## Summary
- add safeOn utility to guard against objects lacking event methods
- use safeOn in chat panel socket subscription
- auto-load map icons when missing and preload pin-blue
- normalize attachments in ChatMessageBase
- guard socket listeners in hooks to avoid `.on` crashes
- validate MapLibre instances and subscribe to map events through `safeOn`

## Testing
- `npm install` *(fails: 403 Forbidden for maplibre-gl package)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afaa3a50988322ac23ff9ac62f011b