### PR TITLE
Use placeholder text for attachment-only messages

### DIFF
--- a/src/hooks/useChatLogic.ts
+++ b/src/hooks/useChatLogic.ts
@@ -205,10 +205,18 @@ export function useChatLogic({ tipoChat, entityToken: propToken, tokenKey = 'aut
 
     // Sanitize text by removing emojis to prevent issues with backend services like Google Search.
     const emojiRegex = /([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/g;
-    const sanitizedText = (actualPayload.text || "").replace(emojiRegex, '').trim();
+    let sanitizedText = (actualPayload.text || "").replace(emojiRegex, '').trim();
 
     const { text: userMessageText, attachmentInfo, ubicacion_usuario, action, location } = actualPayload;
     const actionPayload = 'payload' in actualPayload ? actualPayload.payload : undefined;
+
+    if (!sanitizedText) {
+      if (attachmentInfo || actualPayload.archivo_url) {
+        sanitizedText = '[adjunto]';
+      } else if (location || ubicacion_usuario) {
+        sanitizedText = '[ubicacion]';
+      }
+    }
 
     // Allow confirming/cancelling a claim with free text when awaiting confirmation
     let resolvedAction = action;


### PR DESCRIPTION
## Summary
- ensure messages with attachments or locations send placeholder text so backend treats them as user input

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 on maplibre-gl package)*

------
https://chatgpt.com/codex/tasks/task_e_68b3aef222288322854895e8edaf1192