### PR TITLE
feat: personalize chat greeting with visitor name

### DIFF
--- a/src/utils/visitorName.ts
+++ b/src/utils/visitorName.ts
@@ -1,0 +1,11 @@
+import { safeLocalStorage } from './safeLocalStorage';
+
+const VISITOR_NAME_KEY = 'visitor_name';
+
+export function getVisitorName(): string {
+  return safeLocalStorage.getItem(VISITOR_NAME_KEY) || '';
+}
+
+export function setVisitorName(name: string): void {
+  safeLocalStorage.setItem(VISITOR_NAME_KEY, name);
+}


### PR DESCRIPTION
## Summary
- prompt visitor for their name when the chat widget opens
- send stored visitor name with initial greeting and subsequent messages
- keep visitor name in local storage for future sessions
- avoid using admin auth token in embedded widgets so greetings use visitor name

## Testing
- `npm test` *(fails: vitest not found)*
- `npx vitest run` *(fails: 403 Forbidden fetching vitest)*
- `npm run lint` *(fails: Missing script "lint")*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f5fdee048322b8d32a6964a0e104