### PR TITLE
feat: allow adjustable map height

### DIFF
--- a/src/components/LocationMap.tsx
+++ b/src/components/LocationMap.tsx
@@ -5,15 +5,17 @@ interface Props {
   lng?: number | null;
   onSelect?: (lat: number, lng: number, address?: string) => void;
   heatmapData?: { lat: number; lng: number; weight?: number }[];
+  className?: string;
 }
 
-export default function LocationMap({ lat, lng, onSelect, heatmapData }: Props) {
+export default function LocationMap({ lat, lng, onSelect, heatmapData, className }: Props) {
   const center = lat != null && lng != null ? ([lng, lat] as [number, number]) : undefined;
   return (
     <MapLibreMap
       initialCenter={center}
       onSelect={onSelect}
       heatmapData={heatmapData}
+      className={className}
     />
   );
 }

--- a/src/components/MapLibreMap.tsx
+++ b/src/components/MapLibreMap.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import { cn } from "@/lib/utils";
 // MapLibre se importa de forma dinámica para evitar errores en entornos donde
 // la librería no esté disponible completamente o falten métodos como `on`.
 // Intentamos importar el bundle de MapLibre de manera dinámica. Si no está
@@ -14,6 +15,7 @@ type Props = {
   initialZoom?: number;
   onSelect?: (lat: number, lon: number, address?: string) => void;
   heatmapData?: HeatPoint[];
+  className?: string;
 };
 
 export default function MapLibreMap({
@@ -21,6 +23,7 @@ export default function MapLibreMap({
   initialZoom = 12,
   onSelect,
   heatmapData,
+  className,
 }: Props) {
   const ref = useRef<HTMLDivElement>(null);
   // Referencias al mapa y al marcador; se tipan como `any` porque la librería
@@ -238,5 +241,10 @@ export default function MapLibreMap({
     source.setData(geojson as any);
   }, [heatmapData]);
 
-  return <div ref={ref} className="w-full h-[500px] rounded-2xl overflow-hidden" />;
+  return (
+    <div
+      ref={ref}
+      className={cn("w-full rounded-2xl overflow-hidden", className ?? "h-[500px]")}
+    />
+  );
 }

--- a/src/pages/Perfil.tsx
+++ b/src/pages/Perfil.tsx
@@ -780,6 +780,7 @@ export default function Perfil() {
                       lat={perfil.latitud ?? undefined}
                       lng={perfil.longitud ?? undefined}
                       onSelect={handleMapSelect}
+                      className="h-[400px]"
                     />
                   </div>
                 )}
@@ -981,6 +982,7 @@ export default function Perfil() {
                     lat={mapCenter?.lat}
                     lng={mapCenter?.lng}
                     heatmapData={heatmapData}
+                    className="h-[600px]"
                   />
                 ) : (
                   <p className="text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
- support custom map height via `className` prop
- apply larger map for heatmap section and smaller map for location section

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/maplibre-gl)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bfd9221c83228d883c0d4f7ff34e