### PR TITLE
Guard event hookups and load missing map icons

### DIFF
--- a/src/utils/safeOn.ts
+++ b/src/utils/safeOn.ts
@@ -1,0 +1,33 @@
+export function safeOn(
+  target: any,
+  event: string,
+  handler: (...args: any[]) => void
+): boolean {
+  if (!target) return false;
+  if (typeof (target as any).on === 'function') {
+    (target as any).on(event, handler);
+    return true;
+  }
+  if (typeof (target as any).addEventListener === 'function') {
+    (target as any).addEventListener(event, handler as EventListener);
+    return true;
+  }
+  return false;
+}
+
+export function assertEventSource(target: any, label = 'target') {
+  const hasOn = !!target && typeof (target as any).on === 'function';
+  const hasAdd = !!target && typeof (target as any).addEventListener === 'function';
+  // eslint-disable-next-line no-console
+  console.log(`[DEBUG] ${label}`, {
+    type: target?.constructor?.name,
+    hasOn,
+    hasAdd,
+    keys: target ? Object.keys(target) : null,
+    value: target,
+  });
+  if (!hasOn && !hasAdd) {
+    // eslint-disable-next-line no-console
+    console.error(`[FATAL] ${label} no soporta .on()/.addEventListener()`);
+  }
+}


### PR DESCRIPTION
## Summary
- add safeOn utility to guard against objects lacking event methods
- use safeOn in chat panel socket subscription
- auto-load map icons when missing and preload pin-blue
- normalize attachments in ChatMessageBase
- guard socket listeners in hooks to avoid `.on` crashes
- validate MapLibre instances and subscribe to map events through `safeOn`
- handle blank map icon IDs with transparent placeholder and remove chat debug logs
- fall back to a global MapLibre object if dynamic import fails and render ticket data as a heatmap

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/maplibre-gl)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afaa3a50988322ac23ff9ac62f011b