### PR TITLE
Make chat widget more visible on mobile

### DIFF
--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -161,9 +161,8 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
       : openHeight;
   }, [openHeight, viewport.height, initialPosition.bottom]);
 
-  const mobileClosedSize = "72px";
-  const finalClosedWidth = isMobileView ? mobileClosedSize : closedWidth;
-  const finalClosedHeight = isMobileView ? mobileClosedSize : closedHeight;
+  const finalClosedWidth = closedWidth;
+  const finalClosedHeight = closedHeight;
   const logoSizeFactor = 0.62;
   const closedWidthPx = parseInt(finalClosedWidth.replace('px', ''), 10);
   const calculatedLogoSize = Math.floor(closedWidthPx * logoSizeFactor);


### PR DESCRIPTION
## Summary
- ensure mobile chat widget uses configured closed width/height instead of a small 72px default

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden when fetching maplibre-gl)*

------
https://chatgpt.com/codex/tasks/task_e_68b10322ad2483228d171d6d2af640e8