### PR TITLE
Load MapLibre from bundle with CDN fallback

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,7 +35,8 @@ export default defineConfig(({ mode }) => {
         },
         workbox: {
           globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
-          maximumFileSizeToCacheInBytes: 3 * 1024 * 1024,
+          // Allow larger chunks like MapLibre (~3MB) to be precached
+          maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
           runtimeCaching: [
             {
               urlPattern: /^https:\/\/maps\.googleapis\.com\/.*/,


### PR DESCRIPTION
## Summary
- handle MapLibre initialization errors with a CDN fallback
- raise PWA maximum cacheable file size to 5MB to accommodate map bundle
- fix MapLibre map setup by removing stray brace that broke build

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b7d98f135083229c2f731152550e48