### PR TITLE
Load MapLibre from bundle with CDN fallback

### DIFF
--- a/src/components/MapLibreMap.tsx
+++ b/src/components/MapLibreMap.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
-// MapLibre se importa de forma dinámica para evitar errores en entornos donde
-// la librería no esté disponible completamente o falten métodos como `on`.
-// Intentamos importar el bundle de MapLibre de manera dinámica. Si no está
-// disponible (por ejemplo, cuando la dependencia no pudo instalarse), se
-// cargará desde un CDN junto con su hoja de estilos.
+// MapLibre se importa de forma directa. Si por algún motivo la librería no se
+// encuentra disponible en el bundle, se utilizará un fallback que la carga
+// desde un CDN junto con su hoja de estilos.
+import maplibregl from "maplibre-gl";
+import maplibreWorker from "maplibre-gl/dist/maplibre-gl-csp-worker";
 import "maplibre-gl/dist/maplibre-gl.css";
 import { safeOn, assertEventSource } from "@/utils/safeOn";
 
@@ -87,17 +87,13 @@ export default function MapLibreMap({
           return (window as any).maplibregl || null;
         }
 
-        try {
-          const mod = await import("maplibre-gl");
-          lib = (mod as any).default || mod;
-          // MapLibre v4+ requiere un web worker explícito cuando se usa como módulo.
-          // Intentamos importarlo dinámicamente. Si falla, continuamos y dejaremos
-          // que el fallback al CDN maneje el worker incorporado.
+        lib = maplibregl as any;
+        if (!lib || typeof lib.Map !== "function") {
+          lib = await loadFromCDN();
+        } else {
           try {
-            const workerMod = await import("maplibre-gl/dist/maplibre-gl-csp-worker");
-            const worker = (workerMod as any).default || workerMod;
+            const worker = (maplibreWorker as any).default || maplibreWorker;
             if (worker) {
-              // Algunos bundles exponen `workerClass`, otros `setWorkerClass`.
               if ("workerClass" in lib) {
                 (lib as any).workerClass = worker;
               } else if (typeof (lib as any).setWorkerClass === "function") {
@@ -107,9 +103,6 @@ export default function MapLibreMap({
           } catch (workerErr) {
             console.warn("MapLibreMap: failed to load worker", workerErr);
           }
-        } catch (err) {
-          console.error("MapLibreMap: failed to load library", err);
-          lib = await loadFromCDN();
         }
 
         if (!isMounted || !lib || typeof lib.Map !== "function") {


### PR DESCRIPTION
## Summary
- import MapLibre directly instead of dynamic import
- fallback to CDN and set web worker when bundle missing

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/mammoth)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d98f135083229c2f731152550e48