### PR TITLE
Fix contact phone mismatch in ticket details

### DIFF
--- a/src/components/tickets/DetailsPanel.tsx
+++ b/src/components/tickets/DetailsPanel.tsx
@@ -22,6 +22,7 @@ import {
 import { FaWhatsapp } from 'react-icons/fa';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
+import { getContactPhone } from '@/utils/ticket';
 
 const DetailsPanel: React.FC = () => {
   const { selectedTicket: ticket } = useTickets();
@@ -44,7 +45,7 @@ const DetailsPanel: React.FC = () => {
 
   const personal = {
     nombre: ticket?.informacion_personal_vecino?.nombre || ticket?.display_name,
-    telefono: ticket?.informacion_personal_vecino?.telefono || ticket?.telefono,
+    telefono: getContactPhone(ticket),
     email: ticket?.informacion_personal_vecino?.email || ticket?.email,
     direccion: ticket?.informacion_personal_vecino?.direccion || ticket?.direccion,
     dni: ticket?.informacion_personal_vecino?.dni || ticket?.dni,

--- a/src/pages/TicketLookup.tsx
+++ b/src/pages/TicketLookup.tsx
@@ -8,6 +8,7 @@ import { formatDate } from '@/utils/fecha';
 import TicketTimeline from '@/components/tickets/TicketTimeline';
 import { Separator } from '@/components/ui/separator';
 import { getErrorMessage, ApiError } from '@/utils/api';
+import { getContactPhone } from '@/utils/ticket';
 
 export default function TicketLookup() {
   const { ticketId } = useParams<{ ticketId: string }>();
@@ -141,7 +142,7 @@ export default function TicketLookup() {
             {ticket.direccion && (
               <p className="text-sm text-muted-foreground mt-1">Dirección: {ticket.direccion}</p>
             )}
-            {(ticket.telefono || ticket.email || ticket.dni || ticket.informacion_personal_vecino) && (
+            {(getContactPhone(ticket) || ticket.email || ticket.dni || ticket.informacion_personal_vecino) && (
               <div className="mt-4 text-sm space-y-1">
                 {(ticket.informacion_personal_vecino?.nombre || ticket.display_name) && (
                   <p>Nombre: {ticket.informacion_personal_vecino?.nombre || ticket.display_name}</p>
@@ -152,8 +153,8 @@ export default function TicketLookup() {
                 {(ticket.informacion_personal_vecino?.email || ticket.email) && (
                   <p>Email: {ticket.informacion_personal_vecino?.email || ticket.email}</p>
                 )}
-                {(ticket.informacion_personal_vecino?.telefono || ticket.telefono) && (
-                  <p>Teléfono: {ticket.informacion_personal_vecino?.telefono || ticket.telefono}</p>
+                {getContactPhone(ticket) && (
+                  <p>Teléfono: {getContactPhone(ticket)}</p>
                 )}
               </div>
             )}

--- a/src/services/exportService.ts
+++ b/src/services/exportService.ts
@@ -2,6 +2,7 @@ import jsPDF from 'jspdf';
 import autoTable from 'jspdf-autotable';
 import * as XLSX from 'xlsx';
 import { Ticket, Message } from '@/types/tickets';
+import { getContactPhone } from '@/utils/ticket';
 
 const formatDate = (dateString: string) => {
   return new Date(dateString).toLocaleString();
@@ -16,7 +17,7 @@ const getTicketData = (ticket: Ticket) => {
     'Fecha de Creación': formatDate(ticket.fecha),
     'Cliente': ticket.nombre_usuario || 'Usuario Desconocido',
     'Email': ticket.email_usuario || ticket.email || 'N/A',
-    'Teléfono': ticket.telefono || 'N/A',
+    'Teléfono': getContactPhone(ticket) || 'N/A',
     'Dirección': ticket.direccion || 'N/A',
     'Canal': ticket.channel || 'N/A',
     'Descripción': ticket.description || 'N/A',
@@ -133,7 +134,7 @@ export const exportToExcel = (tickets: Ticket[]) => {
     'Fecha': new Date(ticket.fecha).toLocaleString(),
     'Cliente': ticket.nombre_usuario || 'Desconocido',
     'Email': ticket.email_usuario || ticket.email || '',
-    'Teléfono': ticket.telefono || '',
+    'Teléfono': getContactPhone(ticket) || '',
     'Dirección': ticket.direccion || '',
     'Canal': ticket.channel || '',
     'Descripción': ticket.description || '',

--- a/src/utils/ticket.ts
+++ b/src/utils/ticket.ts
@@ -1,0 +1,25 @@
+import { Ticket } from '@/types/tickets';
+
+/**
+ * Returns the best phone number to contact the ticket's owner.
+ * Prefers explicitly provided contact information and falls back to
+ * the WhatsApp conversation identifier if available.
+ */
+export function getContactPhone(ticket?: Ticket | null): string | undefined {
+  if (!ticket) return undefined;
+
+  if (ticket.informacion_personal_vecino?.telefono) {
+    return ticket.informacion_personal_vecino.telefono;
+  }
+
+  if (ticket.user?.phone) {
+    return ticket.user.phone;
+  }
+
+  if (ticket.whatsapp_conversation_id) {
+    // Remove any suffix like "@c.us" that might come from WhatsApp IDs
+    return ticket.whatsapp_conversation_id.replace(/@.*/, '');
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
## Summary
- pick best contact phone from user data or WhatsApp id
- show contact phone in ticket details and lookups using helper
- export tickets with the correct contact phone

## Testing
- `npm install --no-audit --no-fund` *(failed: 403 Forbidden - GET https://registry.npmjs.org/maplibre-gl)*
- `npm test` *(failed: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b21640cd2483229f124e08dbd152ac