### PR TITLE
fix mammoth import for Vite

### DIFF
--- a/src/components/admin/AgendaPasteForm.tsx
+++ b/src/components/admin/AgendaPasteForm.tsx
@@ -30,7 +30,7 @@ export const AgendaPasteForm: React.FC<AgendaPasteFormProps> = ({ onCancel }) =>
     try {
       let content = '';
       if (file.name.toLowerCase().endsWith('.docx')) {
-        const mammoth = await import('mammoth');
+        const mammoth = await import('mammoth/mammoth.browser');
         const arrayBuffer = await file.arrayBuffer();
         const result = await mammoth.extractRawText({ arrayBuffer });
         content = result.value;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -89,6 +89,9 @@ export default defineConfig(({ mode }) => {
         }
       },
     },
+    optimizeDeps: {
+      exclude: ['mammoth', 'mammoth/mammoth.browser'],
+    },
     test: {
       globals: true,
       environment: 'jsdom',


### PR DESCRIPTION
## Summary
- load `mammoth.browser` dynamically for `.docx` agenda parsing
- exclude `mammoth` and its browser build from Vite's dependency optimizer

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c6521e548322baddbce9c49c1c4a