### PR TITLE
fix: show fallback personal info in ticket details

### DIFF
--- a/src/components/tickets/DetailsPanel.tsx
+++ b/src/components/tickets/DetailsPanel.tsx
@@ -39,7 +39,13 @@ const DetailsPanel: React.FC = () => {
     return name ? name.split(' ').map(n => n[0]).join('').toUpperCase() : '??';
   };
 
-  const personal = ticket?.informacion_personal_vecino;
+  const personal = {
+    nombre: ticket?.informacion_personal_vecino?.nombre || ticket?.display_name,
+    telefono: ticket?.informacion_personal_vecino?.telefono || ticket?.telefono,
+    email: ticket?.informacion_personal_vecino?.email || ticket?.email,
+    direccion: ticket?.informacion_personal_vecino?.direccion || ticket?.direccion,
+    dni: ticket?.informacion_personal_vecino?.dni || ticket?.dni,
+  };
   const isSpecified = (value?: string) => value && value.toLowerCase() !== 'no especificado';
   const displayName = personal?.nombre || ticket?.display_name || '';
 


### PR DESCRIPTION
## Summary
- ensure ticket details panel falls back to top-level ticket fields for personal info (phone, email, DNI, etc.)
- revert display name logic to also fall back to ticket-provided display name

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/maplibre-gl)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b6c3ea8c8322af1ff2d8f28081e0