### PR TITLE
Force widget links to open outside iframe

### DIFF
--- a/src/utils/sanitizeMessageHtml.ts
+++ b/src/utils/sanitizeMessageHtml.ts
@@ -1,5 +1,19 @@
 import DOMPurify from 'dompurify';
 
+// Ensure all links open outside the iframe to avoid blocked pages
+// by enforcing target="_blank" and rel="noopener noreferrer" on anchors.
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+  if (node.tagName === 'A') {
+    const href = node.getAttribute('href') || '';
+    // Ensure links without protocol use https to avoid browser blocks
+    if (href.startsWith('www.')) {
+      node.setAttribute('href', `https://${href}`);
+    }
+    node.setAttribute('target', '_blank');
+    node.setAttribute('rel', 'noopener noreferrer');
+  }
+});
+
 const ALLOWED_TAGS = [
   'b',
   'strong',


### PR DESCRIPTION
## Summary
- ensure sanitized message links always open in a new tab
- coerce links missing a protocol to use https

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/mammoth)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b71c74dcc083228526cf906d75c90b