### PR TITLE
feat: capture full event details

### DIFF
--- a/src/components/admin/EventForm.tsx
+++ b/src/components/admin/EventForm.tsx
@@ -35,11 +35,14 @@ const eventFormSchema = z.object({
   tipo_post: z.enum(['noticia', 'evento'], { required_error: "Debe seleccionar un tipo."}),
   startDate: z.date().optional(),
   endDate: z.date().optional(),
+  startTime: z.string().optional(),
+  endTime: z.string().optional(),
   location: z.object({
       address: z.string().optional(),
   }).optional(),
   category: z.string().optional(),
   imageUrl: z.string().url({ message: 'Por favor, introduce una URL válida.' }).optional().or(z.literal('')),
+  link: z.string().url({ message: 'Por favor, introduce una URL válida.' }).optional().or(z.literal('')),
   flyer: z.any()
     .optional()
     .refine((files) => {
@@ -72,9 +75,12 @@ export const EventForm: React.FC<EventFormProps> = ({ onSubmit, onCancel, isSubm
       tipo_post: fixedTipoPost || 'noticia',
       startDate: undefined,
       endDate: undefined,
+      startTime: '',
+      endTime: '',
       location: { address: '' },
       category: '',
       imageUrl: '',
+      link: '',
       flyer: undefined,
       ...initialData,
     },
@@ -221,6 +227,34 @@ export const EventForm: React.FC<EventFormProps> = ({ onSubmit, onCancel, isSubm
             )}
           />
         </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <FormField
+            control={form.control}
+            name="startTime"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Hora de Inicio</FormLabel>
+                <FormControl>
+                  <Input type="time" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="endTime"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Hora de Fin (Opcional)</FormLabel>
+                <FormControl>
+                  <Input type="time" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
         <FormField
           control={form.control}
           name="location.address"
@@ -269,6 +303,19 @@ export const EventForm: React.FC<EventFormProps> = ({ onSubmit, onCancel, isSubm
               <FormLabel>URL de la Imagen (Opcional)</FormLabel>
               <FormControl>
                 <Input placeholder="https://ejemplo.com/imagen.jpg" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="link"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Enlace (Opcional)</FormLabel>
+              <FormControl>
+                <Input placeholder="https://ejemplo.com" {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/src/pages/Perfil.tsx
+++ b/src/pages/Perfil.tsx
@@ -64,6 +64,7 @@ import { useUser } from "@/hooks/useUser";
 import { safeLocalStorage } from "@/utils/safeLocalStorage";
 import { getCurrentTipoChat } from "@/utils/tipoChat";
 import { apiFetch, getErrorMessage, ApiError } from "@/utils/api"; // Importa apiFetch y getErrorMessage
+import { toLocalISOString } from "@/utils/fecha";
 import { suggestMappings, SystemField, DEFAULT_SYSTEM_FIELDS } from "@/utils/columnMatcher";
 import * as XLSX from 'xlsx';
 import Papa from 'papaparse';
@@ -162,9 +163,24 @@ export default function Perfil() {
       if (values.description) formData.append('contenido', values.description);
       formData.append('tipo_post', values.tipo_post);
       if (values.imageUrl) formData.append('imagen_url', values.imageUrl);
-      if (values.startDate) formData.append('fecha_evento_inicio', values.startDate.toISOString());
-      if (values.endDate) formData.append('fecha_evento_fin', values.endDate.toISOString());
+      if (values.startDate) {
+        const start = new Date(values.startDate);
+        if (values.startTime) {
+          const [h, m] = values.startTime.split(':').map(Number);
+          start.setHours(h || 0, m || 0, 0, 0);
+        }
+        formData.append('fecha_evento_inicio', toLocalISOString(start));
+      }
+      if (values.endDate) {
+        const end = new Date(values.endDate);
+        if (values.endTime) {
+          const [h, m] = values.endTime.split(':').map(Number);
+          end.setHours(h || 0, m || 0, 0, 0);
+        }
+        formData.append('fecha_evento_fin', toLocalISOString(end));
+      }
       if (values.location?.address) formData.append('direccion', values.location.address);
+      if (values.link) formData.append('enlace', values.link);
 
       if (values.flyer && values.flyer.length > 0) {
         formData.append('flyer_image', values.flyer[0]);

--- a/src/utils/agendaParser.ts
+++ b/src/utils/agendaParser.ts
@@ -1,7 +1,10 @@
 export interface AgendaEvent {
-  time: string;
+  startTime: string;
+  endTime?: string;
   title: string;
   location: string;
+  link?: string;
+  image?: string;
 }
 
 export interface AgendaDay {
@@ -49,14 +52,32 @@ export function parseAgendaText(raw: string): Agenda {
     }
 
     if (line.startsWith("🕑")) {
-      const time = stripEmojis(line, "🕑").replace(/hs?\.?$/, "").trim();
+      const rawTime = stripEmojis(line, "🕑").replace(/hs?\.?$/, "").trim();
+      let startTime = rawTime;
+      let endTime: string | undefined;
+      const range = rawTime.split(/\s+a\s+/i);
+      if (range.length === 2) {
+        startTime = range[0].trim();
+        endTime = range[1].trim();
+      }
       const titleLine = lines[i + 1] ? stripEmojis(lines[i + 1], "✅") : "";
       const locationLine = lines[i + 2] ? stripEmojis(lines[i + 2], "📍") : "";
+      let nextIndex = i + 3;
+      let link = "";
+      let image = "";
+      if (lines[nextIndex] && lines[nextIndex].startsWith("🔗")) {
+        link = stripEmojis(lines[nextIndex], "🔗");
+        nextIndex++;
+      }
+      if (lines[nextIndex] && lines[nextIndex].startsWith("🖼")) {
+        image = stripEmojis(lines[nextIndex], "🖼");
+        nextIndex++;
+      }
 
       if (currentDay) {
-        currentDay.events.push({ time, title: titleLine, location: locationLine });
+        currentDay.events.push({ startTime, endTime, title: titleLine, location: locationLine, link, image });
       }
-      i += 3;
+      i = nextIndex;
       continue;
     }
 

--- a/src/utils/fecha.ts
+++ b/src/utils/fecha.ts
@@ -21,3 +21,13 @@ export function formatDate(
 
 // Alias para compatibilidad hacia atrás
 export const fechaArgentina = (iso: string) => formatDate(iso);
+
+/**
+ * Convierte una fecha a una cadena ISO sin ajustar a UTC.
+ * Ajusta la fecha restando el offset de la zona horaria para
+ * mantener la hora local al serializarla.
+ */
+export function toLocalISOString(date: Date): string {
+  const offsetMs = date.getTimezoneOffset() * 60000;
+  return new Date(date.getTime() - offsetMs).toISOString().slice(0, 19);
+}

--- a/tests/agendaPasteForm.test.tsx
+++ b/tests/agendaPasteForm.test.tsx
@@ -1,0 +1,26 @@
+/* @vitest-environment jsdom */
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { AgendaPasteForm } from '../src/components/admin/AgendaPasteForm';
+
+const sample = `*AGENDA MUNICIPAL*
+
+*Domingo 31*
+
+🕑9.00 a 16.00 hs.
+✅Encuentro Femenino de Vóley
+📍Polideportivo Posta El Retamo`;
+
+describe('AgendaPasteForm', () => {
+  it('shows preview of parsed agenda', async () => {
+    render(<AgendaPasteForm onCancel={() => {}} />);
+    const textarea = screen.getByPlaceholderText('Pega aquí el texto completo de la agenda...');
+    fireEvent.change(textarea, { target: { value: sample } });
+
+    expect(await screen.findByText('AGENDA MUNICIPAL')).toBeInTheDocument();
+    expect(await screen.findByText('Domingo 31')).toBeInTheDocument();
+    expect(await screen.findByText('Encuentro Femenino de Vóley')).toBeInTheDocument();
+    expect(await screen.findByText('9.00 - 16.00')).toBeInTheDocument();
+  });
+});

--- a/tests/fecha.test.ts
+++ b/tests/fecha.test.ts
@@ -1,0 +1,10 @@
+import { toLocalISOString } from '@/utils/fecha';
+
+describe('toLocalISOString', () => {
+  it('returns ISO string preserving local time', () => {
+    const date = new Date(2024, 0, 1, 12, 30, 0); // Jan 1 2024 12:30 local
+    const iso = toLocalISOString(date);
+    expect(iso).toBe('2024-01-01T12:30:00');
+    expect(iso.endsWith('Z')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- parse agenda text for start/end times, links, and images before bulk upload
- collect event links and time ranges in the admin event form
- combine chosen dates and times when submitting municipal posts
- keep event timestamps in local time to avoid unintended UTC offsets

## Testing
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68b473f70d38832293c8cbc42fc4bd95