### PR TITLE
Show chat history for each ticket

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,6 +14,7 @@ const {
   generateCsvReport,
   generatePdfReport,
 } = require('./municipalMessageMetrics');
+const { getTicketMessagesById } = require('./db');
 const sessionMiddleware = require('./session');
 const cartRoutes = require('./cartRoutes');
 const preferences = require('./preferences');
@@ -132,6 +133,13 @@ app.get('/municipal/message-metrics.csv', (req, res) => {
 app.get('/municipal/message-metrics.pdf', (req, res) => {
   const pdf = generatePdfReport();
   res.type('application/pdf').attachment('message-metrics.pdf').send(pdf);
+});
+
+// Historial de mensajes de un ticket específico
+app.get('/tickets/chat/:ticketId/mensajes', (req, res) => {
+  const { ticketId } = req.params;
+  const mensajes = getTicketMessagesById(ticketId);
+  res.json({ mensajes });
 });
 
 app.get('/productos', (req, res) => {

--- a/db.js
+++ b/db.js
@@ -5,10 +5,42 @@ let tickets = [
   { municipality: 'Beta', category: 'arbolado', responseMs: 6 * 60 * 60 * 1000 },
 ];
 
+// Mensajes de chat asociados a tickets. Cada mensaje incluye el ID del ticket
+// para permitir filtrar su historial de conversación. Se mantienen los campos
+// `municipality` y `timestamp` para compatibilidad con los tests existentes.
 let messages = [
-  { municipality: 'Alpha', timestamp: Date.now() - 2 * 24 * 60 * 60 * 1000 },
-  { municipality: 'Alpha', timestamp: Date.now() - 10 * 24 * 60 * 60 * 1000 },
-  { municipality: 'Beta', timestamp: Date.now() - 40 * 24 * 60 * 60 * 1000 },
+  {
+    id: 1,
+    ticketId: 1,
+    municipality: 'Alpha',
+    author: 'user',
+    content: 'Hola, tengo un problema',
+    timestamp: Date.now() - 2 * 24 * 60 * 60 * 1000,
+  },
+  {
+    id: 2,
+    ticketId: 1,
+    municipality: 'Alpha',
+    author: 'agent',
+    content: 'Gracias por avisar, lo revisamos.',
+    timestamp: Date.now() - 2 * 24 * 60 * 60 * 1000 + 60000,
+  },
+  {
+    id: 3,
+    ticketId: 2,
+    municipality: 'Alpha',
+    author: 'user',
+    content: '¿Hay novedades?',
+    timestamp: Date.now() - 10 * 24 * 60 * 60 * 1000,
+  },
+  {
+    id: 4,
+    ticketId: 3,
+    municipality: 'Beta',
+    author: 'user',
+    content: 'Se rompió la luminaria',
+    timestamp: Date.now() - 40 * 24 * 60 * 60 * 1000,
+  },
 ];
 
 function getTickets() {
@@ -27,9 +59,15 @@ function __setMessages(newMessages) {
   messages = newMessages;
 }
 
+// Devuelve el historial de mensajes para un ticket específico
+function getTicketMessagesById(ticketId) {
+  return messages.filter(m => m.ticketId === Number(ticketId));
+}
+
 module.exports = {
   getTickets,
   __setTickets,
   getMessages,
   __setMessages,
+  getTicketMessagesById,
 };

--- a/src/components/tickets/ConversationPanel.tsx
+++ b/src/components/tickets/ConversationPanel.tsx
@@ -66,15 +66,22 @@ const ConversationPanel: React.FC<ConversationPanelProps> = ({ isMobile, isSideb
 
   useEffect(() => {
     const fetchMessages = async () => {
-        if (selectedTicket) {
-            try {
-                const fetchedMessages = await getTicketMessages(selectedTicket.id, selectedTicket.tipo);
-                setMessages(fetchedMessages.map(msg => adaptTicketMessageToChatMessage(msg, selectedTicket)));
-            } catch (error) {
-                toast.error("No se pudo cargar el historial de mensajes.");
-                setMessages([]);
-            }
-        } else {
+        if (!selectedTicket) {
+            setMessages([]);
+            return;
+        }
+
+        // Usar los mensajes existentes si vienen con el ticket
+        if (selectedTicket.messages) {
+            setMessages(selectedTicket.messages.map(msg => adaptTicketMessageToChatMessage(msg, selectedTicket)));
+            return;
+        }
+
+        try {
+            const fetchedMessages = await getTicketMessages(selectedTicket.id, selectedTicket.tipo);
+            setMessages(fetchedMessages.map(msg => adaptTicketMessageToChatMessage(msg, selectedTicket)));
+        } catch (error) {
+            toast.error("No se pudo cargar el historial de mensajes.");
             setMessages([]);
         }
     };

--- a/src/components/tickets/DetailsPanel.tsx
+++ b/src/components/tickets/DetailsPanel.tsx
@@ -105,19 +105,28 @@ const DetailsPanel: React.FC = () => {
         setTimelineMessages([]);
         return;
       }
+
+      // Si el ticket ya incluye historial y mensajes, los usamos directamente
+      if (ticket.history || ticket.messages) {
+        setTimelineHistory(ticket.history || []);
+        setTimelineMessages(ticket.messages || []);
+        return;
+      }
+
       try {
         const detailed = await getTicketById(ticket.id.toString());
         setTimelineHistory(detailed.history || []);
+        setTimelineMessages(detailed.messages || []);
       } catch (error) {
-        console.error('Error fetching ticket history:', error);
+        console.error('Error fetching ticket timeline:', error);
         setTimelineHistory([]);
-      }
-      try {
-        const msgs = await getTicketMessages(ticket.id, ticket.tipo);
-        setTimelineMessages(msgs);
-      } catch (error) {
-        console.error('Error fetching ticket messages:', error);
-        setTimelineMessages([]);
+        try {
+          const msgs = await getTicketMessages(ticket.id, ticket.tipo);
+          setTimelineMessages(msgs);
+        } catch (msgErr) {
+          console.error('Error fetching ticket messages:', msgErr);
+          setTimelineMessages([]);
+        }
       }
     };
     fetchTimeline();

--- a/src/pages/TicketLookup.tsx
+++ b/src/pages/TicketLookup.tsx
@@ -39,6 +39,13 @@ export default function TicketLookup() {
     try {
       const data = await getTicketByNumber(id, pinVal);
       setTicket(data);
+
+      // Usar el historial y mensajes incluidos en el ticket si están presentes
+      if (data.history || data.messages) {
+        setTimelineHistory(data.history || []);
+        setTimelineMessages(data.messages || []);
+      }
+
       try {
         const timeline = await getTicketTimeline(data.id, data.tipo, { public: true });
         setTimelineHistory(timeline.history);


### PR DESCRIPTION
## Summary
- expose backend endpoint to retrieve ticket chat messages and store sample chat history
- ensure ticket service and panels reuse provided messages so chat history is always visible

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden for maplibre-gl)*

------
https://chatgpt.com/codex/tasks/task_e_68b0edc276908322b20e6bb87b8e286a