### PR TITLE
fix: anchor chat widget to bottom

### DIFF
--- a/widget.js
+++ b/widget.js
@@ -274,12 +274,8 @@
               style.bottom = "env(safe-area-inset-bottom)";
               style.top = "env(safe-area-inset-top)";
             } else {
-              const topOffset =
-                window.innerHeight -
-                parsePx(newDims.height) -
-                parsePx(initialBottom);
-              style.top = `${Math.max(topOffset, 16)}px`;
-              style.bottom = "auto";
+              style.bottom = initialBottom;
+              style.top = "auto";
             }
             Object.assign(widgetContainer.style, style);
           } else {
@@ -318,12 +314,8 @@
           style.bottom = "env(safe-area-inset-bottom)";
           style.top = "env(safe-area-inset-top)";
         } else {
-          const topOffset =
-            window.innerHeight -
-            parsePx(newDims.height) -
-            parsePx(initialBottom);
-          style.top = `${Math.max(topOffset, 16)}px`;
-          style.bottom = "auto";
+          style.bottom = initialBottom;
+          style.top = "auto";
         }
         Object.assign(widgetContainer.style, style);
       }


### PR DESCRIPTION
## Summary
- keep widget anchored to bottom when opened to avoid top cropping

## Testing
- `npm ci` (fails: 403 Forbidden fetching maplibre-gl)


------
https://chatgpt.com/codex/tasks/task_e_68b0d758a60c83228ae84de365443eb4