### PR TITLE
feat: show ticket info and timeline in chat view

### DIFF
--- a/public/contactos-especializados.json
+++ b/public/contactos-especializados.json
@@ -1,0 +1,63 @@
+{
+  "default": {
+    "nombre": "Atención al Vecino",
+    "titulo": "Mesa de Ayuda General",
+    "telefono": "+5492613168608",
+    "horario": "Lunes a Viernes de 8:00 a 18:00 hs."
+  },
+  "Arreglo de calle": {
+    "nombre": "Juan Carlos de Obras Públicas",
+    "titulo": "Encargado de Bacheo y Calles",
+    "telefono": "+5492610000001",
+    "horario": "Lunes a Viernes de 8:00 a 18:00 hs."
+  },
+  "Luminaria": {
+    "nombre": "Ana María de Servicios",
+    "titulo": "Supervisora de Alumbrado",
+    "telefono": "+5492610000002",
+    "horario": "Lunes a Viernes de 8:00 a 18:00 hs."
+  },
+  "Arbolado": {
+    "nombre": "Roberto de Espacios Verdes",
+    "titulo": "Encargado de Arbolado",
+    "telefono": "+5492610000003",
+    "horario": "Lunes a Viernes de 8:00 a 18:00 hs."
+  },
+  "Limpieza y riego": {
+    "nombre": "Marta de Limpieza",
+    "titulo": "Coordinadora de Limpieza",
+    "telefono": "+5492610000004",
+    "horario": "Lunes a Viernes de 8:00 a 18:00 hs."
+  },
+  "Veterinaria y Bromatologia": {
+    "nombre": "Dra. Laura Funes",
+    "titulo": "Encargada de Veterinaria y Bromatología",
+    "telefono": "+5492634521563",
+    "horario": "Lunes a Viernes de 8:00 a 18:00 hs."
+  },
+  "Licencia de Conducir": {
+    "nombre": "Oficina de Licencias",
+    "titulo": "Consultas sobre Licencias",
+    "telefono": "+5492610000005",
+    "horario": "Lunes a Viernes de 8:00 a 18:00 hs."
+  },
+  "Pago de Tasas": {
+    "nombre": "Oficina de Rentas",
+    "titulo": "Consultas sobre Tasas y Pagos",
+    "telefono": "+5492610000006",
+    "horario": "Lunes a Viernes de 8:00 a 18:00 hs."
+  },
+  "Defensa del Consumidor": {
+    "nombre": "Asesor de Defensa del Consumidor",
+    "titulo": "Consultas y Denuncias",
+    "telefono": "+5492610000007",
+    "horario": "Lunes a Viernes de 8:00 a 18:00 hs.",
+    "email": "defensadelconsumidorjuninmza@gmail.com"
+  },
+  "Otros": {
+    "nombre": "Atención al Vecino",
+    "titulo": "Mesa de Ayuda General",
+    "telefono": "+5492613168608",
+    "horario": "Lunes a Viernes de 8:00 a 18:00 hs."
+  }
+}

