### PR TITLE
Map admin flag to ticket message author

### DIFF
--- a/tests/getTicketMessages.test.ts
+++ b/tests/getTicketMessages.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getTicketMessages } from '../src/services/ticketService';
+import { apiFetch } from '@/utils/api';
+
+vi.mock('@/utils/api', () => ({
+  apiFetch: vi.fn(),
+}));
+
+describe('getTicketMessages', () => {
+  it('maps admin flag to author field', async () => {
+    vi.mocked(apiFetch).mockResolvedValueOnce({
+      mensajes: [
+        { id: 1, mensaje: 'Hola', es_admin: 0, timestamp: '2024-01-01T00:00:00Z' },
+        { id: 2, mensaje: 'Chau', es_admin: 1, timestamp: '2024-01-02T00:00:00Z' },
+      ],
+    } as any);
+
+    const result = await getTicketMessages(1, 'municipio');
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ author: 'user', content: 'Hola' });
+    expect(result[1]).toMatchObject({ author: 'agent', content: 'Chau' });
+  });
+});


### PR DESCRIPTION
## Summary
- Derive message author from `es_admin` flags when fetching ticket messages
- Add unit test for admin flag mapping

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install mammoth` *(fails: 403 Forbidden - GET https://registry.npmjs.org/mammoth)*

------
https://chatgpt.com/codex/tasks/task_e_68b77536e64c8322968b2289aebc7908