### PR TITLE
Show entity logo in widget bubble and fix user typing

### DIFF
--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -493,7 +493,24 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
                   animate={isOpen ? "open" : "closed"}
                   transition={openSpring}
                 >
-                  <ChatbocLogoAnimated size={calculatedLogoSize} blinking={!isOpen} floating={!isOpen} pulsing={!isOpen} />
+                  {entityInfo?.logo_url ? (
+                    <img
+                      src={entityInfo.logo_url}
+                      alt="Logo"
+                      style={{
+                        width: calculatedLogoSize,
+                        height: calculatedLogoSize,
+                        borderRadius: "50%",
+                      }}
+                    />
+                  ) : (
+                    <ChatbocLogoAnimated
+                      size={calculatedLogoSize}
+                      blinking={!isOpen}
+                      floating={!isOpen}
+                      pulsing={!isOpen}
+                    />
+                  )}
                 </motion.div>
               </motion.button>
             </motion.div>

--- a/src/hooks/useUser.tsx
+++ b/src/hooks/useUser.tsx
@@ -15,7 +15,7 @@ interface UserData {
   logo_url?: string;
   picture?: string;
   tipo_chat?: 'pyme' | 'municipio';
-  rol?: string;s
+  rol?: string;
 }
 
 interface UserContextValue {


### PR DESCRIPTION
## Summary
- use entity's `logo_url` when rendering chat widget button
- remove stray character from user hook's `UserData` interface

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c62ab5cc8322a45e014bbe978b49