### PR TITLE
feat: add agenda paste tab with map-based autocomplete

### DIFF
--- a/docs/agenda-paste.md
+++ b/docs/agenda-paste.md
@@ -1,0 +1,14 @@
+# Agenda Paste Form
+
+Allows administrators to paste a full agenda message in WhatsApp format and submit it for bulk creation of events and news. The profile modal now includes a third tab labeled "Pegar Información" alongside the traditional "Evento" and "Noticia" forms.
+
+```
+*AGENDA MUNICIPAL*
+
+*Jueves 28*
+🕑9.30 hs.
+✅Entrega de reconocimientos a los cuatro primeros Presidentes del HCD en democracia.
+📍HCD
+```
+
+The parser splits each day and extracts time, title and location lines.

--- a/src/components/admin/AgendaPasteForm.tsx
+++ b/src/components/admin/AgendaPasteForm.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import { Loader2 } from 'lucide-react';
+import { parseAgendaText } from '@/utils/agendaParser';
+import { apiFetch, getErrorMessage } from '@/utils/api';
+import { toast } from '@/components/ui/use-toast';
+
+interface AgendaPasteFormProps {
+  onCancel: () => void;
+}
+
+export const AgendaPasteForm: React.FC<AgendaPasteFormProps> = ({ onCancel }) => {
+  const [text, setText] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setIsSubmitting(true);
+    try {
+      const agenda = parseAgendaText(text);
+      await apiFetch('/municipal/posts/bulk', {
+        method: 'POST',
+        body: JSON.stringify(agenda),
+        headers: { 'Content-Type': 'application/json' },
+      });
+      toast({ title: 'Éxito', description: 'La agenda ha sido procesada correctamente.' });
+      onCancel();
+    } catch (error) {
+      toast({
+        variant: 'destructive',
+        title: 'Error al procesar la agenda',
+        description: getErrorMessage(error, 'No se pudo procesar la agenda. Intenta de nuevo.'),
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <Textarea
+        placeholder="Pega aquí el texto completo de la agenda..."
+        className="min-h-[300px] resize-y"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+      />
+      <div className="flex justify-end gap-4">
+        <Button type="button" variant="ghost" onClick={onCancel} disabled={isSubmitting}>
+          Cancelar
+        </Button>
+        <Button type="submit" disabled={isSubmitting || !text.trim()}>
+          {isSubmitting ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Procesando...
+            </>
+          ) : (
+            'Procesar Agenda'
+          )}
+        </Button>
+      </div>
+    </form>
+  );
+};
+
+export default AgendaPasteForm;

--- a/src/components/admin/EventForm.tsx
+++ b/src/components/admin/EventForm.tsx
@@ -59,16 +59,17 @@ interface EventFormProps {
   onCancel: () => void;
   isSubmitting?: boolean;
   initialData?: Partial<EventFormValues>;
+  fixedTipoPost?: 'noticia' | 'evento';
 }
 
-export const EventForm: React.FC<EventFormProps> = ({ onSubmit, onCancel, isSubmitting, initialData }) => {
+export const EventForm: React.FC<EventFormProps> = ({ onSubmit, onCancel, isSubmitting, initialData, fixedTipoPost }) => {
   const form = useForm<EventFormValues>({
     resolver: zodResolver(eventFormSchema),
     defaultValues: {
       title: '',
       subtitle: '',
       description: '',
-      tipo_post: 'noticia',
+      tipo_post: fixedTipoPost || 'noticia',
       startDate: undefined,
       endDate: undefined,
       location: { address: '' },
@@ -86,27 +87,29 @@ export const EventForm: React.FC<EventFormProps> = ({ onSubmit, onCancel, isSubm
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(handleFormSubmit)} className="space-y-6">
-        <FormField
-          control={form.control}
-          name="tipo_post"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Tipo de Publicación</FormLabel>
-              <Select onValueChange={field.onChange} defaultValue={field.value}>
-                <FormControl>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Selecciona un tipo" />
-                  </SelectTrigger>
-                </FormControl>
-                <SelectContent>
-                  <SelectItem value="noticia">Noticia</SelectItem>
-                  <SelectItem value="evento">Evento</SelectItem>
-                </SelectContent>
-              </Select>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+        {!fixedTipoPost && (
+          <FormField
+            control={form.control}
+            name="tipo_post"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Tipo de Publicación</FormLabel>
+                <Select onValueChange={field.onChange} defaultValue={field.value}>
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Selecciona un tipo" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    <SelectItem value="noticia">Noticia</SelectItem>
+                    <SelectItem value="evento">Evento</SelectItem>
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        )}
         <FormField
           control={form.control}
           name="title"
@@ -233,7 +236,7 @@ export const EventForm: React.FC<EventFormProps> = ({ onSubmit, onCancel, isSubm
                       placeholder="Ej: Parque San Martín, Mendoza"
                       onSelect={(address) => controllerField.onChange(address)}
                       value={controllerField.value ? { label: controllerField.value, value: controllerField.value } : null}
-                      onChange={(option) => controllerField.onChange(option ? option.label : '')}
+                      onChange={(option) => controllerField.onChange(option ? option.value : '')}
                     />
                   )}
                 />

--- a/src/components/ui/AddressAutocomplete.tsx
+++ b/src/components/ui/AddressAutocomplete.tsx
@@ -1,26 +1,20 @@
-import React, { useEffect, useState } from "react";
-import GooglePlacesAutocomplete from "react-google-places-autocomplete";
+import React, { useEffect, useRef, useState } from "react";
 import { Input } from "./input";
 import { safeLocalStorage } from "@/utils/safeLocalStorage";
 
 interface AddressAutocompleteProps {
   onSelect: (address: string) => void;
-  value?: any;
-  onChange?: (option: any | null) => void;
+  value?: { label: string; value: string } | null;
+  onChange?: (option: { label: string; value: string } | null) => void;
   placeholder?: string;
   className?: string;
   autoFocus?: boolean;
-  /**
-   * If provided, the selected address will be persisted in localStorage
-   * using this key. The stored value will also be used as the initial value
-   * when the component mounts.
-   */
   persistKey?: string;
   readOnly?: boolean;
   disabled?: boolean;
 }
 
-const Maps_API_KEY = import.meta.env.VITE_Maps_API_KEY || "";
+const MAPTILER_KEY = import.meta.env.VITE_MAPTILER_KEY || "";
 
 const AddressAutocomplete: React.FC<AddressAutocompleteProps> = ({
   onSelect,
@@ -33,33 +27,21 @@ const AddressAutocomplete: React.FC<AddressAutocompleteProps> = ({
   readOnly = false,
   disabled = false,
 }) => {
-  const [internalValue, setInternalValue] = useState<any>(value || null);
-  const [scriptLoaded, setScriptLoaded] = useState<boolean>(false);
-  const [tempInput, setTempInput] = useState<string>("");
+  const [query, setQuery] = useState(value?.label || "");
+  const [options, setOptions] = useState<string[]>([]);
+  const [open, setOpen] = useState(false);
+  const committedRef = useRef(false);
 
-  // Ensure Google Maps script loads with async attribute
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    if ((window as any).google) {
-      setScriptLoaded(true);
-      return;
-    }
-
-    const existing = document.getElementById("chatboc-google-maps");
-    if (existing) {
-      existing.addEventListener("load", () => setScriptLoaded(true));
-      return;
-    }
-
-    const s = document.createElement("script");
-    s.id = "chatboc-google-maps";
-
-    s.src = `https://maps.googleapis.com/maps/api/js?key=${Maps_API_KEY}&libraries=places,marker&loading=async`;
-    s.async = true;
-    s.onload = () => setScriptLoaded(true);
-    s.onerror = () => setScriptLoaded(false);
-    document.head.appendChild(s);
-  }, []);
+  const commit = (val: string) => {
+    const trimmed = val.trim();
+    if (!trimmed) return;
+    const obj = { label: trimmed, value: trimmed };
+    setQuery(trimmed);
+    if (persistKey) safeLocalStorage.setItem(persistKey, trimmed);
+    onChange?.(obj);
+    onSelect(trimmed);
+    committedRef.current = true;
+  };
 
   // Load from storage on mount if persistKey provided
   useEffect(() => {
@@ -67,8 +49,8 @@ const AddressAutocomplete: React.FC<AddressAutocompleteProps> = ({
       const stored = safeLocalStorage.getItem(persistKey);
       if (stored) {
         const opt = { label: stored, value: stored };
-        setInternalValue(opt);
-        if (onChange) onChange(opt);
+        setQuery(stored);
+        onChange?.(opt);
         onSelect(stored);
       }
     }
@@ -77,135 +59,99 @@ const AddressAutocomplete: React.FC<AddressAutocompleteProps> = ({
 
   // Sync when parent value changes
   useEffect(() => {
-    if (value !== undefined) {
-      setInternalValue(value);
+    if (value) {
+      setQuery(value.label || value.value);
+    } else {
+      setQuery("");
     }
   }, [value]);
-  const googlePlacesAvailable =
-    typeof window !== "undefined" &&
-    (window as any).google?.maps?.places !== undefined;
+
+  // Fetch suggestions from MapTiler
+  useEffect(() => {
+    if (!MAPTILER_KEY || query.trim().length < 3) {
+      setOptions([]);
+      return;
+    }
+    const controller = new AbortController();
+    fetch(
+      `https://api.maptiler.com/geocoding/${encodeURIComponent(query)}.json?key=${MAPTILER_KEY}&language=es&limit=5`,
+      { signal: controller.signal }
+    )
+      .then((r) => r.json())
+      .then((data) => {
+        const feats = Array.isArray(data?.features) ? data.features : [];
+        const opts = feats
+          .map(
+            (f: any) =>
+              f.place_name ||
+              f.text ||
+              f.properties?.name ||
+              f.properties?.address ||
+              f.properties?.formatted
+          )
+          .filter(Boolean);
+        setOptions(opts);
+      })
+      .catch(() => {});
+    return () => controller.abort();
+  }, [query]);
 
   if (readOnly || disabled) {
     return (
       <Input
-        value={internalValue?.label || internalValue?.value || ""}
+        value={query}
         readOnly
+        disabled={disabled}
         placeholder={placeholder}
         className={className}
       />
     );
   }
 
-  if (!Maps_API_KEY || !scriptLoaded || !googlePlacesAvailable) {
-    return (
+  return (
+    <div className="relative">
       <Input
-        placeholder="Ingrese dirección"
+        value={query}
+        onChange={(e) => {
+          const val = e.target.value;
+          setQuery(val);
+          onChange?.(val ? { label: val, value: val } : null);
+        }}
+        placeholder={placeholder}
         className={className}
         autoFocus={autoFocus}
-        value={tempInput}
-        onChange={(e) => setTempInput(e.currentTarget.value)}
+        onFocus={() => setOpen(true)}
         onKeyDown={(e) => {
-          if (e.key === "Enter" && e.currentTarget.value.trim()) {
-            onSelect(e.currentTarget.value.trim());
+          if (e.key === "Enter") {
+            commit(query);
+            setOpen(false);
           }
         }}
-        onBlur={(e) => {
-          const val = e.currentTarget.value.trim();
-          setTempInput(val);
-          if (val) onSelect(val);
+        onBlur={() => {
+          if (!committedRef.current) {
+            commit(query);
+          }
+          committedRef.current = false;
+          setTimeout(() => setOpen(false), 100);
         }}
       />
-    );
-  }
-
-  return (
-    <GooglePlacesAutocomplete
-      autocompletionRequest={{
-        componentRestrictions: { country: "ar" },
-        types: ["address"],
-      }}
-      selectProps={{
-        value: internalValue,
-        isDisabled: readOnly || disabled,
-        onChange: (option: any) => {
-          setInternalValue(option);
-          const selected =
-            typeof option?.value === "string"
-              ? option.value
-              : option?.value?.description;
-          if (persistKey) {
-            if (selected) {
-              safeLocalStorage.setItem(persistKey, selected);
-            } else {
-              safeLocalStorage.removeItem(persistKey);
-            }
-          }
-          if (onChange) onChange(option);
-          if (selected) {
-            onSelect(selected);
-          }
-        },
-        onBlur: (e: any) => {
-          const val = (e.target as HTMLInputElement).value;
-          if (val) {
-            const opt = { label: val, value: val };
-            if (persistKey) safeLocalStorage.setItem(persistKey, val);
-            setInternalValue(opt);
-            if (onChange) onChange(opt);
-            onSelect(val);
-          }
-        },
-        placeholder,
-        isClearable: true,
-        autoFocus,
-        className,
-        styles: {
-          control: (base: any) => ({
-            ...base,
-            backgroundColor: "hsl(var(--input))",
-            color: "hsl(var(--foreground))",
-            minHeight: "2.5rem",
-            borderRadius: "0.75rem",
-            borderColor: "hsl(var(--border))",
-            fontSize: "0.95rem",
-          }),
-          menu: (base: any) => ({
-            ...base,
-            backgroundColor: "hsl(var(--card))",
-            color: "hsl(var(--foreground))",
-            zIndex: 999999,
-          }),
-          option: (base: any, state: any) => ({
-            ...base,
-            backgroundColor: state.isFocused
-              ? "hsl(var(--accent))"
-              : "hsl(var(--card))",
-            color: "hsl(var(--foreground))",
-            cursor: "pointer",
-          }),
-          singleValue: (base: any) => ({
-            ...base,
-            color: "hsl(var(--foreground))",
-          }),
-          input: (base: any) => ({
-            ...base,
-            color: "hsl(var(--foreground))",
-          }),
-          placeholder: (base: any) => ({
-            ...base,
-            color: "hsl(var(--muted-foreground))",
-            fontWeight: 600,
-          }),
-        },
-        onKeyDown: (e: any) => {
-          if (e.key === "Enter" && e.target.value) {
-            const val = e.target.value;
-            if (persistKey) safeLocalStorage.setItem(persistKey, val);
-            onSelect(val);
-          }
-        },
-      }}
-    />
+      {open && options.length > 0 && (
+        <ul className="absolute z-10 w-full bg-card border border-border rounded-md mt-1 max-h-60 overflow-auto">
+          {options.map((opt) => (
+            <li
+              key={opt}
+              className="px-3 py-2 cursor-pointer hover:bg-accent"
+              onMouseDown={() => {
+                commit(opt);
+                setOpen(false);
+              }}
+            >
+              {opt}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
   );
 };
 

--- a/src/pages/Perfil.tsx
+++ b/src/pages/Perfil.tsx
@@ -23,6 +23,7 @@ import {
   Loader2, // Icono de carga
 } from "lucide-react";
 import { EventForm } from "@/components/admin/EventForm";
+import { AgendaPasteForm } from "@/components/admin/AgendaPasteForm";
 import MunicipioIcon from "@/components/ui/MunicipioIcon";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
@@ -52,6 +53,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { toast } from "@/components/ui/use-toast";
 import { cn } from "@/lib/utils";
 import LocationMap from "@/components/LocationMap";
@@ -148,6 +150,46 @@ export default function Perfil() {
   const [horariosOpen, setHorariosOpen] = useState(false);
   const [isEventModalOpen, setIsEventModalOpen] = useState(false);
   const [isSubmittingEvent, setIsSubmittingEvent] = useState(false);
+
+  const handleSubmitPost = async (values: any) => {
+    setIsSubmittingEvent(true);
+    try {
+      const formData = new FormData();
+
+      formData.append('titulo', values.title);
+      if (values.subtitle) formData.append('subtitulo', values.subtitle);
+      if (values.description) formData.append('contenido', values.description);
+      formData.append('tipo_post', values.tipo_post);
+      if (values.imageUrl) formData.append('imagen_url', values.imageUrl);
+      if (values.startDate) formData.append('fecha_evento_inicio', values.startDate.toISOString());
+      if (values.endDate) formData.append('fecha_evento_fin', values.endDate.toISOString());
+      if (values.location?.address) formData.append('direccion', values.location.address);
+
+      if (values.flyer && values.flyer.length > 0) {
+        formData.append('flyer_image', values.flyer[0]);
+      }
+
+      await apiFetch('/municipal/posts', {
+        method: 'POST',
+        body: formData,
+      });
+
+      toast({
+        title: "Éxito",
+        description: "El evento/noticia ha sido creado correctamente.",
+      });
+
+      setIsEventModalOpen(false);
+    } catch (error) {
+      toast({
+        variant: "destructive",
+        title: "Error al crear el evento",
+        description: getErrorMessage(error, "No se pudo guardar el evento. Intenta de nuevo."),
+      });
+    } finally {
+      setIsSubmittingEvent(false);
+    }
+  };
   const [ticketLocations, setTicketLocations] = useState<TicketLocation[]>([]);
   const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
   const [selectedBarrios, setSelectedBarrios] = useState<string[]>([]);
@@ -1504,53 +1546,32 @@ export default function Perfil() {
             </DialogDescription>
           </DialogHeader>
           <div className="py-4 max-h-[70vh] overflow-y-auto px-2">
-            <EventForm
-              onCancel={() => setIsEventModalOpen(false)}
-              isSubmitting={isSubmittingEvent}
-              onSubmit={async (values) => {
-                setIsSubmittingEvent(true);
-                try {
-                  const formData = new FormData();
-
-                  // Map frontend form values to backend field names and append them
-                  formData.append('titulo', values.title);
-                  if (values.subtitle) formData.append('subtitulo', values.subtitle);
-                  if (values.description) formData.append('contenido', values.description);
-                  formData.append('tipo_post', values.tipo_post);
-                  if (values.imageUrl) formData.append('imagen_url', values.imageUrl);
-                  if (values.startDate) formData.append('fecha_evento_inicio', values.startDate.toISOString());
-                  if (values.endDate) formData.append('fecha_evento_fin', values.endDate.toISOString());
-
-                  // Append the file if it exists
-                  if (values.flyer && values.flyer.length > 0) {
-                    // Assuming the backend will expect the file under the key 'flyer_image'
-                    formData.append('flyer_image', values.flyer[0]);
-                  }
-
-                  // Use the endpoint provided by the backend team
-                  await apiFetch('/municipal/posts', {
-                    method: 'POST',
-                    body: formData, // apiFetch will handle the Content-Type
-                  });
-
-                  toast({
-                    title: "Éxito",
-                    description: "El evento/noticia ha sido creado correctamente.",
-                  });
-
-                  setIsEventModalOpen(false);
-
-                } catch (error) {
-                  toast({
-                    variant: "destructive",
-                    title: "Error al crear el evento",
-                    description: getErrorMessage(error, "No se pudo guardar el evento. Intenta de nuevo."),
-                  });
-                } finally {
-                  setIsSubmittingEvent(false);
-                }
-              }}
-            />
+            <Tabs defaultValue="event">
+              <TabsList className="mb-4 grid w-full grid-cols-3">
+                <TabsTrigger value="event">Evento</TabsTrigger>
+                <TabsTrigger value="news">Noticia</TabsTrigger>
+                <TabsTrigger value="paste">Pegar Información</TabsTrigger>
+              </TabsList>
+              <TabsContent value="event">
+                <EventForm
+                  fixedTipoPost="evento"
+                  onCancel={() => setIsEventModalOpen(false)}
+                  isSubmitting={isSubmittingEvent}
+                  onSubmit={handleSubmitPost}
+                />
+              </TabsContent>
+              <TabsContent value="news">
+                <EventForm
+                  fixedTipoPost="noticia"
+                  onCancel={() => setIsEventModalOpen(false)}
+                  isSubmitting={isSubmittingEvent}
+                  onSubmit={handleSubmitPost}
+                />
+              </TabsContent>
+              <TabsContent value="paste">
+                <AgendaPasteForm onCancel={() => setIsEventModalOpen(false)} />
+              </TabsContent>
+            </Tabs>
           </div>
         </DialogContent>
       </Dialog>

--- a/src/utils/agendaParser.ts
+++ b/src/utils/agendaParser.ts
@@ -1,0 +1,67 @@
+export interface AgendaEvent {
+  time: string;
+  title: string;
+  location: string;
+}
+
+export interface AgendaDay {
+  day: string;
+  events: AgendaEvent[];
+}
+
+export interface Agenda {
+  title: string;
+  days: AgendaDay[];
+}
+
+// Parse agenda text pasted from WhatsApp style messages
+export function parseAgendaText(raw: string): Agenda {
+  const lines = raw
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+
+  let title = "";
+  const days: AgendaDay[] = [];
+  let currentDay: AgendaDay | null = null;
+
+  const isDayLine = (line: string) => line.startsWith("*") && line.endsWith("*");
+
+  const stripEmojis = (line: string, emoji: string) =>
+    line.startsWith(emoji) ? line.slice(emoji.length).trim() : line.trim();
+
+  const stripStars = (line: string) => line.replace(/^\*+|\*+$/g, "").trim();
+
+  for (let i = 0; i < lines.length; ) {
+    const line = lines[i];
+
+    if (!title) {
+      title = stripStars(line);
+      i++;
+      continue;
+    }
+
+    if (isDayLine(line)) {
+      currentDay = { day: stripStars(line), events: [] };
+      days.push(currentDay);
+      i++;
+      continue;
+    }
+
+    if (line.startsWith("🕑")) {
+      const time = stripEmojis(line, "🕑").replace(/hs?\.?$/, "").trim();
+      const titleLine = lines[i + 1] ? stripEmojis(lines[i + 1], "✅") : "";
+      const locationLine = lines[i + 2] ? stripEmojis(lines[i + 2], "📍") : "";
+
+      if (currentDay) {
+        currentDay.events.push({ time, title: titleLine, location: locationLine });
+      }
+      i += 3;
+      continue;
+    }
+
+    i++;
+  }
+
+  return { title, days };
+}

--- a/tests/addressAutocomplete.test.ts
+++ b/tests/addressAutocomplete.test.ts
@@ -1,0 +1,19 @@
+/* @vitest-environment jsdom */
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import AddressAutocomplete from '../src/components/ui/AddressAutocomplete';
+
+describe('AddressAutocomplete', () => {
+  it('calls onSelect when a manual address is entered and input blurs', () => {
+    const handleSelect = vi.fn();
+    const { getByRole } = render(<AddressAutocomplete onSelect={handleSelect} />);
+    const input = getByRole('textbox');
+
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: 'Calle Falsa 123' } });
+    fireEvent.blur(input);
+
+    expect(handleSelect).toHaveBeenCalledWith('Calle Falsa 123');
+  });
+});

--- a/tests/agendaParser.test.ts
+++ b/tests/agendaParser.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { parseAgendaText } from '../src/utils/agendaParser';
+
+const sample = [
+  '*AGENDA MUNICIPAL*',
+  '',
+  '*Jueves 28*',
+  '',
+  '🕑9.30 hs.',
+  '✅Entrega de reconocimientos a los cuatro primeros Presidentes del HCD en democracia.',
+  '📍HCD',
+  '',
+  '*Viernes 29*',
+  '🕑10.00 hs.',
+  '✅Expo Educativa 2026',
+  '📍Centro Universitario del Este',
+  '',
+  '🕑18.30 hs.',
+  '✅Capacitación Internacional "Taller de Juegos" (para docentes de jardines maternales)',
+  '📍Casa del Bicentenario',
+  '',
+  '*Sábado 30*',
+  '🕑11.30 hs.',
+  '✅Entrega de Certificados del Curso de Lengua de Señas',
+  '📍Centro Universitario del Este',
+  '',
+  '*Domingo 31*',
+  '🕑9.00 a 16.00 hs.',
+  '✅Encuentro Femenino de Vóley',
+  '📍Polideportivo Posta El Retamo',
+  '',
+  '🕑10.00 hs.',
+  '✅Torneo de Fútbol "Desafío Libertadores"',
+  '📍Club Social y Deportivo Los Barriales',
+].join('\n');
+
+describe('parseAgendaText', () => {
+  const result = parseAgendaText(sample);
+
+  it('extracts title', () => {
+    expect(result.title).toBe('AGENDA MUNICIPAL');
+  });
+
+  it('parses days and events count', () => {
+    expect(result.days).toHaveLength(4);
+    expect(result.days[0].day).toBe('Jueves 28');
+    expect(result.days[0].events).toHaveLength(1);
+  });
+
+  it('parses event details', () => {
+    const event = result.days[0].events[0];
+    expect(event).toEqual({
+      time: '9.30',
+      title: 'Entrega de reconocimientos a los cuatro primeros Presidentes del HCD en democracia.',
+      location: 'HCD',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add MapTiler-powered address autocomplete for event and news forms
- expose Evento, Noticia, and Pegar Información tabs in profile modal
- document new paste tab in agenda workflow
- allow manual address entry to submit on blur or Enter even without suggestions
- add regression test for manual address submission

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/maplibre-gl)
- `npm test` (fails: vitest: not found)


------
https://chatgpt.com/codex/tasks/task_e_68b25947388883228273f39b3d73867e