--- a/src/components/TicketMap.tsx
+++ b/src/components/TicketMap.tsx
@@ -6,6 +6,10 @@ interface TicketLocation {
   direccion?: string | null;
   municipio_nombre?: string | null;
   tipo?: 'pyme' | 'municipio';
+  origen_latitud?: number | null;
+  origen_longitud?: number | null;
+  municipio_latitud?: number | null;
+  municipio_longitud?: number | null;
 }
 
 const buildFullAddress = (ticket: TicketLocation) => {
@@ -24,9 +28,15 @@ const TicketMap: React.FC<{ ticket: TicketLocation }> = ({ ticket }) => {
   const direccionCompleta = buildFullAddress(ticket);
   const hasCoords =
     typeof ticket.latitud === 'number' && typeof ticket.longitud === 'number';
-  const mapSrc = hasCoords
-    ? `https://www.google.com/maps?q=${ticket.latitud},${ticket.longitud}&output=embed`
-    : `https://www.google.com/maps?q=${encodeURIComponent(direccionCompleta)}&output=embed`;
+  const originLat = ticket.origen_latitud ?? ticket.municipio_latitud;
+  const originLon = ticket.origen_longitud ?? ticket.municipio_longitud;
+  const hasRoute =
+    hasCoords && typeof originLat === 'number' && typeof originLon === 'number';
+  const mapSrc = hasRoute
+    ? `https://www.google.com/maps/dir/?api=1&origin=${originLat},${originLon}&destination=${ticket.latitud},${ticket.longitud}&travelmode=driving&output=embed`
+    : hasCoords
+      ? `https://www.google.com/maps?q=${ticket.latitud},${ticket.longitud}&output=embed`
+      : `https://www.google.com/maps?q=${encodeURIComponent(direccionCompleta)}&output=embed`;
   return ticket.direccion || hasCoords ? (
     <div className="mb-6">
       <h4 className="font-semibold mb-2">Ubicación aproximada</h4>

--- a/src/components/tickets/DetailsPanel.tsx
+++ b/src/components/tickets/DetailsPanel.tsx
@@ -23,12 +23,14 @@ import { FaWhatsapp } from 'react-icons/fa';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 import { getContactPhone } from '@/utils/ticket';
+import { getSpecializedContact, SpecializedContact } from '@/utils/contacts';
 
 const DetailsPanel: React.FC = () => {
   const { selectedTicket: ticket } = useTickets();
   const [isSendingEmail, setIsSendingEmail] = React.useState(false);
   const [timelineHistory, setTimelineHistory] = React.useState<TicketHistoryEvent[]>([]);
   const [timelineMessages, setTimelineMessages] = React.useState<Message[]>([]);
+  const [specialContact, setSpecialContact] = React.useState<SpecializedContact | null>(null);
 
   const copyToClipboard = (text: string, label: string) => {
     navigator.clipboard.writeText(text).then(() => {
@@ -38,6 +40,14 @@ const DetailsPanel: React.FC = () => {
       console.error('Error al copiar: ', err);
     });
   };
+
+  React.useEffect(() => {
+    if (ticket?.categoria) {
+      getSpecializedContact(ticket.categoria).then(setSpecialContact);
+    } else {
+      setSpecialContact(null);
+    }
+  }, [ticket?.categoria]);
 
   const getInitials = (name: string) => {
     return name ? name.split(' ').map(n => n[0]).join('').toUpperCase() : '??';
@@ -285,6 +295,19 @@ const DetailsPanel: React.FC = () => {
                 </div>
               </div>
             </CardContent>
+
+            {specialContact && (
+              <CardContent className="p-4 text-sm border-t">
+                <h4 className="font-semibold mb-2">Contacto para seguimiento</h4>
+                <div className="space-y-1">
+                  <p>{specialContact.nombre}</p>
+                  {specialContact.titulo && <p>{specialContact.titulo}</p>}
+                  {specialContact.telefono && <p>Teléfono: {specialContact.telefono}</p>}
+                  {specialContact.horario && <p>Horario: {specialContact.horario}</p>}
+                  {specialContact.email && <p>Email: {specialContact.email}</p>}
+                </div>
+              </CardContent>
+            )}
 
             <CardContent className="p-4 space-y-3 text-sm border-t">
                 <h4 className="font-semibold mb-2">Detalles del Ticket</h4>

--- a/src/pages/TicketLookup.tsx
+++ b/src/pages/TicketLookup.tsx
@@ -6,9 +6,11 @@ import { getTicketByNumber, getTicketTimeline } from '@/services/ticketService';
 import { Ticket, Message, TicketHistoryEvent } from '@/types/tickets';
 import { formatDate } from '@/utils/fecha';
 import TicketTimeline from '@/components/tickets/TicketTimeline';
+import TicketMap from '@/components/TicketMap';
 import { Separator } from '@/components/ui/separator';
 import { getErrorMessage, ApiError } from '@/utils/api';
 import { getContactPhone } from '@/utils/ticket';
+import { getSpecializedContact, SpecializedContact } from '@/utils/contacts';
 
 export default function TicketLookup() {
   const { ticketId } = useParams<{ ticketId: string }>();
@@ -22,6 +24,7 @@ export default function TicketLookup() {
   const [timelineHistory, setTimelineHistory] = useState<TicketHistoryEvent[]>([]);
   const [timelineMessages, setTimelineMessages] = useState<Message[]>([]);
   const [estadoChat, setEstadoChat] = useState('');
+  const [specialContact, setSpecialContact] = useState<SpecializedContact | null>(null);
 
   const performSearch = useCallback(async (searchId: string, searchPin: string) => {
     const id = searchId.trim();
@@ -37,9 +40,11 @@ export default function TicketLookup() {
     setTimelineHistory([]);
     setTimelineMessages([]);
     setEstadoChat('');
+    setSpecialContact(null);
     try {
       const data = await getTicketByNumber(id, pinVal);
       setTicket(data);
+      getSpecializedContact(data.categoria).then(setSpecialContact);
 
       // Usar el historial y mensajes incluidos en el ticket si están presentes
       if (data.history || data.messages) {
@@ -158,6 +163,17 @@ export default function TicketLookup() {
                 )}
               </div>
             )}
+            {specialContact && (
+              <div className="mt-4 text-sm space-y-1">
+                <p className="font-medium">Contacto para seguimiento:</p>
+                <p>{specialContact.nombre}</p>
+                {specialContact.titulo && <p>{specialContact.titulo}</p>}
+                {specialContact.telefono && <p>Teléfono: {specialContact.telefono}</p>}
+                {specialContact.horario && <p>Horario: {specialContact.horario}</p>}
+                {specialContact.email && <p>Email: {specialContact.email}</p>}
+              </div>
+            )}
+            <TicketMap ticket={ticket} />
           </div>
 
           <Separator />

--- a/src/utils/contacts.ts
+++ b/src/utils/contacts.ts
@@ -1,0 +1,34 @@
+export interface SpecializedContact {
+  nombre: string;
+  titulo?: string;
+  telefono?: string;
+  horario?: string;
+  email?: string;
+}
+
+let contactsCache: Record<string, SpecializedContact> | null = null;
+
+async function loadContacts(): Promise<Record<string, SpecializedContact>> {
+  if (contactsCache) return contactsCache;
+  try {
+    const res = await fetch('/contactos-especializados.json');
+    if (!res.ok) throw new Error('No se pudo cargar el archivo de contactos');
+    contactsCache = await res.json();
+    return contactsCache || {};
+  } catch (err) {
+    console.error('Error loading specialized contacts', err);
+    contactsCache = {};
+    return contactsCache;
+  }
+}
+
+export async function getSpecializedContact(categoria?: string): Promise<SpecializedContact | null> {
+  if (!categoria) return null;
+  const contacts = await loadContacts();
+  return (
+    contacts[categoria] ||
+    contacts['Otros'] ||
+    contacts['default'] ||
+    null
+  );
+}

--- a/tests/contacts.test.ts
+++ b/tests/contacts.test.ts
@@ -1,0 +1,43 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+// Helper to reload module fresh for each test
+async function loadModule() {
+  const mod = await import('../src/utils/contacts');
+  return mod;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+describe('getSpecializedContact', () => {
+  it('returns contact when category exists', async () => {
+    const mockData = { Luminaria: { nombre: 'Atención Luminarias' } };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => mockData }));
+    const { getSpecializedContact } = await loadModule();
+    const contact = await getSpecializedContact('Luminaria');
+    expect(contact).toEqual(mockData.Luminaria);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to default contact when category missing', async () => {
+    const mockData = { default: { nombre: 'Atención al Vecino' } };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => mockData }));
+    const { getSpecializedContact } = await loadModule();
+    const contact = await getSpecializedContact('Inexistente');
+    expect(contact).toEqual(mockData.default);
+  });
+
+  it('caches contacts after first load', async () => {
+    const mockData = { Luminaria: { nombre: 'Atención Luminarias' } };
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, json: async () => mockData });
+    vi.stubGlobal('fetch', mockFetch);
+    const { getSpecializedContact } = await loadModule();
+    await getSpecializedContact('Luminaria');
+    await getSpecializedContact('Luminaria');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- replace placeholder specialized contact file with full category directory
- fall back to generic contact when a category-specific entry is missing
- expand unit tests to cover default contact fallback and caching

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/maplibre-gl)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b274af64148322acae20100ddf617b