### PR TITLE
feat: add ticket analytics charts and heatmap

### DIFF
--- a/src/components/TicketStatsCharts.tsx
+++ b/src/components/TicketStatsCharts.tsx
@@ -1,0 +1,57 @@
+import { Bar } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  BarElement,
+  CategoryScale,
+  LinearScale,
+  Tooltip,
+  Legend,
+  Title,
+} from 'chart.js';
+import React from 'react';
+
+ChartJS.register(BarElement, CategoryScale, LinearScale, Tooltip, Legend, Title);
+
+export interface ChartBlock {
+  title: string;
+  data: Record<string, number>;
+}
+
+interface Props {
+  charts?: ChartBlock[];
+}
+
+function SingleChart({ title, data }: ChartBlock) {
+  const labels = Object.keys(data);
+  const values = Object.values(data);
+  const chartData = {
+    labels,
+    datasets: [
+      {
+        label: title,
+        data: values,
+        backgroundColor: 'rgba(59,130,246,0.5)',
+      },
+    ],
+  };
+  const options = {
+    responsive: true,
+    plugins: {
+      legend: { display: false },
+      title: { display: true, text: title },
+    },
+  } as const;
+  return <Bar data={chartData} options={options} />;
+}
+
+export default function TicketStatsCharts({ charts }: Props) {
+  if (!charts || charts.length === 0) return null;
+  return (
+    <div className="grid gap-8 md:grid-cols-2">
+      {charts.map((c, idx) => (
+        <SingleChart key={idx} {...c} />
+      ))}
+    </div>
+  );
+}
+

--- a/src/pages/EstadisticasPage.tsx
+++ b/src/pages/EstadisticasPage.tsx
@@ -1,10 +1,30 @@
+import { useEffect, useState } from 'react';
 import MapLibreMap from "@/components/MapLibreMap";
+import TicketStatsCharts from "@/components/TicketStatsCharts";
+import { getTicketStats, HeatPoint, TicketStatsResponse } from "@/services/statsService";
 
 export default function EstadisticasPage() {
+  const [charts, setCharts] = useState<TicketStatsResponse['charts']>([]);
+  const [heatmap, setHeatmap] = useState<HeatPoint[]>([]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const stats = await getTicketStats();
+        setCharts(stats.charts || []);
+        setHeatmap(stats.heatmap || []);
+      } catch (err) {
+        console.error('Error loading ticket stats:', err);
+      }
+    })();
+  }, []);
+
   return (
-    <div className="p-4">
+    <div className="p-4 space-y-8">
       <h1 className="text-2xl font-bold mb-4">Estadísticas y Mapas de Calor</h1>
-      <MapLibreMap />
+      <TicketStatsCharts charts={charts} />
+      {heatmap.length > 0 && <MapLibreMap heatmapData={heatmap} />}
     </div>
   );
 }
+

--- a/src/services/statsService.ts
+++ b/src/services/statsService.ts
@@ -1,0 +1,18 @@
+import { apiFetch } from '@/utils/api';
+
+export interface HeatPoint { lat: number; lng: number; weight?: number }
+
+export interface TicketStatsResponse {
+  charts?: { title: string; data: Record<string, number> }[];
+  heatmap?: HeatPoint[];
+}
+
+export const getTicketStats = async (): Promise<TicketStatsResponse> => {
+  try {
+    return await apiFetch<TicketStatsResponse>('/tickets/stats');
+  } catch (err) {
+    console.error('Error fetching ticket stats:', err);
+    throw err;
+  }
+};
+


### PR DESCRIPTION
## Summary
- fetch ticket statistics and heatmap data from backend
- display bar charts for provided stats
- show heatmap on analytics page when data exists

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden fetching maplibre-gl)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c1a38c908322b00f3722c4850e54