### PR TITLE
Fix JSX brace error in ChatPage

### DIFF
--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -474,8 +474,6 @@ const ChatPage = () => {
                       {(ticketInfo.informacion_personal_vecino?.nombre || ticketInfo.display_name) && (
                         <p>Nombre: {ticketInfo.informacion_personal_vecino?.nombre || ticketInfo.display_name}</p>
                       )}
-
-                      )}
                       {(ticketInfo.informacion_personal_vecino?.email || ticketInfo.email) && (
                         <p>Email: {ticketInfo.informacion_personal_vecino?.email || ticketInfo.email}</p>
                       )}


### PR DESCRIPTION
## Summary
- remove stray closing brace in ticket info section causing build error

## Testing
- `npm install` *(fails: 403 Forbidden when fetching maplibre-gl)*
- `npm test` *(fails: vitest: not found)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b398a5d88483228989569f638d63b1