### PR TITLE
Fix admin comments misclassified in ticket timeline

### DIFF
--- a/src/services/ticketService.ts
+++ b/src/services/ticketService.ts
@@ -149,9 +149,11 @@ export const getTicketTimeline = async (
     const messages: Message[] = [];
     response.timeline?.forEach((evt, idx) => {
       if (evt.tipo === 'comentario') {
+        const isAgent =
+          typeof evt.es_admin === 'boolean' ? evt.es_admin : !!evt.user_id;
         messages.push({
           id: idx,
-          author: evt.es_admin ? 'agent' : 'user',
+          author: isAgent ? 'agent' : 'user',
           content: evt.texto || '',
           timestamp: evt.fecha,
         });

--- a/tests/ticketTimeline.test.ts
+++ b/tests/ticketTimeline.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getTicketTimeline } from '../src/services/ticketService';
+import { apiFetch } from '@/utils/api';
+
+describe('getTicketTimeline', () => {
+  it('marks events with user_id as agent when es_admin is missing', async () => {
+    vi.mocked(apiFetch).mockResolvedValueOnce({
+      estado_chat: 'abierto',
+      timeline: [
+        { tipo: 'comentario', fecha: '2024-01-01', texto: 'Hola', user_id: 5 }
+      ]
+    } as any);
+    const result = await getTicketTimeline(1, 'municipio');
+    expect(result.messages[0].author).toBe('agent');
+  });
+});


### PR DESCRIPTION
## Summary
- correctly detect municipal admin comments in ticket timeline
- test admin comment classification

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/mammoth)*

------
https://chatgpt.com/codex/tasks/task_e_68b710a6015c83228e55722de1e9e6a7