### PR TITLE
Refactor geocoder country retrieval in AddressAutocomplete

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,10 @@ VITE_LOCALE=es-AR
 
 # Google Maps API Key for heatmap and other map features
 VITE_Maps_API_KEY=AIzaSyDbEoPzFgN5zJsIeywiRE7jRI8xr5ioGNI
+
+# MapTiler API key for address autocomplete and map tiles
+VITE_MAPTILER_KEY=
+
+# Optional comma-separated country codes (ISO 3166-1 alpha-2) to restrict geocoding
+# Example: VITE_GEOCODER_COUNTRIES=ar,uy
+VITE_GEOCODER_COUNTRIES=

--- a/src/components/ui/AddressAutocomplete.tsx
+++ b/src/components/ui/AddressAutocomplete.tsx
@@ -27,6 +27,7 @@ const AddressAutocomplete: React.FC<AddressAutocompleteProps> = ({
   readOnly = false,
   disabled = false,
 }) => {
+  const geocoderCountries = import.meta.env.VITE_GEOCODER_COUNTRIES || "";
   const [query, setQuery] = useState(value?.label || "");
   const [options, setOptions] = useState<string[]>([]);
   const [open, setOpen] = useState(false);
@@ -73,8 +74,13 @@ const AddressAutocomplete: React.FC<AddressAutocompleteProps> = ({
       return;
     }
     const controller = new AbortController();
+    const countryParam = geocoderCountries
+      ? `&country=${encodeURIComponent(geocoderCountries)}`
+      : "";
     fetch(
-      `https://api.maptiler.com/geocoding/${encodeURIComponent(query)}.json?key=${MAPTILER_KEY}&language=es&limit=5`,
+      `https://api.maptiler.com/geocoding/${encodeURIComponent(
+        query
+      )}.json?key=${MAPTILER_KEY}&language=es&limit=5${countryParam}`,
       { signal: controller.signal }
     )
       .then((r) => r.json())
@@ -94,7 +100,7 @@ const AddressAutocomplete: React.FC<AddressAutocompleteProps> = ({
       })
       .catch(() => {});
     return () => controller.abort();
-  }, [query]);
+  }, [query, geocoderCountries]);
 
   if (readOnly || disabled) {
     return (

--- a/tests/addressAutocomplete.test.ts
+++ b/tests/addressAutocomplete.test.ts
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import AddressAutocomplete from '../src/components/ui/AddressAutocomplete';
 
@@ -15,5 +15,29 @@ describe('AddressAutocomplete', () => {
     fireEvent.blur(input);
 
     expect(handleSelect).toHaveBeenCalledWith('Calle Falsa 123');
+  });
+
+  it('appends country filter from env when fetching suggestions', async () => {
+    vi.stubEnv('VITE_MAPTILER_KEY', 'demo');
+    vi.stubEnv('VITE_GEOCODER_COUNTRIES', 'ar');
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({ json: () => Promise.resolve({ features: [] }) })
+    );
+    const originalFetch = global.fetch;
+    // @ts-expect-error override global
+    global.fetch = fetchMock;
+
+    const { getByRole } = render(
+      <AddressAutocomplete onSelect={vi.fn()} />
+    );
+    const input = getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'San' } });
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const url = fetchMock.mock.calls[0][0];
+    expect(url).toContain('country=ar');
+
+    vi.unstubAllEnvs();
+    global.fetch = originalFetch;
   });
 });


### PR DESCRIPTION
## Summary
- compute `VITE_GEOCODER_COUNTRIES` inside the component so it initializes safely

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/mammoth)
- `npm test` (fails: vitest: not found)


------
https://chatgpt.com/codex/tasks/task_e_68b7b2cf99a08322aa3963d4d50ce51f