### PR TITLE
Load MapLibre from bundle with CDN fallback

### DIFF
--- a/src/components/MapLibreMap.tsx
+++ b/src/components/MapLibreMap.tsx
@@ -1,10 +1,7 @@
 import { useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
-// MapLibre se importa de forma dinámica para evitar errores en entornos donde
-// la librería no esté disponible completamente o falten métodos como `on`.
-// Intentamos importar el bundle de MapLibre de manera dinámica. Si no está
-// disponible (por ejemplo, cuando la dependencia no pudo instalarse), se
-// cargará desde un CDN junto con su hoja de estilos.
+// Importar el CSS garantiza que los estilos estén disponibles incluso si la
+// librería se carga de manera dinámica más adelante.
 import "maplibre-gl/dist/maplibre-gl.css";
 import { safeOn, assertEventSource } from "@/utils/safeOn";
 
@@ -57,198 +54,209 @@ export default function MapLibreMap({
     }
     let isMounted = true;
     (async () => {
-      try {
-        let lib: any = null;
-
-        async function loadFromCDN() {
-          const existing = (window as any).maplibregl;
-          if (existing) return existing;
-
-          const scriptUrl = "https://unpkg.com/maplibre-gl@3.5.2/dist/maplibre-gl.js";
-          const cssUrl = "https://unpkg.com/maplibre-gl@3.5.2/dist/maplibre-gl.css";
-
-          await new Promise<void>((resolve, reject) => {
-            const script = document.createElement("script");
-            script.src = scriptUrl;
-            script.onload = () => resolve();
-            script.onerror = () => reject();
-            document.head.appendChild(script);
-          }).catch((cdnErr) => {
-            console.error("MapLibreMap: CDN script load failed", cdnErr);
-          });
-
-          if (!document.querySelector(`link[href="${cssUrl}"]`)) {
-            const link = document.createElement("link");
-            link.rel = "stylesheet";
-            link.href = cssUrl;
-            document.head.appendChild(link);
-          }
-
-          return (window as any).maplibregl || null;
-        }
-
+      async function loadLocal() {
         try {
-          const mod = await import("maplibre-gl");
-          lib = (mod as any).default || mod;
-          // MapLibre v4+ requiere un web worker explícito cuando se usa como módulo.
-          // Intentamos importarlo dinámicamente. Si falla, continuamos y dejaremos
-          // que el fallback al CDN maneje el worker incorporado.
-          try {
-            const workerMod = await import("maplibre-gl/dist/maplibre-gl-csp-worker");
-            const worker = (workerMod as any).default || workerMod;
-            if (worker) {
-              // Algunos bundles exponen `workerClass`, otros `setWorkerClass`.
-              if ("workerClass" in lib) {
-                (lib as any).workerClass = worker;
-              } else if (typeof (lib as any).setWorkerClass === "function") {
-                (lib as any).setWorkerClass(worker);
-              }
+          const libMod = await import("maplibre-gl");
+          const workerMod = await import(
+            "maplibre-gl/dist/maplibre-gl-csp-worker"
+          );
+          const lib = (libMod as any).default || libMod;
+          const worker = (workerMod as any).default || workerMod;
+          if (worker) {
+            if ("workerClass" in lib) {
+              (lib as any).workerClass = worker;
+            } else if (typeof (lib as any).setWorkerClass === "function") {
+              (lib as any).setWorkerClass(worker);
             }
-          } catch (workerErr) {
-            console.warn("MapLibreMap: failed to load worker", workerErr);
           }
+          return lib;
         } catch (err) {
-          console.error("MapLibreMap: failed to load library", err);
-          lib = await loadFromCDN();
+          console.error("MapLibreMap: failed to load local library", err);
+          return null;
         }
+      }
 
-        if (!isMounted || !lib || typeof lib.Map !== "function") {
-          console.error("MapLibreMap: Map constructor unavailable", lib);
-          return;
-        }
+      async function loadFromCDN() {
+        const existing = (window as any).maplibregl;
+        if (existing) return existing;
 
-        const styleUrl = apiKey
-          ? `https://api.maptiler.com/maps/streets-v2/style.json?key=${apiKey}`
-          : "https://demotiles.maplibre.org/style.json";
+        const scriptUrl = "https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js";
+        const cssUrl = "https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css";
 
-        const map = new lib.Map({
-          container: ref.current!,
-          style: styleUrl,
-          center: initialCenter,
-          zoom: initialZoom,
+        await new Promise<void>((resolve, reject) => {
+          const script = document.createElement("script");
+          script.src = scriptUrl;
+          script.onload = () => resolve();
+          script.onerror = () => reject();
+          document.head.appendChild(script);
+        }).catch((cdnErr) => {
+          console.error("MapLibreMap: CDN script load failed", cdnErr);
         });
 
-        const hasOn = typeof (map as any).on === "function";
-        const hasRemove = typeof (map as any).remove === "function";
-        if (!hasOn || !hasRemove) {
-          console.error("MapLibreMap: map instance missing methods", map);
+        if (!document.querySelector(`link[href="${cssUrl}"]`)) {
+          const link = document.createElement("link");
+          link.rel = "stylesheet";
+          link.href = cssUrl;
+          document.head.appendChild(link);
+        }
+
+        return (window as any).maplibregl || null;
+      }
+
+      let lib: any = await loadLocal();
+      if (!lib || typeof lib.Map !== "function") {
+        lib = await loadFromCDN();
+      }
+
+      if (!isMounted || !lib || typeof lib.Map !== "function") {
+        console.error("MapLibreMap: Map constructor unavailable", lib);
+        return;
+      }
+
+      const styleUrl = apiKey
+        ? `https://api.maptiler.com/maps/streets-v2/style.json?key=${apiKey}`
+        : "https://demotiles.maplibre.org/style.json";
+
+      const map = new lib.Map({
+        container: ref.current!,
+        style: styleUrl,
+        center: initialCenter,
+        zoom: initialZoom,
+      });
+
+      const hasOn = typeof (map as any).on === "function";
+      const hasRemove = typeof (map as any).remove === "function";
+      if (!hasOn || !hasRemove) {
+        console.error("MapLibreMap: map instance missing methods", map);
+        try {
+          map.remove?.();
+        } catch (rmErr) {
+          console.error("MapLibreMap: unable to cleanup incomplete map", rmErr);
+        }
+        return;
+      }
+
+      mapRef.current = map;
+      libRef.current = lib;
+      assertEventSource(map, "map");
+      safeOn(map, "error", (e) => {
+        console.error(
+          "MapLibreMap: style or runtime error",
+          (e as any)?.error ?? e
+        );
+        // Evita que MapLibre eleve el error y detenga la carga del mapa
+        (e as any)?.preventDefault?.();
+      });
+
+      try {
+        if (typeof lib.NavigationControl === "function") {
+          map.addControl?.(new lib.NavigationControl(), "top-right");
+        }
+
+        const clickHandler = (e: any) => {
+          const { lng, lat } = e.lngLat || {};
+          if (typeof lng === "number" && typeof lat === "number") {
+            markerRef.current?.remove?.();
+            markerRef.current = new lib.Marker()
+              .setLngLat([lng, lat])
+              .addTo(map);
+            onSelect?.(lat, lng);
+          }
+        };
+
+        const styleImageMissingHandler = (e: any) => {
+          const name = (e.id as string | undefined)?.trim() ?? "";
+          if (map.hasImage?.(name)) return;
+          // Si el estilo solicita un icono que no tenemos disponible,
+          // agregamos un pixel transparente para evitar errores fatales.
+          const empty = {
+            width: 1,
+            height: 1,
+            data: new Uint8Array([0, 0, 0, 0]),
+          };
+          try {
+            map.addImage?.(name, empty as any);
+          } catch (imgErr) {
+            console.warn("No se pudo agregar imagen vacía", imgErr);
+          }
+        };
+
+        const loadHandler = () => {
+          // Solo agregamos la capa de calor si se proporcionan datos.
+          if (heatmapData && heatmapData.length > 0) {
+            const sourceData = {
+              type: "FeatureCollection",
+              features: heatmapData.map((p) => ({
+                type: "Feature",
+                properties: {
+                  weight:
+                    p.weight ?? (p.estado?.toLowerCase() === "resuelto" ? 2 : 1),
+                },
+                geometry: { type: "Point", coordinates: [p.lng, p.lat] },
+              })),
+            } as const;
+
+            map.addSource?.("puntos", {
+              type: "geojson",
+              data: sourceData as any,
+            });
+
+            map.addLayer?.({
+              id: "tickets-heat",
+              type: "heatmap",
+              source: "puntos",
+              maxzoom: 15,
+              paint: {
+                "heatmap-weight": ["get", "weight"],
+                "heatmap-intensity": [
+                  "interpolate",
+                  ["linear"],
+                  ["zoom"],
+                  0,
+                  1,
+                  15,
+                  3,
+                ],
+                "heatmap-radius": ["interpolate", ["linear"], ["zoom"], 0, 2, 9, 20],
+                "heatmap-opacity": 0.6,
+              },
+            });
+
+            map.addLayer?.({
+              id: "tickets-circles",
+              type: "circle",
+              source: "puntos",
+              minzoom: 14,
+              paint: {
+                "circle-radius": 6,
+                "circle-color": "#3b82f6",
+                "circle-opacity": 0.9,
+              },
+            });
+          }
+        };
+
+        if (onSelect) {
+          safeOn(map, "click", clickHandler);
+        }
+        safeOn(map, "styleimagemissing", styleImageMissingHandler);
+        safeOn(map, "load", loadHandler);
+
+        return () => {
+          markerRef.current?.remove?.();
+          map.off?.("click", clickHandler);
+          map.off?.("styleimagemissing", styleImageMissingHandler);
+          map.off?.("load", loadHandler);
           try {
             map.remove?.();
-          } catch (rmErr) {
-            console.error("MapLibreMap: unable to cleanup incomplete map", rmErr);
+          } catch (err) {
+            console.error("MapLibreMap: failed to remove map", err);
           }
-          return;
-        }
-
-        mapRef.current = map;
-        libRef.current = lib;
-        assertEventSource(map, "map");
-        safeOn(map, "error", (e) => {
-          console.error(
-            "MapLibreMap: style or runtime error",
-            (e as any)?.error ?? e
-          );
-          // Evita que MapLibre eleve el error y detenga la carga del mapa
-          (e as any)?.preventDefault?.();
-        });
-
-        try {
-          if (typeof lib.NavigationControl === "function") {
-            map.addControl?.(new lib.NavigationControl(), "top-right");
-          }
-
-          const clickHandler = (e: any) => {
-            const { lng, lat } = e.lngLat || {};
-            if (typeof lng === "number" && typeof lat === "number") {
-              markerRef.current?.remove?.();
-              markerRef.current = new lib.Marker().setLngLat([lng, lat]).addTo(map);
-              onSelect?.(lat, lng);
-            }
-          };
-
-          const styleImageMissingHandler = (e: any) => {
-            const name = (e.id as string | undefined)?.trim() ?? "";
-            if (map.hasImage?.(name)) return;
-            // Si el estilo solicita un icono que no tenemos disponible,
-            // agregamos un pixel transparente para evitar errores fatales.
-            const empty = { width: 1, height: 1, data: new Uint8Array([0, 0, 0, 0]) };
-            try {
-              map.addImage?.(name, empty as any);
-            } catch (imgErr) {
-              console.warn("No se pudo agregar imagen vacía", imgErr);
-            }
-          };
-
-          const loadHandler = () => {
-            // Solo agregamos la capa de calor si se proporcionan datos.
-            if (heatmapData && heatmapData.length > 0) {
-              const sourceData = {
-                type: "FeatureCollection",
-                features: heatmapData.map((p) => ({
-                  type: "Feature",
-                  properties: {
-                    weight: p.weight ?? (p.estado?.toLowerCase() === 'resuelto' ? 2 : 1),
-                  },
-                  geometry: { type: "Point", coordinates: [p.lng, p.lat] },
-                })),
-              } as const;
-
-              map.addSource?.("puntos", {
-                type: "geojson",
-                data: sourceData as any,
-              });
-
-              map.addLayer?.({
-                id: "tickets-heat",
-                type: "heatmap",
-                source: "puntos",
-                maxzoom: 15,
-                paint: {
-                  "heatmap-weight": ["get", "weight"],
-                  "heatmap-intensity": ["interpolate", ["linear"], ["zoom"], 0, 1, 15, 3],
-                  "heatmap-radius": ["interpolate", ["linear"], ["zoom"], 0, 2, 9, 20],
-                  "heatmap-opacity": 0.6,
-                },
-              });
-
-              map.addLayer?.({
-                id: "tickets-circles",
-                type: "circle",
-                source: "puntos",
-                minzoom: 14,
-                paint: {
-                  "circle-radius": 6,
-                  "circle-color": "#3b82f6",
-                  "circle-opacity": 0.9,
-                },
-              });
-            }
-          };
-
-          if (onSelect) {
-            safeOn(map, "click", clickHandler);
-          }
-          safeOn(map, "styleimagemissing", styleImageMissingHandler);
-          safeOn(map, "load", loadHandler);
-
-          return () => {
-            markerRef.current?.remove?.();
-            map.off?.("click", clickHandler);
-            map.off?.("styleimagemissing", styleImageMissingHandler);
-            map.off?.("load", loadHandler);
-            try {
-              map.remove?.();
-            } catch (err) {
-              console.error("MapLibreMap: failed to remove map", err);
-            }
-          };
-        } catch (err) {
-          console.error("MapLibreMap: failed to configure map", err);
-        }
+        };
       } catch (err) {
-        console.error("Error initializing map", err);
+        console.error("MapLibreMap: failed to configure map", err);
       }
-    })();
+      })();
     return () => {
       isMounted = false;
       try {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,7 +35,8 @@ export default defineConfig(({ mode }) => {
         },
         workbox: {
           globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
-          maximumFileSizeToCacheInBytes: 3 * 1024 * 1024,
+          // Allow larger chunks like MapLibre (~3MB) to be precached
+          maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
           runtimeCaching: [
             {
               urlPattern: /^https:\/\/maps\.googleapis\.com\/.*/,


### PR DESCRIPTION
## Summary
- load MapLibre dynamically and attach the CSP worker, falling back to CDN if local bundle fails

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/mammoth)*
- `npm test` *(fails: vitest: not found)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d98f135083229c2f731152550e48