### PR TITLE
feat: add agenda paste form with parser

### DIFF
--- a/docs/agenda-paste.md
+++ b/docs/agenda-paste.md
@@ -1,0 +1,14 @@
+# Agenda Paste Form
+
+Allows administrators to paste a full agenda message in WhatsApp format and submit it for bulk creation of events and news.
+
+```
+*AGENDA MUNICIPAL*
+
+*Jueves 28*
+🕑9.30 hs.
+✅Entrega de reconocimientos a los cuatro primeros Presidentes del HCD en democracia.
+📍HCD
+```
+
+The parser splits each day and extracts time, title and location lines.

--- a/src/components/admin/AgendaPasteForm.tsx
+++ b/src/components/admin/AgendaPasteForm.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import { Loader2 } from 'lucide-react';
+import { parseAgendaText } from '@/utils/agendaParser';
+import { apiFetch, getErrorMessage } from '@/utils/api';
+import { toast } from '@/components/ui/use-toast';
+
+interface AgendaPasteFormProps {
+  onCancel: () => void;
+}
+
+export const AgendaPasteForm: React.FC<AgendaPasteFormProps> = ({ onCancel }) => {
+  const [text, setText] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setIsSubmitting(true);
+    try {
+      const agenda = parseAgendaText(text);
+      await apiFetch('/municipal/posts/bulk', {
+        method: 'POST',
+        body: JSON.stringify(agenda),
+        headers: { 'Content-Type': 'application/json' },
+      });
+      toast({ title: 'Éxito', description: 'La agenda ha sido procesada correctamente.' });
+      onCancel();
+    } catch (error) {
+      toast({
+        variant: 'destructive',
+        title: 'Error al procesar la agenda',
+        description: getErrorMessage(error, 'No se pudo procesar la agenda. Intenta de nuevo.'),
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <Textarea
+        placeholder="Pega aquí el texto completo de la agenda..."
+        className="min-h-[300px] resize-y"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+      />
+      <div className="flex justify-end gap-4">
+        <Button type="button" variant="ghost" onClick={onCancel} disabled={isSubmitting}>
+          Cancelar
+        </Button>
+        <Button type="submit" disabled={isSubmitting || !text.trim()}>
+          {isSubmitting ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Procesando...
+            </>
+          ) : (
+            'Procesar Agenda'
+          )}
+        </Button>
+      </div>
+    </form>
+  );
+};
+
+export default AgendaPasteForm;

--- a/src/pages/Perfil.tsx
+++ b/src/pages/Perfil.tsx
@@ -23,6 +23,7 @@ import {
   Loader2, // Icono de carga
 } from "lucide-react";
 import { EventForm } from "@/components/admin/EventForm";
+import { AgendaPasteForm } from "@/components/admin/AgendaPasteForm";
 import MunicipioIcon from "@/components/ui/MunicipioIcon";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
@@ -52,6 +53,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { toast } from "@/components/ui/use-toast";
 import { cn } from "@/lib/utils";
 import LocationMap from "@/components/LocationMap";
@@ -1504,53 +1506,64 @@ export default function Perfil() {
             </DialogDescription>
           </DialogHeader>
           <div className="py-4 max-h-[70vh] overflow-y-auto px-2">
-            <EventForm
-              onCancel={() => setIsEventModalOpen(false)}
-              isSubmitting={isSubmittingEvent}
-              onSubmit={async (values) => {
-                setIsSubmittingEvent(true);
-                try {
-                  const formData = new FormData();
+            <Tabs defaultValue="form">
+              <TabsList className="mb-4 grid w-full grid-cols-2">
+                <TabsTrigger value="form">Formulario</TabsTrigger>
+                <TabsTrigger value="paste">Pegar Información</TabsTrigger>
+              </TabsList>
+              <TabsContent value="form">
+                <EventForm
+                  onCancel={() => setIsEventModalOpen(false)}
+                  isSubmitting={isSubmittingEvent}
+                  onSubmit={async (values) => {
+                    setIsSubmittingEvent(true);
+                    try {
+                      const formData = new FormData();
 
-                  // Map frontend form values to backend field names and append them
-                  formData.append('titulo', values.title);
-                  if (values.subtitle) formData.append('subtitulo', values.subtitle);
-                  if (values.description) formData.append('contenido', values.description);
-                  formData.append('tipo_post', values.tipo_post);
-                  if (values.imageUrl) formData.append('imagen_url', values.imageUrl);
-                  if (values.startDate) formData.append('fecha_evento_inicio', values.startDate.toISOString());
-                  if (values.endDate) formData.append('fecha_evento_fin', values.endDate.toISOString());
+                      // Map frontend form values to backend field names and append them
+                      formData.append('titulo', values.title);
+                      if (values.subtitle) formData.append('subtitulo', values.subtitle);
+                      if (values.description) formData.append('contenido', values.description);
+                      formData.append('tipo_post', values.tipo_post);
+                      if (values.imageUrl) formData.append('imagen_url', values.imageUrl);
+                      if (values.startDate) formData.append('fecha_evento_inicio', values.startDate.toISOString());
+                      if (values.endDate) formData.append('fecha_evento_fin', values.endDate.toISOString());
 
-                  // Append the file if it exists
-                  if (values.flyer && values.flyer.length > 0) {
-                    // Assuming the backend will expect the file under the key 'flyer_image'
-                    formData.append('flyer_image', values.flyer[0]);
-                  }
+                      // Append the file if it exists
+                      if (values.flyer && values.flyer.length > 0) {
+                        // Assuming the backend will expect the file under the key 'flyer_image'
+                        formData.append('flyer_image', values.flyer[0]);
+                      }
 
-                  // Use the endpoint provided by the backend team
-                  await apiFetch('/municipal/posts', {
-                    method: 'POST',
-                    body: formData, // apiFetch will handle the Content-Type
-                  });
+                      // Use the endpoint provided by the backend team
+                      await apiFetch('/municipal/posts', {
+                        method: 'POST',
+                        body: formData, // apiFetch will handle the Content-Type
+                      });
 
-                  toast({
-                    title: "Éxito",
-                    description: "El evento/noticia ha sido creado correctamente.",
-                  });
+                      toast({
+                        title: "Éxito",
+                        description: "El evento/noticia ha sido creado correctamente.",
+                      });
 
-                  setIsEventModalOpen(false);
+                      setIsEventModalOpen(false);
 
-                } catch (error) {
-                  toast({
-                    variant: "destructive",
-                    title: "Error al crear el evento",
-                    description: getErrorMessage(error, "No se pudo guardar el evento. Intenta de nuevo."),
-                  });
-                } finally {
-                  setIsSubmittingEvent(false);
-                }
-              }}
-            />
+                    } catch (error) {
+                      toast({
+                        variant: "destructive",
+                        title: "Error al crear el evento",
+                        description: getErrorMessage(error, "No se pudo guardar el evento. Intenta de nuevo."),
+                      });
+                    } finally {
+                      setIsSubmittingEvent(false);
+                    }
+                  }}
+                />
+              </TabsContent>
+              <TabsContent value="paste">
+                <AgendaPasteForm onCancel={() => setIsEventModalOpen(false)} />
+              </TabsContent>
+            </Tabs>
           </div>
         </DialogContent>
       </Dialog>

--- a/src/utils/agendaParser.ts
+++ b/src/utils/agendaParser.ts
@@ -1,0 +1,67 @@
+export interface AgendaEvent {
+  time: string;
+  title: string;
+  location: string;
+}
+
+export interface AgendaDay {
+  day: string;
+  events: AgendaEvent[];
+}
+
+export interface Agenda {
+  title: string;
+  days: AgendaDay[];
+}
+
+// Parse agenda text pasted from WhatsApp style messages
+export function parseAgendaText(raw: string): Agenda {
+  const lines = raw
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+
+  let title = "";
+  const days: AgendaDay[] = [];
+  let currentDay: AgendaDay | null = null;
+
+  const isDayLine = (line: string) => line.startsWith("*") && line.endsWith("*");
+
+  const stripEmojis = (line: string, emoji: string) =>
+    line.startsWith(emoji) ? line.slice(emoji.length).trim() : line.trim();
+
+  const stripStars = (line: string) => line.replace(/^\*+|\*+$/g, "").trim();
+
+  for (let i = 0; i < lines.length; ) {
+    const line = lines[i];
+
+    if (!title) {
+      title = stripStars(line);
+      i++;
+      continue;
+    }
+
+    if (isDayLine(line)) {
+      currentDay = { day: stripStars(line), events: [] };
+      days.push(currentDay);
+      i++;
+      continue;
+    }
+
+    if (line.startsWith("🕑")) {
+      const time = stripEmojis(line, "🕑").replace(/hs?\.?$/, "").trim();
+      const titleLine = lines[i + 1] ? stripEmojis(lines[i + 1], "✅") : "";
+      const locationLine = lines[i + 2] ? stripEmojis(lines[i + 2], "📍") : "";
+
+      if (currentDay) {
+        currentDay.events.push({ time, title: titleLine, location: locationLine });
+      }
+      i += 3;
+      continue;
+    }
+
+    i++;
+  }
+
+  return { title, days };
+}

--- a/tests/agendaParser.test.ts
+++ b/tests/agendaParser.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { parseAgendaText } from '../src/utils/agendaParser';
+
+const sample = [
+  '*AGENDA MUNICIPAL*',
+  '',
+  '*Jueves 28*',
+  '',
+  '🕑9.30 hs.',
+  '✅Entrega de reconocimientos a los cuatro primeros Presidentes del HCD en democracia.',
+  '📍HCD',
+  '',
+  '*Viernes 29*',
+  '🕑10.00 hs.',
+  '✅Expo Educativa 2026',
+  '📍Centro Universitario del Este',
+  '',
+  '🕑18.30 hs.',
+  '✅Capacitación Internacional "Taller de Juegos" (para docentes de jardines maternales)',
+  '📍Casa del Bicentenario',
+  '',
+  '*Sábado 30*',
+  '🕑11.30 hs.',
+  '✅Entrega de Certificados del Curso de Lengua de Señas',
+  '📍Centro Universitario del Este',
+  '',
+  '*Domingo 31*',
+  '🕑9.00 a 16.00 hs.',
+  '✅Encuentro Femenino de Vóley',
+  '📍Polideportivo Posta El Retamo',
+  '',
+  '🕑10.00 hs.',
+  '✅Torneo de Fútbol "Desafío Libertadores"',
+  '📍Club Social y Deportivo Los Barriales',
+].join('\n');
+
+describe('parseAgendaText', () => {
+  const result = parseAgendaText(sample);
+
+  it('extracts title', () => {
+    expect(result.title).toBe('AGENDA MUNICIPAL');
+  });
+
+  it('parses days and events count', () => {
+    expect(result.days).toHaveLength(4);
+    expect(result.days[0].day).toBe('Jueves 28');
+    expect(result.days[0].events).toHaveLength(1);
+  });
+
+  it('parses event details', () => {
+    const event = result.days[0].events[0];
+    expect(event).toEqual({
+      time: '9.30',
+      title: 'Entrega de reconocimientos a los cuatro primeros Presidentes del HCD en democracia.',
+      location: 'HCD',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- allow pasting WhatsApp-style agendas and submit them in bulk via new AgendaPasteForm
- parse pasted agenda text into structured days and events
- integrate paste option into profile modal alongside existing event/news form
- document how to use the paste workflow

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/maplibre-gl)
- `npm test` (fails: vitest: not found)


------
https://chatgpt.com/codex/tasks/task_e_68b25947388883228273f39b3d73867e