### PR TITLE
fix: load map worker and stop chat widget spinner

### DIFF
--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -299,7 +299,10 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
   useEffect(() => {
     async function fetchEntityProfile() {
       // Wait until the token is resolved before deciding what to do.
-      if (entityToken == null) return;
+      if (entityToken === undefined) {
+        setProfileLoading(false);
+        return;
+      }
       if (!entityToken) {
         console.log("ChatWidget: No hay entityToken, se asume configuración por defecto.");
         setProfileLoading(false);


### PR DESCRIPTION
## Summary
- ensure maplibre loads its web worker when imported dynamically so map and heatmap render correctly
- stop ChatWidget from spinning indefinitely when no entity token is provided

## Testing
- `npm install` *(fails: 403 Forbidden for mammoth)*
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4f74f9b4483228eada1e62362d7c2