### PR TITLE
Refactor analytics tooltip for reuse

### DIFF
--- a/src/components/analytics/ChartTooltip.tsx
+++ b/src/components/analytics/ChartTooltip.tsx
@@ -1,0 +1,13 @@
+import type { TooltipProps } from 'recharts';
+
+export default function ChartTooltip({ active, payload }: TooltipProps<number, string>) {
+  if (!active || !payload || payload.length === 0) return null;
+  const item = payload[0];
+  const label = (item as any).payload?.name ?? item.name;
+  return (
+    <div className="bg-background p-2 shadow-lg rounded-lg">
+      <p className="text-sm text-muted-foreground">{label}</p>
+      <p className="text-sm font-bold">{item.value}</p>
+    </div>
+  );
+}

--- a/src/pages/BusinessMetrics.tsx
+++ b/src/pages/BusinessMetrics.tsx
@@ -31,6 +31,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { apiFetch, ApiError } from "@/utils/api";
+import ChartTooltip from "@/components/analytics/ChartTooltip";
 
 // --- MOCK DATA & TYPES (as per backend spec) ---
 
@@ -152,7 +153,11 @@ const RegionChart: FC<{ data: RegionSale[] }> = ({ data }) => {
                         <Pie data={data} dataKey="sales" nameKey="region_name" cx="50%" cy="50%" outerRadius={80} label>
                             {data.map((entry, index) => <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />)}
                         </Pie>
-                        <Tooltip formatter={(value) => `$${Number(value).toLocaleString('es-AR')}`} />
+                        <Tooltip
+                            cursor={false}
+                            content={<ChartTooltip />}
+                            formatter={(value) => `$${Number(value).toLocaleString('es-AR')}`}
+                        />
                         <Legend />
                     </PieChart>
                 </ResponsiveContainer>

--- a/src/pages/MunicipalAnalytics.tsx
+++ b/src/pages/MunicipalAnalytics.tsx
@@ -4,6 +4,7 @@ import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip, Legend } from 'recharts';
 import useRequireRole from '@/hooks/useRequireRole';
 import type { Role } from '@/utils/roles';
+import ChartTooltip from '@/components/analytics/ChartTooltip';
 
 interface Municipality {
   name: string;
@@ -102,13 +103,7 @@ export default function MunicipalAnalytics() {
               <BarChart data={chartData}>
                 <XAxis dataKey="name" />
                 <YAxis />
-                <Tooltip
-                  cursor={false}
-                  content={<div className="bg-background p-2 shadow-lg rounded-lg">
-                    <p className="text-sm text-muted-foreground">{'{payload?.[0]?.payload?.name}'}</p>
-                    <p className="text-sm font-bold">{'{payload?.[0]?.value}'}</p>
-                  </div>}
-                />
+                <Tooltip cursor={false} content={<ChartTooltip />} />
                 <Legend />
                 <Bar dataKey="value" fill="var(--color-value)" radius={4} />
               </BarChart>


### PR DESCRIPTION
## Summary
- extract reusable `ChartTooltip` component for analytics charts
- apply `ChartTooltip` across municipal and business analytics

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden for maplibre-gl)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c968a6808322bef4b4d70eb7bb60