### PR TITLE
Add fallback ticket status timeline

### DIFF
--- a/src/components/tickets/TicketTimeline.tsx
+++ b/src/components/tickets/TicketTimeline.tsx
@@ -6,6 +6,8 @@ import { TicketHistoryEvent, Message } from '@/types/tickets';
 interface TicketTimelineProps {
   history: TicketHistoryEvent[];
   messages?: Message[];
+  currentStatus?: string;
+  statusOrder?: string[];
 }
 
 type TimelineEvent =
@@ -25,7 +27,21 @@ const formatStatus = (status: string) =>
         .replace(/\b\w/g, (c) => c.toUpperCase())
     : '';
 
-const TicketTimeline: React.FC<TicketTimelineProps> = ({ history, messages = [] }) => {
+const DEFAULT_STATUS_ORDER = [
+  'nuevo',
+  'abierto',
+  'en_proceso',
+  'completado',
+  'resuelto',
+  'cerrado',
+];
+
+const TicketTimeline: React.FC<TicketTimelineProps> = ({
+  history,
+  messages = [],
+  currentStatus,
+  statusOrder = DEFAULT_STATUS_ORDER,
+}) => {
   const events: TimelineEvent[] = [
     ...history.map((h) => ({ type: 'status', ...h })),
     ...messages.map((m) => ({
@@ -39,6 +55,40 @@ const TicketTimeline: React.FC<TicketTimelineProps> = ({ history, messages = [] 
     (a, b) =>
       (new Date(a.date).getTime() || 0) - (new Date(b.date).getTime() || 0)
   );
+
+  if (events.length === 0 && currentStatus) {
+    const currentIndex = statusOrder.indexOf(currentStatus);
+    if (currentIndex === -1) {
+      return (
+        <p className="text-sm text-muted-foreground">No hay historial disponible.</p>
+      );
+    }
+    return (
+      <ol className="relative border-l border-gray-200 dark:border-gray-700">
+        {statusOrder.map((status, index) => {
+          const reached = index <= currentIndex;
+          const icon = reached ? (
+            <CheckCircle size={16} />
+          ) : (
+            <Clock size={16} />
+          );
+          const circleClass = reached
+            ? 'bg-green-500 text-white'
+            : 'bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-300';
+          return (
+            <li key={status} className="mb-8 ml-6">
+              <span
+                className={`absolute -left-3 flex items-center justify-center w-6 h-6 rounded-full ring-8 ring-white dark:ring-gray-900 ${circleClass}`}
+              >
+                {icon}
+              </span>
+              <h4 className="font-semibold">{formatStatus(status)}</h4>
+            </li>
+          );
+        })}
+      </ol>
+    );
+  }
 
   if (events.length === 0) {
     return <p className="text-sm text-muted-foreground">No hay historial disponible.</p>;

--- a/src/pages/TicketLookup.tsx
+++ b/src/pages/TicketLookup.tsx
@@ -169,7 +169,11 @@ export default function TicketLookup() {
 
           <div>
             <h3 className="text-xl font-semibold mb-4">Historial del Reclamo</h3>
-            <TicketTimeline history={timelineHistory} messages={timelineMessages} />
+            <TicketTimeline
+              history={timelineHistory}
+              messages={timelineMessages}
+              currentStatus={estadoChat || ticket.estado}
+            />
           </div>
 
         </div>


### PR DESCRIPTION
## Summary
- extend TicketTimeline with default status order and support for current status
- show progress timeline on ticket lookup when history is absent

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7acc392b483229ae523ebb1eaaa86