### PR TITLE
fix: avoid pre-init reference in iframe entry

### DIFF
--- a/src/pages/iframe.tsx
+++ b/src/pages/iframe.tsx
@@ -55,7 +55,7 @@ function ChatWidgetComponent({
   );
 }
 
-export default function Iframe() {
+function Iframe() {
   const [widgetParams, setWidgetParams] = useState<any | null>(null);
   const [entityToken, setEntityToken] = useState<string | null>(null);
   const [tipoChat, setTipoChat] = useState<'pyme' | 'municipio' | null>(null);
@@ -143,3 +143,5 @@ createRoot(container).render(
         <Iframe />
     </ErrorBoundary>
 );
+
+export default Iframe;


### PR DESCRIPTION
## Summary
- refactor iframe entrypoint to define component before calling `createRoot`

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c48c4cd08322aba27a48cc3bf0cf