### PR TITLE
fix: ensure widget iframe loads fully

### DIFF
--- a/public/iframe.html
+++ b/public/iframe.html
@@ -12,8 +12,10 @@
       height: 100%;
       width: 100%;
       margin: 0;
+      padding: 0;
+    }
+    body {
       background: #0B1020;
-      overflow: hidden;
     }
   </style>
 </head>

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -192,6 +192,12 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
   );
 
   useEffect(() => {
+    if (mode === "iframe" && typeof window !== "undefined" && window.parent !== window && widgetId) {
+      window.parent.postMessage({ type: "chatboc-ready", widgetId }, "*");
+    }
+  }, [mode, widgetId]);
+
+  useEffect(() => {
     sendStateMessageToParent(isOpen);
     if (isOpen) {
       setShowProactiveBubble(false);

--- a/widget.js
+++ b/widget.js
@@ -207,6 +207,9 @@
         transition: "opacity 0.4s ease-in",
         zIndex: "1",
       });
+      iframe.setAttribute("width", "100%");
+      iframe.setAttribute("height", "100%");
+      iframe.setAttribute("frameborder", "0");
       iframe.allow = "clipboard-write; geolocation";
       iframe.setAttribute("title", "Chatboc Asistente Virtual");
       widgetContainer.appendChild(iframe);
@@ -251,6 +254,13 @@
           return;
         }
 
+        if (event.data?.type === "chatboc-ready" && event.data.widgetId === iframeId) {
+          loader.style.opacity = "0";
+          setTimeout(() => loader.remove(), 300);
+          iframe.style.opacity = "1";
+          return;
+        }
+
         if (event.data?.type === "chatboc-state-change" && event.data.widgetId === iframeId) {
           iframeIsCurrentlyOpen = event.data.isOpen;
           const newDims = computeResponsiveDims(
@@ -274,12 +284,8 @@
               style.bottom = "env(safe-area-inset-bottom)";
               style.top = "env(safe-area-inset-top)";
             } else {
-              const topOffset =
-                window.innerHeight -
-                parsePx(newDims.height) -
-                parsePx(initialBottom);
-              style.top = `${Math.max(topOffset, 16)}px`;
-              style.bottom = "auto";
+              style.bottom = initialBottom;
+              style.top = "auto";
             }
             Object.assign(widgetContainer.style, style);
           } else {
@@ -318,12 +324,8 @@
           style.bottom = "env(safe-area-inset-bottom)";
           style.top = "env(safe-area-inset-top)";
         } else {
-          const topOffset =
-            window.innerHeight -
-            parsePx(newDims.height) -
-            parsePx(initialBottom);
-          style.top = `${Math.max(topOffset, 16)}px`;
-          style.bottom = "auto";
+          style.bottom = initialBottom;
+          style.top = "auto";
         }
         Object.assign(widgetContainer.style, style);
       }


### PR DESCRIPTION
## Summary
- remove overflow restrictions in iframe container to prevent cropping
- emit and handle `chatboc-ready` message so loader clears once widget initializes
- explicitly size iframe element via width/height attributes

## Testing
- `npm ci` (fails: 403 Forbidden - GET https://registry.npmjs.org/maplibre-gl)
- `npm test` (fails: vitest not found)


------
https://chatgpt.com/codex/tasks/task_e_68b0d758a60c83228ae84de365443eb4