### PR TITLE
fix mammoth import for Vite

### DIFF
--- a/src/components/admin/AgendaPasteForm.tsx
+++ b/src/components/admin/AgendaPasteForm.tsx
@@ -30,9 +30,9 @@ export const AgendaPasteForm: React.FC<AgendaPasteFormProps> = ({ onCancel }) =>
     try {
       let content = '';
       if (file.name.toLowerCase().endsWith('.docx')) {
-        const mammoth = await import('mammoth');
+        const { extractRawText } = await import('mammoth/mammoth.browser.js');
         const arrayBuffer = await file.arrayBuffer();
-        const result = await mammoth.extractRawText({ arrayBuffer });
+        const result = await extractRawText({ arrayBuffer });
         content = result.value;
       } else {
         content = await file.text();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -89,6 +89,9 @@ export default defineConfig(({ mode }) => {
         }
       },
     },
+    optimizeDeps: {
+      exclude: ['mammoth'],
+    },
     test: {
       globals: true,
       environment: 'jsdom',


### PR DESCRIPTION
## Summary
- load `extractRawText` from the browser build of `mammoth`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c6521e548322baddbce9c49c1c4a