### PR TITLE
fix: send parsed agenda payload directly

### DIFF
--- a/src/components/admin/AgendaPasteForm.tsx
+++ b/src/components/admin/AgendaPasteForm.tsx
@@ -65,8 +65,7 @@ export const AgendaPasteForm: React.FC<AgendaPasteFormProps> = ({ onCancel }) =>
       );
       await apiFetch('/municipal/posts/bulk', {
         method: 'POST',
-        body: JSON.stringify({ events }),
-        headers: { 'Content-Type': 'application/json' },
+        body: { events },
       });
       toast({ title: 'Éxito', description: 'La agenda ha sido procesada correctamente.' });
       onCancel();


### PR DESCRIPTION
## Summary
- fix agenda paste form to send events object instead of pre-stringified JSON

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b1abb1f0832295f069577eb5426b