### PR TITLE
feat: refresh tickets on real-time events

### DIFF
--- a/src/context/TicketContext.tsx
+++ b/src/context/TicketContext.tsx
@@ -1,7 +1,8 @@
-import React, { createContext, useState, useContext, useEffect, ReactNode } from 'react';
+import React, { createContext, useState, useContext, useEffect, ReactNode, useCallback } from 'react';
 import { Ticket } from '@/types/tickets';
 import { getTickets } from '@/services/ticketService';
 import { toast } from 'sonner';
+import useTicketUpdates from '@/hooks/useTicketUpdates';
 
 interface TicketContextType {
   tickets: Ticket[];
@@ -32,33 +33,33 @@ export const TicketProvider: React.FC<{ children: ReactNode }> = ({ children }) 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    const fetchTickets = async () => {
-      try {
-        setLoading(true);
-        const apiResponse = await getTickets();
-        const fetchedTickets = (apiResponse as any)?.tickets;
+  const fetchTickets = useCallback(async () => {
+    try {
+      const apiResponse = await getTickets();
+      const fetchedTickets = (apiResponse as any)?.tickets;
 
-        if (Array.isArray(fetchedTickets)) {
-            setTickets(fetchedTickets);
-            if (fetchedTickets.length > 0) {
-                setSelectedTicket(fetchedTickets[0]);
-            }
-        } else {
-            console.warn("La respuesta de la API no contiene un array de tickets:", apiResponse);
-            setTickets([]);
-        }
-      } catch (err) {
-        console.error('Error fetching tickets:', err);
-        setError('No se pudieron cargar los tickets.');
+      if (Array.isArray(fetchedTickets)) {
+        setTickets(fetchedTickets);
+        setSelectedTicket((prev) => prev ?? (fetchedTickets[0] || null));
+      } else {
+        console.warn("La respuesta de la API no contiene un array de tickets:", apiResponse);
         setTickets([]);
-      } finally {
-        setLoading(false);
       }
-    };
-
-    fetchTickets();
+    } catch (err) {
+      console.error('Error fetching tickets:', err);
+      setError('No se pudieron cargar los tickets.');
+      setTickets([]);
+    } finally {
+      setLoading(false);
+    }
   }, []);
+
+  useEffect(() => {
+    setLoading(true);
+    fetchTickets();
+  }, [fetchTickets]);
+
+  useTicketUpdates({ onNewTicket: fetchTickets });
 
   const selectTicket = (ticketId: number | null) => {
     if (ticketId === null) {

--- a/src/context/TicketContext.tsx
+++ b/src/context/TicketContext.tsx
@@ -1,7 +1,6 @@
 import React, { createContext, useState, useContext, useEffect, ReactNode, useCallback } from 'react';
 import { Ticket } from '@/types/tickets';
 import { getTickets } from '@/services/ticketService';
-import { toast } from 'sonner';
 import useTicketUpdates from '@/hooks/useTicketUpdates';
 
 interface TicketContextType {
@@ -59,8 +58,6 @@ export const TicketProvider: React.FC<{ children: ReactNode }> = ({ children }) 
     fetchTickets();
   }, [fetchTickets]);
 
-  useTicketUpdates({ onNewTicket: fetchTickets });
-
   const selectTicket = (ticketId: number | null) => {
     if (ticketId === null) {
         setSelectedTicket(null);
@@ -80,6 +77,13 @@ export const TicketProvider: React.FC<{ children: ReactNode }> = ({ children }) 
       setSelectedTicket(prev => prev ? { ...prev, ...updates } : null);
     }
   };
+
+  useTicketUpdates({
+    onNewTicket: fetchTickets,
+    onNewComment: (data) => {
+      updateTicket(data.ticketId, { estado: data.estado });
+    },
+  });
 
   const ticketsByCategory = groupTicketsByCategory(tickets);
 

--- a/src/hooks/useTicketUpdates.tsx
+++ b/src/hooks/useTicketUpdates.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { io, Socket } from 'socket.io-client';
 import { toast } from '@/components/ui/use-toast';
 import { useUser } from './useUser';
@@ -21,7 +21,17 @@ const SOCKET_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000';
 
 export default function useTicketUpdates(options: UseTicketUpdatesOptions = {}) {
   const { onNewTicket, onNewComment } = options;
+  const newTicketRef = useRef<UseTicketUpdatesOptions['onNewTicket']>(onNewTicket);
+  const newCommentRef = useRef<UseTicketUpdatesOptions['onNewComment']>(onNewComment);
   const { user } = useUser();
+
+  useEffect(() => {
+    newTicketRef.current = onNewTicket;
+  }, [onNewTicket]);
+
+  useEffect(() => {
+    newCommentRef.current = onNewComment;
+  }, [onNewComment]);
 
   useEffect(() => {
     if (!user) return;
@@ -36,14 +46,14 @@ export default function useTicketUpdates(options: UseTicketUpdatesOptions = {}) 
       console.log('Socket.io disconnected');
     };
     const handleNewTicket = (data: any) => {
-      onNewTicket?.(data);
+      newTicketRef.current?.(data);
       toast({
         title: `Nuevo Ticket #${data.nro_ticket}`,
         description: data.asunto,
       });
     };
     const handleNewComment = (data: any) => {
-      onNewComment?.(data);
+      newCommentRef.current?.(data);
       toast({
         title: `Nuevo Comentario en Ticket #${data.ticketId}`,
         description: data.comment.comentario,
@@ -93,5 +103,5 @@ export default function useTicketUpdates(options: UseTicketUpdatesOptions = {}) 
         socket.disconnect();
       }
     };
-  }, [user, onNewTicket, onNewComment]);
+  }, [user]);
 }

--- a/src/hooks/useTicketUpdates.tsx
+++ b/src/hooks/useTicketUpdates.tsx
@@ -11,10 +11,16 @@ interface TicketUpdate {
   mensaje?: string | null;
 }
 
+interface UseTicketUpdatesOptions {
+  onNewTicket?: (data: any) => void;
+  onNewComment?: (data: any) => void;
+}
+
 // Asegúrate de que esta URL coincida con tu servidor de Socket.io
 const SOCKET_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000';
 
-export default function useTicketUpdates() {
+export default function useTicketUpdates(options: UseTicketUpdatesOptions = {}) {
+  const { onNewTicket, onNewComment } = options;
   const { user } = useUser();
 
   useEffect(() => {
@@ -44,12 +50,14 @@ export default function useTicketUpdates() {
           console.log('Socket.io disconnected');
         };
         const handleNewTicket = (data: any) => {
+          onNewTicket?.(data);
           toast({
             title: `Nuevo Ticket #${data.nro_ticket}`,
             description: data.asunto,
           });
         };
         const handleNewComment = (data: any) => {
+          onNewComment?.(data);
           toast({
             title: `Nuevo Comentario en Ticket #${data.ticketId}`,
             description: data.comment.comentario,

--- a/src/hooks/useTicketUpdates.tsx
+++ b/src/hooks/useTicketUpdates.tsx
@@ -27,11 +27,8 @@ export default function useTicketUpdates(options: UseTicketUpdatesOptions = {}) 
 
   useEffect(() => {
     newTicketRef.current = onNewTicket;
-  }, [onNewTicket]);
-
-  useEffect(() => {
     newCommentRef.current = onNewComment;
-  }, [onNewComment]);
+  }, [onNewTicket, onNewComment]);
 
   useEffect(() => {
     if (!user) return;

--- a/src/hooks/useTicketUpdates.tsx
+++ b/src/hooks/useTicketUpdates.tsx
@@ -25,10 +25,14 @@ export default function useTicketUpdates(options: UseTicketUpdatesOptions = {}) 
   const newCommentRef = useRef<UseTicketUpdatesOptions['onNewComment']>(onNewComment);
   const { user } = useUser();
 
+  // Keep listeners synced with the latest callbacks without re-subscribing
   useEffect(() => {
     newTicketRef.current = onNewTicket;
+  }, [onNewTicket]);
+
+  useEffect(() => {
     newCommentRef.current = onNewComment;
-  }, [onNewTicket, onNewComment]);
+  }, [onNewComment]);
 
   useEffect(() => {
     if (!user) return;

--- a/src/hooks/useTicketUpdates.tsx
+++ b/src/hooks/useTicketUpdates.tsx
@@ -29,6 +29,31 @@ export default function useTicketUpdates(options: UseTicketUpdatesOptions = {}) 
     let socket: Socket | null = null;
     let active = true;
 
+    const handleConnect = () => {
+      console.log('Socket.io connected successfully');
+    };
+    const handleDisconnect = () => {
+      console.log('Socket.io disconnected');
+    };
+    const handleNewTicket = (data: any) => {
+      onNewTicket?.(data);
+      toast({
+        title: `Nuevo Ticket #${data.nro_ticket}`,
+        description: data.asunto,
+      });
+    };
+    const handleNewComment = (data: any) => {
+      onNewComment?.(data);
+      toast({
+        title: `Nuevo Comentario en Ticket #${data.ticketId}`,
+        description: data.comment.comentario,
+      });
+    };
+    const handleConnectError = (err: any) => {
+      console.error('Socket.io connection error:', err);
+      socket?.close();
+    };
+
     const initSocket = async () => {
       try {
         // Opcional: Verifica si el usuario tiene activadas las notificaciones
@@ -42,31 +67,6 @@ export default function useTicketUpdates(options: UseTicketUpdatesOptions = {}) 
         });
 
         assertEventSource(socket, 'ticket-socket');
-
-        const handleConnect = () => {
-          console.log('Socket.io connected successfully');
-        };
-        const handleDisconnect = () => {
-          console.log('Socket.io disconnected');
-        };
-        const handleNewTicket = (data: any) => {
-          onNewTicket?.(data);
-          toast({
-            title: `Nuevo Ticket #${data.nro_ticket}`,
-            description: data.asunto,
-          });
-        };
-        const handleNewComment = (data: any) => {
-          onNewComment?.(data);
-          toast({
-            title: `Nuevo Comentario en Ticket #${data.ticketId}`,
-            description: data.comment.comentario,
-          });
-        };
-        const handleConnectError = (err: any) => {
-          console.error('Socket.io connection error:', err);
-          socket?.close();
-        };
 
         safeOn(socket, 'connect', handleConnect);
         safeOn(socket, 'disconnect', handleDisconnect);
@@ -93,5 +93,5 @@ export default function useTicketUpdates(options: UseTicketUpdatesOptions = {}) 
         socket.disconnect();
       }
     };
-  }, [user]);
+  }, [user, onNewTicket, onNewComment]);
 }


### PR DESCRIPTION
## Summary
- allow ticket update hook to accept callbacks for new events
- reload ticket list whenever a new ticket arrives via socket

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b255d24cf08322af1a4cacfc5b47f6