### PR TITLE
fix: update widget default domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ You can embed the floating chat widget on any site by loading `widget.js` and pa
     }
 
     var s = document.createElement('script');
-    s.src = 'https://www.chatboc.ar/widget.js';
+    s.src = 'https://chatboc.ar/widget.js';
     s.async = true;
     s.setAttribute('data-entity-token', 'TU_TOKEN_AQUI');
     // Choose the API endpoint. If omitted, the widget falls back
@@ -137,18 +137,18 @@ You can embed the floating chat widget on any site by loading `widget.js` and pa
 
 This snippet loads the widget without needing an iframe and creates a floating bubble styled just like on chatboc.ar.
 You can also pass `data-theme="dark"` or `data-theme="light"` to force a specific theme inside the widget.
-If you host `widget.js` yourself, remember to add `data-domain="https://www.chatboc.ar"` so the iframe loads from our servers. Example self-hosted snippet:
+If you host `widget.js` yourself, remember to add `data-domain="https://chatboc.ar"` so the iframe loads from our servers. Example self-hosted snippet:
 
 ```html
 <script async src="/widget.js"
-  data-domain="https://www.chatboc.ar"
+  data-domain="https://chatboc.ar"
   data-entity-token="TU_TOKEN_AQUI"></script>
 ```
 Using `widget.js` from another domain **without** this attribute causes the iframe
 to load its scripts from the wrong origin, leading to console errors and 403
 responses from `https://api.chatboc.ar`. If you see messages such as `attribute
 cx: Expected length` or `Access Forbidden`, verify that `data-domain` is set to
-`https://www.chatboc.ar`.
+`https://chatboc.ar`.
 The script automatically adds `allow="clipboard-write; geolocation"` to the underlying iframe so the widget can request GPS access.
 If your site embeds this script inside another `<iframe>`, be sure that outer frame also includes
 `allow="clipboard-write; geolocation"`. The permission must be granted at every level
