### PR TITLE
feat: display ticket timeline with status and comments

### DIFF
--- a/src/components/tickets/TicketTimeline.tsx
+++ b/src/components/tickets/TicketTimeline.tsx
@@ -10,7 +10,13 @@ interface TicketTimelineProps {
 
 type TimelineEvent =
   | { type: 'status'; status: string; date: string; notes?: string }
-  | { type: 'message'; date: string; author: string; content: string };
+  | {
+      type: 'message';
+      date: string;
+      author: string;
+      origin: 'agent' | 'user';
+      content: string;
+    };
 
 const TicketTimeline: React.FC<TicketTimelineProps> = ({ history, messages = [] }) => {
   const events: TimelineEvent[] = [
@@ -19,6 +25,7 @@ const TicketTimeline: React.FC<TicketTimelineProps> = ({ history, messages = [] 
       type: 'message',
       date: m.timestamp,
       author: m.agentName || (m.author === 'agent' ? 'Agente' : 'Vecino'),
+      origin: m.author,
       content: m.content,
     })),
   ].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
@@ -66,9 +73,16 @@ const TicketTimeline: React.FC<TicketTimelineProps> = ({ history, messages = [] 
                 )}
               </div>
             ) : (
-              <div className="flex flex-col gap-1">
-                <h4 className="font-semibold">{event.author}</h4>
-                <p className="mt-1">{event.content}</p>
+              <div className={`flex flex-col gap-1 ${event.origin === 'agent' ? 'items-end' : 'items-start'}`}>
+                <div
+                  className={`px-3 py-2 rounded-lg max-w-[80%] ${
+                    event.origin === 'agent'
+                      ? 'bg-primary text-primary-foreground'
+                      : 'bg-muted'
+                  }`}
+                >
+                  <p className="text-sm">{event.content}</p>
+                </div>
                 <time className="text-sm text-muted-foreground">
                   {formatDate(
                     event.date,

--- a/src/types/tickets.ts
+++ b/src/types/tickets.ts
@@ -59,6 +59,20 @@ export interface TicketHistoryEvent {
   notes?: string;
 }
 
+export interface TicketTimelineEvent {
+  tipo: 'ticket_creado' | 'comentario' | 'estado';
+  fecha: string;
+  estado?: string;
+  texto?: string;
+  es_admin?: boolean;
+  user_id?: number;
+}
+
+export interface TicketTimelineResponse {
+  estado_chat: string;
+  timeline: TicketTimelineEvent[];
+}
+
 export interface Ticket {
   id: number;
   tipo: 'municipio' | 'pyme';


### PR DESCRIPTION
## Summary
- fetch timeline data via `/tickets/{tipo}/{ticketId}/timeline`
- render ticket comments as chat-style bubbles with status events
- show current state from timeline on ticket lookup page

## Testing
- `npm install` *(fails: 403 Forbidden retrieving maplibre-gl)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0beab3e948322acd06f952bc2ce4c