### PR TITLE
feat: personalize chat greeting with visitor name

### DIFF
--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -27,6 +27,7 @@ import { Button } from "@/components/ui/button";
 import io from 'socket.io-client';
 import { getSocketUrl } from "@/config";
 import { safeOn, assertEventSource } from "@/utils/safeOn";
+import { getVisitorName, setVisitorName } from "@/utils/visitorName";
 
 const PENDING_TICKET_KEY = 'pending_ticket_id';
 const PENDING_GPS_KEY = 'pending_gps';
@@ -90,6 +91,19 @@ const ChatPanel = ({
     tipoChat: tipoChat,
     entityToken: propEntityToken,
   });
+
+  const [visitorName, setVisitorNameState] = useState(() => getVisitorName());
+
+  useEffect(() => {
+    if (!visitorName && typeof window !== 'undefined') {
+      const nombre = window.prompt('¿Cuál es tu nombre?');
+      if (nombre) {
+        setVisitorName(nombre);
+        setVisitorNameState(nombre);
+        handleSend({ action: 'set_user_name', payload: { nombre } });
+      }
+    }
+  }, [visitorName, handleSend]);
 
   const handlePersonalDataSubmit = (data: { nombre: string; email: string; telefono: string; dni: string; }) => {
     handleSend({

--- a/src/hooks/useChatLogic.ts
+++ b/src/hooks/useChatLogic.ts
@@ -13,6 +13,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { MunicipioContext, updateMunicipioContext, getInitialMunicipioContext } from "@/utils/contexto_municipio";
 import { useUser } from './useUser';
 import { safeOn, assertEventSource } from "@/utils/safeOn";
+import { getVisitorName } from "@/utils/visitorName";
 
 interface UseChatLogicOptions {
   tipoChat: 'pyme' | 'municipio';
@@ -91,6 +92,7 @@ export function useChatLogic({ tipoChat, entityToken: propToken, tokenKey = 'aut
       console.log("useChatLogic: Sending initial greeting to fetch menu.");
       setIsTyping(true);
 
+      const initialName = getVisitorName();
       apiFetch<any>(endpoint, {
         method: 'POST',
         body: {
@@ -98,6 +100,7 @@ export function useChatLogic({ tipoChat, entityToken: propToken, tokenKey = 'aut
           action: 'initial_greeting',
           contexto_previo: initialContext,
           tipo_chat: tipoChat,
+          ...(initialName && { nombre_usuario: initialName }),
         },
       })
         .catch(error => {
@@ -306,6 +309,8 @@ export function useChatLogic({ tipoChat, entityToken: propToken, tokenKey = 'aut
       const updatedContext = updateMunicipioContext(contexto, { userInput: userMessageText, action: resolvedAction });
       setContexto(updatedContext);
 
+      const visitorName = getVisitorName();
+
       const requestBody: Record<string, any> = {
         pregunta: sanitizedText,
         contexto_previo: updatedContext,
@@ -316,6 +321,7 @@ export function useChatLogic({ tipoChat, entityToken: propToken, tokenKey = 'aut
         ...(resolvedAction && { action: resolvedAction }),
         ...(actionPayload && { payload: actionPayload }),
         ...(resolvedAction === "confirmar_reclamo" && currentClaimIdempotencyKey && { idempotency_key: currentClaimIdempotencyKey }),
+        ...(visitorName && { nombre_usuario: visitorName }),
       };
 
       if (resolvedAction === 'confirmar_reclamo') {

--- a/src/utils/visitorName.ts
+++ b/src/utils/visitorName.ts
@@ -1,0 +1,11 @@
+import { safeLocalStorage } from './safeLocalStorage';
+
+const VISITOR_NAME_KEY = 'visitor_name';
+
+export function getVisitorName(): string {
+  return safeLocalStorage.getItem(VISITOR_NAME_KEY) || '';
+}
+
+export function setVisitorName(name: string): void {
+  safeLocalStorage.setItem(VISITOR_NAME_KEY, name);
+}


### PR DESCRIPTION
## Summary
- prompt visitor for their name when the chat widget opens
- send stored visitor name with initial greeting and subsequent messages
- keep visitor name in local storage for future sessions

## Testing
- `npm test` *(fails: vitest not found)*
- `npx vitest run` *(fails: 403 Forbidden when fetching vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f5fdee048322b8d32a6964a0e104