@@ -187,7 +187,7 @@ If your site blocks external JavaScript, you can embed the chatbot using an
 ```html
 <iframe
   id="chatboc-iframe"
-  src="https://www.chatboc.ar/iframe.html?entityToken=TU_TOKEN_AQUI&endpoint=pyme&rubro=comercio" <!-- or "municipio"; `tipo_chat` also works -->
+  src="https://chatboc.ar/iframe.html?entityToken=TU_TOKEN_AQUI&endpoint=pyme&rubro=comercio" <!-- or "municipio"; `tipo_chat` also works -->
   style="position:fixed;bottom:24px;right:24px;border:none;border-radius:50%;z-index:9999;box-shadow:0 4px 32px rgba(0,0,0,0.2);background:transparent;overflow:hidden;width:96px!important;height:96px!important;display:block"
   allow="clipboard-write; geolocation"
   loading="lazy"
@@ -364,7 +364,7 @@ numeric value like `width={300}`. The Google OAuth library does not accept
 percentage values.
 
 If you host `widget.js` on your own domain and forget to include
-`data-domain="https://www.chatboc.ar"`, the iframe will attempt to load its
+`data-domain="https://chatboc.ar"`, the iframe will attempt to load its
 assets from your site. This results in an HTML error page being parsed as
 JavaScript and the browser reports `Uncaught SyntaxError: Invalid or
 unexpected token (window-provider.js:...)`. Always set the `data-domain`

--- a/app.js
+++ b/app.js
@@ -24,7 +24,7 @@ app.use(express.json());
 
 // CORS Configuration
 const whitelist = [
-  'https://www.chatboc.ar',
+  'https://chatboc.ar',
   'https://chatboc-demo-widget-oigs.vercel.app',
   'http://localhost:5173', // Common dev port for Vite
   'http://localhost:3000'  // Common dev port for backend

--- a/pruebaiframe.html
+++ b/pruebaiframe.html
@@ -1,6 +1,6 @@
 <iframe
   id="chatboc-iframe"
-  src="https://www.chatboc.ar/iframe?entityToken=ef403b5b-e0df-4b35-be34-35b9dac0d6f1&tipo_chat=municipio"
+  src="https://chatboc.ar/iframe?entityToken=ef403b5b-e0df-4b35-be34-35b9dac0d6f1&tipo_chat=municipio"
   style="position:fixed; bottom:20px; right:20px; border:none; border-radius:50%; z-index:9999; box-shadow:0 4px 32px rgba(0,0,0,0.2); background:transparent; overflow:hidden; width:112px; height:112px; display:block; transition: width 0.3s ease, height 0.3s ease, border-radius 0.3s ease;"
   allow="clipboard-write; geolocation"
   loading="lazy"
@@ -17,7 +17,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   // Comunicación con el iframe para ajustar tamaño y forma
   window.addEventListener('message', function (event) {
-    if (event.origin !== 'https://www.chatboc.ar') return; // Seguridad: aceptar mensajes solo del origen del iframe
+    if (event.origin !== 'https://chatboc.ar') return; // Seguridad: aceptar mensajes solo del origen del iframe
 
     if (event.data && event.data.type === 'chatboc-state-change') {
       if (event.data.dimensions) {
@@ -30,7 +30,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   // Opcional: Enviar un mensaje al iframe una vez cargado para configuraciones iniciales si es necesario
   // chatIframe.onload = function() {
-  //   chatIframe.contentWindow.postMessage({ type: 'chatboc-init', settings: { exampleSetting: true } }, 'https://www.chatboc.ar');
+  //   chatIframe.contentWindow.postMessage({ type: 'chatboc-init', settings: { exampleSetting: true } }, 'https://chatboc.ar');
   // };
 });
 </script>

--- a/pruebascr.html
+++ b/pruebascr.html
@@ -7,7 +7,7 @@ document.addEventListener('DOMContentLoaded', function () {
   window.APP_TARGET = 'municipio'; // Define el endpoint antes de cargar el script
 
   var s = document.createElement('script');
-  s.src = 'https://www.chatboc.ar/widget.js'; // URL del script del widget
+  s.src = 'https://chatboc.ar/widget.js'; // URL del script del widget
   s.async = true; // Carga asíncrona para no bloquear el renderizado de la página
   s.setAttribute('data-entity-token', 'ef403b5b-e0df-4b35-be34-35b9dac0d6f1'); // Token de la entidad para el widget
   s.setAttribute('data-default-open', 'false'); // El widget comienza cerrado por defecto

--- a/public/widget.js
+++ b/public/widget.js
@@ -7,7 +7,7 @@
       s.src && s.src.includes("widget.js")
     );
 
-  const DEFAULT_DOMAIN = "https://www.chatboc.ar";
+  const DEFAULT_DOMAIN = "https://chatboc.ar";
   const chatbocDomain =
     (script &&
       (script.getAttribute("data-domain") || new URL(script.src).origin)) ||

--- a/src/components/chat/WidgetEmbed.tsx
+++ b/src/components/chat/WidgetEmbed.tsx
@@ -20,7 +20,7 @@ const WidgetEmbed = ({ token }: { token: string }) => {
     }
   }, []);
 
-  const embedCode = `<script>(function(){var s=document.createElement('script');s.src='https://www.chatboc.ar/widget.js';s.async=true;s.setAttribute('data-entity-token','${token}');s.setAttribute('data-endpoint','${tipoChat}');document.head.appendChild(s);})();</script>`;
+  const embedCode = `<script>(function(){var s=document.createElement('script');s.src='https://chatboc.ar/widget.js';s.async=true;s.setAttribute('data-entity-token','${token}');s.setAttribute('data-endpoint','${tipoChat}');document.head.appendChild(s);})();</script>`;
 
   const copiar = () => {
     navigator.clipboard.writeText(embedCode)

--- a/src/pages/Integracion.tsx
+++ b/src/pages/Integracion.tsx
@@ -132,7 +132,7 @@ document.addEventListener('DOMContentLoaded', function () {
   window.APP_TARGET = '${endpoint}'; // Define el endpoint antes de cargar el script
 
   var s = document.createElement('script');
-  s.src = 'https://www.chatboc.ar/widget.js'; // URL del script del widget
+  s.src = 'https://chatboc.ar/widget.js'; // URL del script del widget
   s.async = true; // Carga asíncrona para no bloquear el renderizado de la página
   s.setAttribute('data-entity-token', '${entityToken}'); // Token de la entidad para el widget
   s.setAttribute('data-default-open', 'false'); // El widget comienza cerrado por defecto
@@ -164,7 +164,7 @@ ${customLines ? customLines + "\n" : ""}  // Importante para la geolocalización
   }, [entityToken, endpoint, primaryColor, logoUrl, logoAnimation]);
 
   const iframeSrcUrl = useMemo(() => {
-    const url = new URL("https://www.chatboc.ar/iframe");
+    const url = new URL("https://chatboc.ar/iframe");
     url.searchParams.set("entityToken", entityToken);
     url.searchParams.set("tipo_chat", endpoint);
     if (primaryColor) url.searchParams.set("primaryColor", primaryColor);
@@ -192,7 +192,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   // Comunicación con el iframe para ajustar tamaño y forma
   window.addEventListener('message', function (event) {
-    if (event.origin !== 'https://www.chatboc.ar') return; // Seguridad: aceptar mensajes solo del origen del iframe
+    if (event.origin !== 'https://chatboc.ar') return; // Seguridad: aceptar mensajes solo del origen del iframe
 
     if (event.data && event.data.type === 'chatboc-state-change') {
       if (event.data.dimensions) {
@@ -205,7 +205,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   // Opcional: Enviar un mensaje al iframe una vez cargado para configuraciones iniciales si es necesario
   // chatIframe.onload = function() {
-  //   chatIframe.contentWindow.postMessage({ type: 'chatboc-init', settings: { exampleSetting: true } }, 'https://www.chatboc.ar');
+  //   chatIframe.contentWindow.postMessage({ type: 'chatboc-init', settings: { exampleSetting: true } }, 'https://chatboc.ar');
   // };
 });
 </script>`, [iframeSrcUrl, endpoint]);

--- a/widget.js
+++ b/widget.js
@@ -14,7 +14,7 @@
       DEFAULT_CLOSED_HEIGHT: "56px",
       MOBILE_BREAKPOINT_PX: 640,
       LOADER_TIMEOUT_MS: 10000,
-      DEFAULT_CHATBOC_DOMAIN: "https://www.chatboc.ar",
+      DEFAULT_CHATBOC_DOMAIN: "https://chatboc.ar",
     };
 
     const script =


### PR DESCRIPTION
## Summary
- point widget scripts and sample integrations to https://chatboc.ar
- adjust CORS whitelist and documentation to the new domain

## Testing
- `npm test` *(fails: vitest not found)*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/maplibre-gl)*

------
https://chatgpt.com/codex/tasks/task_e_68b11f552960832281acf5dd470e43d1