### PR TITLE
normalize ticket categories

### DIFF
--- a/src/context/TicketContext.tsx
+++ b/src/context/TicketContext.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useState, useContext, useEffect, ReactNode, useCa
 import { Ticket } from '@/types/tickets';
 import { getTickets } from '@/services/ticketService';
 import useTicketUpdates from '@/hooks/useTicketUpdates';
+import { mapToKnownCategory } from '@/utils/category';
 
 interface TicketContextType {
   tickets: Ticket[];
@@ -25,11 +26,11 @@ const groupTicketsByCategory = (tickets: Ticket[]) => {
       resolved.push(ticket);
       return;
     }
-    const category = ticket.categoria || 'Sin Categoría';
+    const category = mapToKnownCategory(ticket.categoria);
     if (!groups[category]) {
       groups[category] = [];
     }
-    groups[category].push(ticket);
+    groups[category].push({ ...ticket, categoria: category });
   });
 
   if (resolved.length > 0) {
@@ -51,8 +52,12 @@ export const TicketProvider: React.FC<{ children: ReactNode }> = ({ children }) 
       const fetchedTickets = (apiResponse as any)?.tickets;
 
       if (Array.isArray(fetchedTickets)) {
-        setTickets(fetchedTickets);
-        setSelectedTicket((prev) => prev ?? (fetchedTickets[0] || null));
+        const normalizedTickets = fetchedTickets.map((t: Ticket) => ({
+          ...t,
+          categoria: mapToKnownCategory(t.categoria),
+        }));
+        setTickets(normalizedTickets);
+        setSelectedTicket((prev) => prev ?? (normalizedTickets[0] || null));
       } else {
         console.warn("La respuesta de la API no contiene un array de tickets:", apiResponse);
         setTickets([]);

--- a/src/utils/category.ts
+++ b/src/utils/category.ts
@@ -1,0 +1,23 @@
+export const DEFAULT_CATEGORIES = [
+  'Alumbrado',
+  'Bache',
+  'Limpieza',
+  'Arbolado',
+  'General'
+];
+
+function normalize(str: string): string {
+  return str
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[^\w\s]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function mapToKnownCategory(categoria?: string | null): string {
+  if (!categoria) return 'General';
+  const target = normalize(categoria);
+  const match = DEFAULT_CATEGORIES.find(c => normalize(c) === target);
+  return match || 'General';
+}

--- a/src/utils/contexto_municipio.ts
+++ b/src/utils/contexto_municipio.ts
@@ -1,5 +1,7 @@
 // src/utils/contexto_municipio.ts
 
+import { mapToKnownCategory } from './category';
+
 // Define la estructura del contexto específico para municipios.
 export interface MunicipioContext {
   estado_conversacion: 'inicio' | 'recolectando_info' | 'recolectando_datos_personales' | 'confirmando_reclamo' | 'reclamo_creado' | 'conversacion_general';
@@ -54,7 +56,7 @@ export function updateMunicipioContext(
     const { datos_estructura } = interaction.llmResponse;
     const reclamo = newContext.datos_reclamo;
 
-    if (datos_estructura.categoria) reclamo.categoria = datos_estructura.categoria;
+    if (datos_estructura.categoria) reclamo.categoria = mapToKnownCategory(datos_estructura.categoria);
     if (datos_estructura.descripcion) reclamo.descripcion = datos_estructura.descripcion;
     if (datos_estructura.ubicacion) reclamo.ubicacion = datos_estructura.ubicacion;
     if (datos_estructura.nombre_usuario_detectado) reclamo.nombre_ciudadano = datos_estructura.nombre_usuario_detectado;


### PR DESCRIPTION
## Summary
- map ticket categories to a predefined list to avoid creating new entries
- normalize ticket categories when updating conversation context and grouping tickets

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b84bc40fa4832282853ec8bee8a06c