### PR TITLE
feat: prompt anonymous users to select rubro

### DIFF
--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -10,16 +10,13 @@ import ScrollToBottomButton from "@/components/ui/ScrollToBottomButton";
 import { useChatLogic } from "@/hooks/useChatLogic";
 import { SendPayload } from "@/types/chat";
 import PersonalDataForm from './PersonalDataForm';
-import { Rubro } from "./RubroSelector";
 import { Message } from "@/types/chat";
 import { safeLocalStorage } from "@/utils/safeLocalStorage";
 import { requestLocation } from "@/utils/geolocation";
 import { toast } from "@/components/ui/use-toast";
-import RubroSelector from "./RubroSelector";
 import AddressAutocomplete from "@/components/ui/AddressAutocomplete";
 import TicketMap from "@/components/TicketMap";
 import { apiFetch } from "@/utils/api";
-import { parseRubro, esRubroPublico } from "@/utils/chatEndpoints";
 import { useUser } from "@/hooks/useUser";
 import { motion } from "framer-motion";
 import { useBusinessHours } from "@/hooks/useBusinessHours";
@@ -56,7 +53,6 @@ interface ChatPanelProps {
   onShowLogin?: () => void;
   onShowRegister?: () => void;
   selectedRubro?: string | null;
-  onRubroSelect?: (rubro: any) => void;
   muted?: boolean;
   onToggleSound?: () => void;
   onCart?: () => void;
@@ -73,7 +69,6 @@ const ChatPanel = ({
   onToggleSound,
   onRequireAuth,
   selectedRubro,
-  onRubroSelect,
   mode,
   entityToken: propEntityToken,
 }: ChatPanelProps) => {
@@ -126,6 +121,20 @@ const ChatPanel = ({
     const stored = safeLocalStorage.getItem("ultima_direccion");
     if (stored) setDireccionGuardada(stored);
   }, []);
+
+  useEffect(() => {
+    if (selectedRubro && messages.length === 0) {
+      setMessages([
+        {
+          id: Date.now(),
+          text: `¡Hola! Soy Chatboc, tu asistente para ${selectedRubro.toLowerCase()}. ¿En qué puedo ayudarte hoy?`,
+          isBot: true,
+          timestamp: new Date(),
+          query: undefined,
+        },
+      ]);
+    }
+  }, [selectedRubro, messages.length, setMessages]);
 
   useEffect(() => {
     if (activeTicketId) {

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -15,6 +15,8 @@ import ChatUserPanel from "./ChatUserPanel";
 import ChatHeader from "./ChatHeader";
 import EntityInfoPanel from "./EntityInfoPanel";
 import ChatPanel from "./ChatPanel";
+import RubroSelector, { Rubro } from "./RubroSelector";
+import { esRubroPublico, parseRubro } from "@/utils/chatEndpoints";
 
 interface ChatWidgetProps {
   mode?: "standalone" | "iframe" | "script";
@@ -93,19 +95,31 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
     getOrCreateAnonId();
   }, []);
 
+  useEffect(() => {
+    if (!esperandoRubro) return;
+    setRubrosLoading(true);
+    apiFetch<Rubro[]>("/rubros/", { skipAuth: true })
+      .then((data) => setRubrosDisponibles(Array.isArray(data) ? data : []))
+      .catch(() => setRubrosDisponibles([]))
+      .finally(() => setRubrosLoading(false));
+  }, [esperandoRubro]);
+
   const [showCta, setShowCta] = useState(false);
   const [proactiveMessage, setProactiveMessage] = useState<string | null>(null);
   const [showProactiveBubble, setShowProactiveBubble] = useState(false);
   const [proactiveCycle, setProactiveCycle] = useState(0);
-  const [selectedRubro, setSelectedRubro] = useState<string | null>(initialRubro || null);
-  const [hasSetInitialRubro, setHasSetInitialRubro] = useState(false);
+  const storedRubro = typeof window !== 'undefined' ? safeLocalStorage.getItem('rubroSeleccionado') : null;
+  const [selectedRubro, setSelectedRubro] = useState<string | null>(initialRubro || storedRubro);
+  const [rubrosDisponibles, setRubrosDisponibles] = useState<Rubro[]>([]);
+  const [esperandoRubro, setEsperandoRubro] = useState(!entityToken && !(initialRubro || storedRubro));
+  const [rubrosLoading, setRubrosLoading] = useState(false);
 
   useEffect(() => {
-    if (initialRubro && !hasSetInitialRubro) {
+    if (initialRubro && initialRubro !== selectedRubro) {
       setSelectedRubro(initialRubro);
-      setHasSetInitialRubro(true);
+      setEsperandoRubro(false);
     }
-  }, [initialRubro, hasSetInitialRubro]);
+  }, [initialRubro, selectedRubro]);
 
   const openUserPanel = useCallback(() => {
     if (user) {
@@ -132,6 +146,19 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
       return nv;
     });
   }, []);
+
+  const handleRubroSelect = useCallback((r: Rubro) => {
+    safeLocalStorage.setItem('rubroSeleccionado', r.nombre);
+    setSelectedRubro(r.nombre);
+    setEsperandoRubro(false);
+    setResolvedTipoChat(esRubroPublico(parseRubro(r.nombre)) ? 'municipio' : 'pyme');
+  }, []);
+
+  useEffect(() => {
+    if (selectedRubro) {
+      setResolvedTipoChat(esRubroPublico(parseRubro(selectedRubro)) ? 'municipio' : 'pyme');
+    }
+  }, [selectedRubro]);
 
   const [viewport, setViewport] = useState({
     width: typeof window !== "undefined" ? window.innerWidth : 0,
@@ -449,24 +476,41 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
                 : view === "login" ? <ChatUserLoginPanel onSuccess={() => setView("chat")} onShowRegister={() => setView("register")} />
                 : view === "user" ? <ChatUserPanel onClose={() => setView("chat")} />
                 : view === "info" ? <EntityInfoPanel info={entityInfo} onClose={() => setView("chat")} />
-                : <ChatPanel
-                    mode={mode}
-                    widgetId={widgetId}
-                    entityToken={entityToken}
-                    openWidth={finalOpenWidth}
-                    openHeight={finalOpenHeight}
-                    onClose={toggleChat}
-                    tipoChat={resolvedTipoChat}
-                    onRequireAuth={() => setView("register")}
-                    onShowLogin={() => setView("login")}
-                    onShowRegister={() => setView("register")}
-                    onOpenUserPanel={openUserPanel}
-                    muted={muted}
-                    onToggleSound={toggleMuted}
-                    onCart={openCart}
-                    selectedRubro={entityInfo?.rubro || selectedRubro}
-                    onRubroSelect={setSelectedRubro}
-                  />}
+                : esperandoRubro ? (
+                    <>
+                      <ChatHeader onClose={toggleChat} onProfile={openUserPanel} muted={muted} onToggleSound={toggleMuted} onCart={openCart} />
+                      <div className="flex-1 p-4 overflow-y-auto text-center">
+                        {rubrosLoading ? (
+                          <div className="w-full h-full flex items-center justify-center">
+                            <div className="w-8 h-8 border-4 border-primary border-t-transparent rounded-full animate-spin" />
+                          </div>
+                        ) : (
+                          <>
+                            <p className="mb-4 text-sm text-muted-foreground">Seleccioná un rubro para comenzar:</p>
+                            <RubroSelector rubros={rubrosDisponibles} onSelect={handleRubroSelect} />
+                          </>
+                        )}
+                      </div>
+                    </>
+                  ) : (
+                    <ChatPanel
+                      mode={mode}
+                      widgetId={widgetId}
+                      entityToken={entityToken}
+                      openWidth={finalOpenWidth}
+                      openHeight={finalOpenHeight}
+                      onClose={toggleChat}
+                      tipoChat={resolvedTipoChat}
+                      onRequireAuth={() => setView("register")}
+                      onShowLogin={() => setView("login")}
+                      onShowRegister={() => setView("register")}
+                      onOpenUserPanel={openUserPanel}
+                      muted={muted}
+                      onToggleSound={toggleMuted}
+                      onCart={openCart}
+                      selectedRubro={entityInfo?.rubro || selectedRubro}
+                    />
+                  )}
             </motion.div>
           ) : (
             <motion.div

--- a/src/hooks/useChatLogic.ts
+++ b/src/hooks/useChatLogic.ts
@@ -87,7 +87,8 @@ export function useChatLogic({ tipoChat, entityToken: propToken, tokenKey = 'aut
       socket.emit('join', { room: sessionId, channel: 'web' });
 
       // Automatically send a silent greeting to fetch the main menu on connect.
-      const endpoint = getAskEndpoint({ tipoChat, rubro: null });
+      const rubro = safeLocalStorage.getItem("rubroSeleccionado") || null;
+      const endpoint = getAskEndpoint({ tipoChat, rubro });
       const initialContext = getInitialMunicipioContext();
 
       console.log("useChatLogic: Sending initial greeting to fetch menu.");
@@ -102,6 +103,7 @@ export function useChatLogic({ tipoChat, entityToken: propToken, tokenKey = 'aut
           action: 'initial_greeting',
           contexto_previo: initialContext,
           tipo_chat: tipoChat,
+          ...(rubro && { rubro_clave: rubro }),
           ...(initialName && { nombre_usuario: initialName }),
         },
       })

--- a/src/utils/tipoChat.ts
+++ b/src/utils/tipoChat.ts
@@ -35,11 +35,23 @@ export function getCurrentRubro(): string | null {
  * Si no hay usuario o no se puede determinar, usa 'pyme' como default para demos.
  */
 export function getCurrentTipoChat(): 'pyme' | 'municipio' {
+  try {
+    const stored = safeLocalStorage.getItem('user');
+    if (stored) {
+      const user = JSON.parse(stored);
+      if (user?.tipo_chat === 'municipio' || user?.tipo_chat === 'pyme') {
+        return user.tipo_chat;
+      }
+    }
+  } catch {
+    /* ignore */
+  }
+
   const rubro = getCurrentRubro();
   if (rubro) {
     return esRubroPublico(rubro) ? 'municipio' : 'pyme';
   }
-  
+
   // Si no hay rubro (ej. demo anónima sin rubro pre-seleccionado),
   // por defecto debería ser 'pyme' para las demos generales.
   // Tu APP_TARGET en src/config.ts debería ser 'pyme' si esa es la configuración por defecto de la app.


### PR DESCRIPTION
## Summary
- prompt unregistered visitors to pick a sample rubro before starting chat
- greet using the chosen rubro and send it with the initial backend request

## Testing
- `npm install` *(fails: 403 Forbidden for mammoth)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b775a9af84832296e5df0a0ff91933