### PR TITLE
Add resolved ticket grouping and timeline status formatting

### DIFF
--- a/src/components/tickets/TicketTimeline.tsx
+++ b/src/components/tickets/TicketTimeline.tsx
@@ -18,6 +18,13 @@ type TimelineEvent =
       content: string;
     };
 
+const formatStatus = (status: string) =>
+  status
+    ? status
+        .replace(/_/g, ' ')
+        .replace(/\b\w/g, (c) => c.toUpperCase())
+    : '';
+
 const TicketTimeline: React.FC<TicketTimelineProps> = ({ history, messages = [] }) => {
   const events: TimelineEvent[] = [
     ...history.map((h) => ({ type: 'status', ...h })),
@@ -26,9 +33,12 @@ const TicketTimeline: React.FC<TicketTimelineProps> = ({ history, messages = [] 
       date: m.timestamp,
       author: m.agentName || (m.author === 'agent' ? 'Agente' : 'Vecino'),
       origin: m.author,
-      content: m.content,
+      content: m.content || '',
     })),
-  ].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+  ].sort(
+    (a, b) =>
+      (new Date(a.date).getTime() || 0) - (new Date(b.date).getTime() || 0)
+  );
 
   if (events.length === 0) {
     return <p className="text-sm text-muted-foreground">No hay historial disponible.</p>;
@@ -60,7 +70,7 @@ const TicketTimeline: React.FC<TicketTimelineProps> = ({ history, messages = [] 
             </span>
             {isStatus ? (
               <div className="flex flex-col gap-1">
-                <h4 className="font-semibold">{event.status}</h4>
+                <h4 className="font-semibold">{formatStatus(event.status)}</h4>
                 <time className="text-sm text-muted-foreground">
                   {formatDate(
                     event.date,

--- a/src/context/TicketContext.tsx
+++ b/src/context/TicketContext.tsx
@@ -16,15 +16,27 @@ interface TicketContextType {
 const TicketContext = createContext<TicketContextType | undefined>(undefined);
 
 const groupTicketsByCategory = (tickets: Ticket[]) => {
-    return tickets.reduce((acc, ticket) => {
-      const category = ticket.categoria || 'Sin Categoría';
-      if (!acc[category]) {
-        acc[category] = [];
-      }
-      acc[category].push(ticket);
-      return acc;
-    }, {} as { [key: string]: Ticket[] });
-  };
+  const groups: { [key: string]: Ticket[] } = {};
+  const resolved: Ticket[] = [];
+
+  tickets.forEach((ticket) => {
+    if (ticket.estado === 'resuelto') {
+      resolved.push(ticket);
+      return;
+    }
+    const category = ticket.categoria || 'Sin Categoría';
+    if (!groups[category]) {
+      groups[category] = [];
+    }
+    groups[category].push(ticket);
+  });
+
+  if (resolved.length > 0) {
+    groups['Resueltos'] = resolved;
+  }
+
+  return groups;
+};
 
 export const TicketProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const [tickets, setTickets] = useState<Ticket[]>([]);

--- a/src/pages/TicketLookup.tsx
+++ b/src/pages/TicketLookup.tsx
@@ -23,9 +23,9 @@ export default function TicketLookup() {
   const [estadoChat, setEstadoChat] = useState('');
   const [specialContact, setSpecialContact] = useState<SpecializedContact | null>(null);
 
-  const performSearch = useCallback(async (searchId: string, searchPin: string) => {
-    const id = searchId.trim();
-    const pinVal = searchPin.trim();
+  const performSearch = useCallback(async (searchId?: string, searchPin?: string) => {
+    const id = (searchId || '').trim();
+    const pinVal = (searchPin || '').trim();
     if (!id) return;
     if (!pinVal) {
       setError('El PIN es obligatorio para consultar el ticket');


### PR DESCRIPTION
## Summary
- group resolved tickets separately in sidebar context
- format ticket status labels in timeline
- guard ticket lookup search parameters

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b679cb8e9c832290d573712ecbcb1a