### PR TITLE
feat: highlight resolved tickets and fix message history

### DIFF
--- a/src/components/MapLibreMap.tsx
+++ b/src/components/MapLibreMap.tsx
@@ -186,7 +186,9 @@ export default function MapLibreMap({
                 type: "FeatureCollection",
                 features: heatmapData.map((p) => ({
                   type: "Feature",
-                  properties: { weight: p.weight ?? 1 },
+                  properties: {
+                    weight: p.weight ?? (p.estado?.toLowerCase() === 'resuelto' ? 2 : 1),
+                  },
                   geometry: { type: "Point", coordinates: [p.lng, p.lat] },
                 })),
               } as const;
@@ -274,7 +276,7 @@ export default function MapLibreMap({
     const features = (heatmapData ?? []).map((p) => ({
       type: "Feature",
       properties: {
-        weight: p.weight ?? 1,
+        weight: p.weight ?? (p.estado?.toLowerCase() === 'resuelto' ? 2 : 1),
         id: p.id,
         ticket: p.ticket,
       },

--- a/src/context/TicketContext.tsx
+++ b/src/context/TicketContext.tsx
@@ -20,7 +20,8 @@ const groupTicketsByCategory = (tickets: Ticket[]) => {
   const resolved: Ticket[] = [];
 
   tickets.forEach((ticket) => {
-    if (ticket.estado === 'resuelto') {
+    const status = ticket.estado?.toLowerCase();
+    if (status && ['resuelto', 'cerrado'].includes(status)) {
       resolved.push(ticket);
       return;
     }

--- a/src/services/statsService.ts
+++ b/src/services/statsService.ts
@@ -9,6 +9,7 @@ export interface HeatPoint {
   categoria?: string;
   barrio?: string;
   tipo_ticket?: string;
+  estado?: string;
 }
 
 export interface TicketStatsResponse {

--- a/src/services/ticketService.ts
+++ b/src/services/ticketService.ts
@@ -123,16 +123,30 @@ export const sendTicketHistory = async (ticket: Ticket): Promise<void> => {
     }
 };
 
-export const getTicketMessages = async (ticketId: number, tipo: 'municipio' | 'pyme'): Promise<Message[]> => {
-    try {
-        const endpoint = tipo === 'municipio' ? `/tickets/chat/${ticketId}/mensajes` : `/tickets/chat/pyme/${ticketId}/mensajes`;
-        const response = await apiFetch<{ mensajes: Message[] }>(endpoint);
-        return response.mensajes || [];
-    } catch (error) {
-        console.error(`Error fetching messages for ticket ${ticketId}:`, error);
-        throw error;
-    }
-}
+export const getTicketMessages = async (
+  ticketId: number,
+  tipo: 'municipio' | 'pyme'
+): Promise<Message[]> => {
+  try {
+    const endpoint =
+      tipo === 'municipio'
+        ? `/tickets/chat/${ticketId}/mensajes`
+        : `/tickets/chat/pyme/${ticketId}/mensajes`;
+    const response = await apiFetch<{ mensajes?: any[]; messages?: any[] }>(endpoint);
+    const rawMsgs = response.mensajes || response.messages || [];
+    return rawMsgs.map((m: any) => ({
+      ...m,
+      content: m.content || m.texto || m.mensaje || '',
+      timestamp:
+        typeof m.timestamp === 'number'
+          ? new Date(m.timestamp).toISOString()
+          : m.timestamp || new Date().toISOString(),
+    }));
+  } catch (error) {
+    console.error(`Error fetching messages for ticket ${ticketId}:`, error);
+    throw error;
+  }
+};
 
 export const getTicketTimeline = async (
   ticketId: number,


### PR DESCRIPTION
## Summary
- group closed tickets in "Resueltos" category
- emphasize resolved tickets on heatmap via weight
- normalize ticket messages to ensure timeline history displays

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden for mammoth)*

------
https://chatgpt.com/codex/tasks/task_e_68b7484bc00c83229f4a1d1c2168f7f3