### PR TITLE
fix: avoid pre-init reference in iframe entry

### DIFF
--- a/src/pages/iframe.tsx
+++ b/src/pages/iframe.tsx
@@ -55,7 +55,7 @@ function ChatWidgetComponent({
   );
 }
 
-export default function Iframe() {
+const Iframe: React.FC = () => {
   const [widgetParams, setWidgetParams] = useState<any | null>(null);
   const [entityToken, setEntityToken] = useState<string | null>(null);
   const [tipoChat, setTipoChat] = useState<'pyme' | 'municipio' | null>(null);
@@ -135,11 +135,13 @@ export default function Iframe() {
       <MemoryRouter>{widgetNode}</MemoryRouter>
     </GoogleOAuthProvider>
   );
-}
+};
+
+export default Iframe;
 
 const container = document.getElementById('root')!;
 createRoot(container).render(
-    <ErrorBoundary>
-        <Iframe />
-    </ErrorBoundary>
+  <ErrorBoundary>
+    <Iframe />
+  </ErrorBoundary>
 );


### PR DESCRIPTION
## Summary
- export the `Iframe` component before rendering to prevent access-before-init errors

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c48c4cd08322aba27a48cc3bf0cf