### PR TITLE
fix: include button payload in chat requests

### DIFF
--- a/src/components/chat/ChatButtons.tsx
+++ b/src/components/chat/ChatButtons.tsx
@@ -69,8 +69,8 @@ const ChatButtons: React.FC<ChatButtonsProps> = ({
             return;
         }
 
-        // Priority 5: Default - send button text as a simple message to backend
-        onButtonClick({ text: boton.texto });
+        // Priority 5: Default - send button text along with payload (if any)
+        onButtonClick({ text: boton.texto, payload: boton.payload });
     };
 
     const baseClass =

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -307,9 +307,10 @@ const ChatPage = () => {
           const requestPayload: Record<string, any> = { 
             pregunta: userMessageText, 
             contexto_previo: contexto,
-            ...(payload.attachmentInfo && { attachment_info: payload.attachmentInfo }), 
+            ...(payload.attachmentInfo && { attachment_info: payload.attachmentInfo }),
             ...(payload.es_ubicacion && { es_ubicacion: true, ubicacion_usuario: payload.ubicacion_usuario }),
             ...(payload.action && { action: payload.action }),
+            ...(payload.payload !== undefined && { payload: payload.payload }),
             // Mantener campos legados si el bot los necesita para transición
             ...(payload.archivo_url && !payload.attachmentInfo && { archivo_url: payload.archivo_url }),
             ...(payload.es_foto && !payload.attachmentInfo && { es_foto: payload.es_foto }),


### PR DESCRIPTION
## Summary
- ensure chat buttons send payload to backend even without action
- forward payload from chat messages to backend requests

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7100d05e48322b7a9bce4378ecd64