### PR TITLE
fix: remove default export from iframe entrypoint

### DIFF
--- a/src/pages/iframe.tsx
+++ b/src/pages/iframe.tsx
@@ -137,13 +137,9 @@ const Iframe: React.FC = () => {
   );
 };
 
-export default Iframe;
-
 const container = document.getElementById('root')!;
 createRoot(container).render(
   <ErrorBoundary>
     <Iframe />
   </ErrorBoundary>
 );
-
-export default Iframe;


### PR DESCRIPTION
## Summary
- remove default export from iframe entrypoint to avoid initialization issues

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ca402a7c83228e914741d4cb0b21