### PR TITLE
feat: allow custom widget icon and color via script attributes

### DIFF
--- a/docs/widget-embedding.md
+++ b/docs/widget-embedding.md
@@ -10,9 +10,10 @@ To embed the chat widget on your website, you need to add the following script t
 
 You can customize the chat widget by adding the following attributes to the script tag:
 
-*   `data-primary-color`: The primary color of the widget (in hex format).
-*   `data-logo-url`: The URL of the logo to display in the widget launcher.
-*   `data-position`: The position of the widget on the screen ('left' or 'right').
+*   `data-primary-color`: Background color of the closed launcher (any CSS color).
+*   `data-logo-url`: URL of the image shown inside the launcher.
+*   `data-logo-animation`: CSS animation to apply to the launcher image (e.g., `bounce 2s infinite`).
+*   `data-bottom` / `data-right`: Offsets (e.g., `24px`) to tweak widget position.
 *   `data-lang`: ISO language code (for example, `es` or `en`) used to request localized widget content.
 
 Example:
@@ -22,13 +23,13 @@ Example:
   src="http://localhost:3001/widget.js"
   data-primary-color="#ff0000"
   data-logo-url="https://example.com/logo.png"
-  data-position="left"
+  data-logo-animation="bounce 2s infinite"
   data-lang="es"
 ></script>
 ```
 
 ## How it works
 
-The `widget.js` script will create an iframe on your page and load the chat widget into it. The widget will be displayed as a floating button on the bottom right corner of the screen (or bottom left, if you set the `data-position` attribute to 'left'). When the user clicks on the button, the chat panel will open.
+The `widget.js` script creates an iframe on your page and displays a floating button on the bottom right corner of the screen. You can tweak its offset with `data-bottom` and `data-right`. When the user clicks on the button, the chat panel opens.
 
-The script will also automatically pass the user's information to the widget, if the user is logged in to your website. This will allow the widget to display the user's name and contact information in the chat.
+If the user is logged in to your website, the script passes that information to the widget so the chat can display their name and contact details.

--- a/widget.js
+++ b/widget.js
@@ -73,6 +73,10 @@
     const rubroAttr = script.getAttribute("data-rubro") || "";
     const ctaMessageAttr = script.getAttribute("data-cta-message") || "";
     const langAttr = script.getAttribute("data-lang") || "";
+    const primaryColor = script.getAttribute("data-primary-color") || "#007aff";
+    const logoUrlAttr = script.getAttribute("data-logo-url");
+    const logoAnimationAttr = script.getAttribute("data-logo-animation") || "";
+    const logoUrl = logoUrlAttr || `${chatbocDomain}/chatboc_widget_64x64.webp`;
     const endpointAttr = script.getAttribute("data-endpoint");
     const tipoChat =
       endpointAttr === "municipio" || endpointAttr === "pyme"
@@ -139,8 +143,8 @@
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
-        background: "#007aff",
-        cursor: "pointer",
+        background: defaultOpen ? "white" : primaryColor,
+        cursor: defaultOpen ? "default" : "pointer",
       });
 
       widgetContainer.addEventListener("mouseenter", () => {
@@ -158,6 +162,21 @@
       });
       document.body.appendChild(widgetContainer);
 
+      const logoImg = document.createElement("img");
+      logoImg.id = `chatboc-logo-${iframeId}`;
+      logoImg.src = logoUrl;
+      logoImg.alt = "Abrir chat";
+      Object.assign(logoImg.style, {
+        width: "70%",
+        height: "70%",
+        objectFit: "contain",
+        pointerEvents: "none",
+        transition: "opacity 0.3s ease",
+        opacity: iframeIsCurrentlyOpen ? "0" : "1",
+      });
+      if (logoAnimationAttr) logoImg.style.animation = logoAnimationAttr;
+      widgetContainer.appendChild(logoImg);
+
       const loader = document.createElement("div");
       loader.id = `chatboc-loader-${iframeId}`;
       Object.assign(loader.style, {
@@ -168,7 +187,7 @@
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
-        background: "hsl(var(--primary, 218 92% 41%))",
+        background: primaryColor,
         borderRadius: "inherit",
         transition: "opacity 0.3s ease-out 0.1s",
         zIndex: "2",
@@ -288,13 +307,14 @@
               style.top = "auto";
             }
             Object.assign(widgetContainer.style, style);
+            logoImg.style.opacity = "0";
           } else {
             Object.assign(widgetContainer.style, {
               width: newDims.width,
               height: newDims.height,
               borderRadius: "50%",
               boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
-              background: "#007aff",
+              background: primaryColor,
               cursor: "pointer",
               bottom:
                 window.innerWidth <= SCRIPT_CONFIG.MOBILE_BREAKPOINT_PX
@@ -304,6 +324,7 @@
               top: "auto",
               left: "auto",
             });
+            logoImg.style.opacity = "1";
           }
         }
       }


### PR DESCRIPTION
## Summary
- enable widget.js to read `data-logo-url`, `data-logo-animation`, and `data-primary-color`
- show a launcher image that toggles visibility based on widget state
- document new customization options for widget embedding

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/maplibre-gl)*

------
https://chatgpt.com/codex/tasks/task_e_68b10ce909ec83229617d9207223b920