### PR TITLE
fix: improve event rendering formatting

### DIFF
--- a/src/components/chat/ChatMessageBase.tsx
+++ b/src/components/chat/ChatMessageBase.tsx
@@ -241,8 +241,8 @@ const ChatMessageBase = React.forwardRef<HTMLDivElement, ChatMessageBaseProps>( 
 
           {/* Prioridad al texto si no hay otros contenidos especiales */}
           {(!showAttachmentOrMap && !showStructuredContent && sanitizedHtml) && (
-            <span
-              className="max-w-none text-sm [&_p]:my-0"
+            <div
+              className="whitespace-pre-wrap text-justify max-w-none text-sm [&_p]:my-0 mb-2"
               dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
             />
           )}
@@ -262,8 +262,8 @@ const ChatMessageBase = React.forwardRef<HTMLDivElement, ChatMessageBaseProps>( 
             <>
               {/* Si hay texto Y contenido estructurado, el texto puede ser una introducción */}
               {sanitizedHtml && !showAttachmentOrMap && (
-                 <span
-                    className="max-w-none text-sm [&_p]:my-0 mb-2 block"
+                 <div
+                    className="whitespace-pre-wrap text-justify max-w-none text-sm [&_p]:my-0 mb-2"
                     dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
                 />
               )}

--- a/src/components/chat/EventCard.tsx
+++ b/src/components/chat/EventCard.tsx
@@ -3,18 +3,24 @@ import { Post } from '@/types/chat';
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Calendar, Clock, Facebook, Instagram, Youtube, ExternalLink } from 'lucide-react';
-import { format } from 'date-fns';
-import { es } from 'date-fns/locale';
+import { useDateSettings } from '@/hooks/useDateSettings';
 
 interface EventCardProps {
   post: Post;
 }
 
 const EventCard: React.FC<EventCardProps> = ({ post }) => {
+  const { timezone, locale } = useDateSettings();
+
   const formatDate = (dateString?: string) => {
     if (!dateString) return null;
     try {
-      return format(new Date(dateString), "d 'de' MMMM, yyyy", { locale: es });
+      return new Date(dateString).toLocaleDateString(locale, {
+        timeZone: timezone,
+        day: '2-digit',
+        month: 'long',
+        year: 'numeric',
+      });
     } catch {
       return null;
     }
@@ -23,7 +29,14 @@ const EventCard: React.FC<EventCardProps> = ({ post }) => {
   const formatTime = (dateString?: string) => {
     if (!dateString) return null;
     try {
-      return format(new Date(dateString), "HH:mm 'hs'", { locale: es });
+      return (
+        new Date(dateString).toLocaleTimeString(locale, {
+          timeZone: timezone,
+          hour: '2-digit',
+          minute: '2-digit',
+          hour12: false,
+        }) + ' hs'
+      );
     } catch {
       return null;
     }
@@ -34,7 +47,7 @@ const EventCard: React.FC<EventCardProps> = ({ post }) => {
   const endDate = formatDate(post.fecha_evento_fin);
   const endTime = formatTime(post.fecha_evento_fin);
 
-  const image = post.imagen_url || post.image;
+  const image = post.imagen_url || post.image || post.imageUrl;
   const mainLink = post.url || post.enlace || post.link;
   const socials = [
     { key: 'facebook', url: post.facebook, Icon: Facebook },
@@ -61,7 +74,7 @@ const EventCard: React.FC<EventCardProps> = ({ post }) => {
         )}
       </CardHeader>
       <CardContent>
-        <p className="text-sm text-foreground/90 whitespace-pre-wrap">{post.contenido}</p>
+        <p className="text-sm text-foreground/90 whitespace-pre-wrap text-justify">{post.contenido}</p>
 
         {post.tipo_post === 'evento' && startDate && (
           <div className="mt-4 pt-4 border-t border-border/60 space-y-2">

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -43,6 +43,7 @@ export interface Post {
   tipo_post: 'noticia' | 'evento';
   imagen_url?: string;
   image?: string; // compatibilidad con "image"
+  imageUrl?: string; // alias adicional para imagen
   fecha_evento_inicio?: string; // ISO 8601 string
   fecha_evento_fin?: string; // ISO 8601 string
   url?: string; // Un enlace principal


### PR DESCRIPTION
## Summary
- render bot messages as block elements with preserved spacing and justification
- show event images and links with additional fallbacks and locale-aware date/time
- add optional imageUrl to Post type for wider backend compatibility

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7247b31f883228341032bc9383be1