### PR TITLE
normalize ticket categories

### DIFF
--- a/src/components/MapLibreMap.tsx
+++ b/src/components/MapLibreMap.tsx
@@ -58,200 +58,204 @@ export default function MapLibreMap({
       let styleImageMissingHandler: any;
       let loadHandler: any;
 
-      async function init() {
+      function init() {
         async function loadLocal() {
-        try {
-          const libMod = await import("maplibre-gl");
-          const workerMod = await import(
-            "maplibre-gl/dist/maplibre-gl-csp-worker"
-          );
-          const lib = (libMod as any).default || libMod;
-          const worker = (workerMod as any).default || workerMod;
-          if (worker) {
-            if ("workerClass" in lib) {
-              (lib as any).workerClass = worker;
-            } else if (typeof (lib as any).setWorkerClass === "function") {
-              (lib as any).setWorkerClass(worker);
-            }
-          }
-          return lib;
-        } catch (err) {
-          console.error("MapLibreMap: failed to load local library", err);
-          return null;
-        }
-      }
-
-      async function loadFromCDN() {
-        const existing = (window as any).maplibregl;
-        if (existing) return existing;
-
-        const scriptUrl = "https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js";
-        const cssUrl = "https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css";
-
-        await new Promise<void>((resolve, reject) => {
-          const script = document.createElement("script");
-          script.src = scriptUrl;
-          script.onload = () => resolve();
-          script.onerror = () => reject();
-          document.head.appendChild(script);
-        }).catch((cdnErr) => {
-          console.error("MapLibreMap: CDN script load failed", cdnErr);
-        });
-
-        if (!document.querySelector(`link[href="${cssUrl}"]`)) {
-          const link = document.createElement("link");
-          link.rel = "stylesheet";
-          link.href = cssUrl;
-          document.head.appendChild(link);
-        }
-
-        return (window as any).maplibregl || null;
-      }
-
-      let lib: any = await loadLocal();
-      if (!lib || typeof lib.Map !== "function") {
-        lib = await loadFromCDN();
-      }
-
-      if (!isMounted || !lib || typeof lib.Map !== "function") {
-        console.error("MapLibreMap: Map constructor unavailable", lib);
-        return;
-      }
-
-      const styleUrl = apiKey
-        ? `https://api.maptiler.com/maps/streets-v2/style.json?key=${apiKey}`
-        : "https://demotiles.maplibre.org/style.json";
-
-      const map = new lib.Map({
-        container: ref.current!,
-        style: styleUrl,
-        center: initialCenter,
-        zoom: initialZoom,
-      });
-
-      const hasOn = typeof (map as any).on === "function";
-      const hasRemove = typeof (map as any).remove === "function";
-      if (!hasOn || !hasRemove) {
-        console.error("MapLibreMap: map instance missing methods", map);
-        try {
-          map.remove?.();
-        } catch (rmErr) {
-          console.error("MapLibreMap: unable to cleanup incomplete map", rmErr);
-        }
-        return;
-      }
-
-      mapRef.current = map;
-      libRef.current = lib;
-      assertEventSource(map, "map");
-      safeOn(map, "error", (e) => {
-        console.error(
-          "MapLibreMap: style or runtime error",
-          (e as any)?.error ?? e
-        );
-        // Evita que MapLibre eleve el error y detenga la carga del mapa
-        (e as any)?.preventDefault?.();
-      });
-
-      try {
-        if (typeof lib.NavigationControl === "function") {
-          map.addControl?.(new lib.NavigationControl(), "top-right");
-        }
-
-        clickHandler = (e: any) => {
-          const { lng, lat } = e.lngLat || {};
-          if (typeof lng === "number" && typeof lat === "number") {
-            markerRef.current?.remove?.();
-            markerRef.current = new lib.Marker()
-              .setLngLat([lng, lat])
-              .addTo(map);
-            onSelect?.(lat, lng);
-          }
-        };
-
-        styleImageMissingHandler = (e: any) => {
-          const name = (e.id as string | undefined)?.trim() ?? "";
-          if (map.hasImage?.(name)) return;
-          // Si el estilo solicita un icono que no tenemos disponible,
-          // agregamos un pixel transparente para evitar errores fatales.
-          const empty = {
-            width: 1,
-            height: 1,
-            data: new Uint8Array([0, 0, 0, 0]),
-          };
           try {
-            map.addImage?.(name, empty as any);
-          } catch (imgErr) {
-            console.warn("No se pudo agregar imagen vacía", imgErr);
+            const libMod = await import("maplibre-gl");
+            const workerMod = await import(
+              "maplibre-gl/dist/maplibre-gl-csp-worker"
+            );
+            const lib = (libMod as any).default || libMod;
+            const worker = (workerMod as any).default || workerMod;
+            if (worker) {
+              if ("workerClass" in lib) {
+                (lib as any).workerClass = worker;
+              } else if (typeof (lib as any).setWorkerClass === "function") {
+                (lib as any).setWorkerClass(worker);
+              }
+            }
+            return lib;
+          } catch (err) {
+            console.error("MapLibreMap: failed to load local library", err);
+            return null;
           }
-        };
-
-        loadHandler = () => {
-          // Solo agregamos la capa de calor si se proporcionan datos.
-          if (heatmapData && heatmapData.length > 0) {
-            const sourceData = {
-              type: "FeatureCollection",
-              features: heatmapData.map((p) => ({
-                type: "Feature",
-                properties: {
-                  weight:
-                    p.weight ?? (p.estado?.toLowerCase() === "resuelto" ? 2 : 1),
-                },
-                geometry: { type: "Point", coordinates: [p.lng, p.lat] },
-              })),
-            } as const;
-
-            map.addSource?.("puntos", {
-              type: "geojson",
-              data: sourceData as any,
-            });
-
-            map.addLayer?.({
-              id: "tickets-heat",
-              type: "heatmap",
-              source: "puntos",
-              maxzoom: 15,
-              paint: {
-                "heatmap-weight": ["get", "weight"],
-                "heatmap-intensity": [
-                  "interpolate",
-                  ["linear"],
-                  ["zoom"],
-                  0,
-                  1,
-                  15,
-                  3,
-                ],
-                "heatmap-radius": ["interpolate", ["linear"], ["zoom"], 0, 2, 9, 20],
-                "heatmap-opacity": 0.6,
-              },
-            });
-
-            map.addLayer?.({
-              id: "tickets-circles",
-              type: "circle",
-              source: "puntos",
-              minzoom: 14,
-              paint: {
-                "circle-radius": 6,
-                "circle-color": "#3b82f6",
-                "circle-opacity": 0.9,
-              },
-            });
-          }
-        };
-
-        if (onSelect) {
-          safeOn(map, "click", clickHandler);
         }
-        safeOn(map, "styleimagemissing", styleImageMissingHandler);
-        safeOn(map, "load", loadHandler);
-      } catch (err) {
-        console.error("MapLibreMap: failed to configure map", err);
-      }
+
+        async function loadFromCDN() {
+          const existing = (window as any).maplibregl;
+          if (existing) return existing;
+
+          const scriptUrl = "https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js";
+          const cssUrl = "https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css";
+
+          await new Promise<void>((resolve, reject) => {
+            const script = document.createElement("script");
+            script.src = scriptUrl;
+            script.onload = () => resolve();
+            script.onerror = () => reject();
+            document.head.appendChild(script);
+          }).catch((cdnErr) => {
+            console.error("MapLibreMap: CDN script load failed", cdnErr);
+          });
+
+          if (!document.querySelector(`link[href="${cssUrl}"]`)) {
+            const link = document.createElement("link");
+            link.rel = "stylesheet";
+            link.href = cssUrl;
+            document.head.appendChild(link);
+          }
+
+          return (window as any).maplibregl || null;
+        }
+
+        loadLocal()
+          .catch(() => null)
+          .then(async (loaded) => {
+            let lib = loaded;
+            if (!lib || typeof lib.Map !== "function") {
+              lib = await loadFromCDN();
+            }
+
+            if (!isMounted || !lib || typeof lib.Map !== "function") {
+              console.error("MapLibreMap: Map constructor unavailable", lib);
+              return;
+            }
+
+            const styleUrl = apiKey
+              ? `https://api.maptiler.com/maps/streets-v2/style.json?key=${apiKey}`
+              : "https://demotiles.maplibre.org/style.json";
+
+            const map = new lib.Map({
+              container: ref.current!,
+              style: styleUrl,
+              center: initialCenter,
+              zoom: initialZoom,
+            });
+
+            const hasOn = typeof (map as any).on === "function";
+            const hasRemove = typeof (map as any).remove === "function";
+            if (!hasOn || !hasRemove) {
+              console.error("MapLibreMap: map instance missing methods", map);
+              try {
+                map.remove?.();
+              } catch (rmErr) {
+                console.error("MapLibreMap: unable to cleanup incomplete map", rmErr);
+              }
+              return;
+            }
+
+            mapRef.current = map;
+            libRef.current = lib;
+            assertEventSource(map, "map");
+            safeOn(map, "error", (e) => {
+              console.error(
+                "MapLibreMap: style or runtime error",
+                (e as any)?.error ?? e
+              );
+              // Evita que MapLibre eleve el error y detenga la carga del mapa
+              (e as any)?.preventDefault?.();
+            });
+
+            try {
+              if (typeof lib.NavigationControl === "function") {
+                map.addControl?.(new lib.NavigationControl(), "top-right");
+              }
+
+              clickHandler = (e: any) => {
+                const { lng, lat } = e.lngLat || {};
+                if (typeof lng === "number" && typeof lat === "number") {
+                  markerRef.current?.remove?.();
+                  markerRef.current = new lib.Marker()
+                    .setLngLat([lng, lat])
+                    .addTo(map);
+                  onSelect?.(lat, lng);
+                }
+              };
+
+              styleImageMissingHandler = (e: any) => {
+                const name = (e.id as string | undefined)?.trim() ?? "";
+                if (map.hasImage?.(name)) return;
+                // Si el estilo solicita un icono que no tenemos disponible,
+                // agregamos un pixel transparente para evitar errores fatales.
+                const empty = {
+                  width: 1,
+                  height: 1,
+                  data: new Uint8Array([0, 0, 0, 0]),
+                };
+                try {
+                  map.addImage?.(name, empty as any);
+                } catch (imgErr) {
+                  console.warn("No se pudo agregar imagen vacía", imgErr);
+                }
+              };
+
+              loadHandler = () => {
+                // Solo agregamos la capa de calor si se proporcionan datos.
+                if (heatmapData && heatmapData.length > 0) {
+                  const sourceData = {
+                    type: "FeatureCollection",
+                    features: heatmapData.map((p) => ({
+                      type: "Feature",
+                      properties: {
+                        weight:
+                          p.weight ?? (p.estado?.toLowerCase() === "resuelto" ? 2 : 1),
+                      },
+                      geometry: { type: "Point", coordinates: [p.lng, p.lat] },
+                    })),
+                  } as const;
+
+                  map.addSource?.("puntos", {
+                    type: "geojson",
+                    data: sourceData as any,
+                  });
+
+                  map.addLayer?.({
+                    id: "tickets-heat",
+                    type: "heatmap",
+                    source: "puntos",
+                    maxzoom: 15,
+                    paint: {
+                      "heatmap-weight": ["get", "weight"],
+                      "heatmap-intensity": [
+                        "interpolate",
+                        ["linear"],
+                        ["zoom"],
+                        0,
+                        1,
+                        15,
+                        3,
+                      ],
+                      "heatmap-radius": ["interpolate", ["linear"], ["zoom"], 0, 2, 9, 20],
+                      "heatmap-opacity": 0.6,
+                    },
+                  });
+
+                  map.addLayer?.({
+                    id: "tickets-circles",
+                    type: "circle",
+                    source: "puntos",
+                    minzoom: 14,
+                    paint: {
+                      "circle-radius": 6,
+                      "circle-color": "#3b82f6",
+                      "circle-opacity": 0.9,
+                    },
+                  });
+                }
+              };
+
+              if (onSelect) {
+                safeOn(map, "click", clickHandler);
+              }
+              safeOn(map, "styleimagemissing", styleImageMissingHandler);
+              safeOn(map, "load", loadHandler);
+            } catch (err) {
+              console.error("MapLibreMap: failed to configure map", err);
+            }
+          });
       }
 
-      void init();
+      init();
     return () => {
       isMounted = false;
       // Remove marker and all event listeners safely

--- a/src/components/MapLibreMap.tsx
+++ b/src/components/MapLibreMap.tsx
@@ -52,9 +52,14 @@ export default function MapLibreMap({
         "MapLibreMap: missing VITE_MAPTILER_KEY; using public demo tiles."
       );
     }
-    let isMounted = true;
-    (async () => {
-      async function loadLocal() {
+      let isMounted = true;
+      // Handlers are declared in the outer scope so they can be cleaned up on unmount
+      let clickHandler: any;
+      let styleImageMissingHandler: any;
+      let loadHandler: any;
+
+      async function init() {
+        async function loadLocal() {
         try {
           const libMod = await import("maplibre-gl");
           const workerMod = await import(
@@ -153,7 +158,7 @@ export default function MapLibreMap({
           map.addControl?.(new lib.NavigationControl(), "top-right");
         }
 
-        const clickHandler = (e: any) => {
+        clickHandler = (e: any) => {
           const { lng, lat } = e.lngLat || {};
           if (typeof lng === "number" && typeof lat === "number") {
             markerRef.current?.remove?.();
@@ -164,7 +169,7 @@ export default function MapLibreMap({
           }
         };
 
-        const styleImageMissingHandler = (e: any) => {
+        styleImageMissingHandler = (e: any) => {
           const name = (e.id as string | undefined)?.trim() ?? "";
           if (map.hasImage?.(name)) return;
           // Si el estilo solicita un icono que no tenemos disponible,
@@ -181,7 +186,7 @@ export default function MapLibreMap({
           }
         };
 
-        const loadHandler = () => {
+        loadHandler = () => {
           // Solo agregamos la capa de calor si se proporcionan datos.
           if (heatmapData && heatmapData.length > 0) {
             const sourceData = {
@@ -241,26 +246,22 @@ export default function MapLibreMap({
         }
         safeOn(map, "styleimagemissing", styleImageMissingHandler);
         safeOn(map, "load", loadHandler);
-
-        return () => {
-          markerRef.current?.remove?.();
-          map.off?.("click", clickHandler);
-          map.off?.("styleimagemissing", styleImageMissingHandler);
-          map.off?.("load", loadHandler);
-          try {
-            map.remove?.();
-          } catch (err) {
-            console.error("MapLibreMap: failed to remove map", err);
-          }
-        };
       } catch (err) {
         console.error("MapLibreMap: failed to configure map", err);
       }
-      })();
+      }
+
+      void init();
     return () => {
       isMounted = false;
+      // Remove marker and all event listeners safely
+      markerRef.current?.remove?.();
+      const map = mapRef.current;
+      map?.off?.("click", clickHandler);
+      map?.off?.("styleimagemissing", styleImageMissingHandler);
+      map?.off?.("load", loadHandler);
       try {
-        mapRef.current?.remove?.();
+        map?.remove?.();
       } catch (err) {
         console.error("MapLibreMap: failed to remove map", err);
       }

--- a/src/context/TicketContext.tsx
+++ b/src/context/TicketContext.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useState, useContext, useEffect, ReactNode, useCa
 import { Ticket } from '@/types/tickets';
 import { getTickets } from '@/services/ticketService';
 import useTicketUpdates from '@/hooks/useTicketUpdates';
+import { mapToKnownCategory } from '@/utils/category';
 
 interface TicketContextType {
   tickets: Ticket[];
@@ -25,11 +26,11 @@ const groupTicketsByCategory = (tickets: Ticket[]) => {
       resolved.push(ticket);
       return;
     }
-    const category = ticket.categoria || 'Sin Categoría';
+    const category = mapToKnownCategory(ticket.categoria);
     if (!groups[category]) {
       groups[category] = [];
     }
-    groups[category].push(ticket);
+    groups[category].push({ ...ticket, categoria: category });
   });
 
   if (resolved.length > 0) {
@@ -51,8 +52,12 @@ export const TicketProvider: React.FC<{ children: ReactNode }> = ({ children }) 
       const fetchedTickets = (apiResponse as any)?.tickets;
 
       if (Array.isArray(fetchedTickets)) {
-        setTickets(fetchedTickets);
-        setSelectedTicket((prev) => prev ?? (fetchedTickets[0] || null));
+        const normalizedTickets = fetchedTickets.map((t: Ticket) => ({
+          ...t,
+          categoria: mapToKnownCategory(t.categoria),
+        }));
+        setTickets(normalizedTickets);
+        setSelectedTicket((prev) => prev ?? (normalizedTickets[0] || null));
       } else {
         console.warn("La respuesta de la API no contiene un array de tickets:", apiResponse);
         setTickets([]);

--- a/src/utils/category.ts
+++ b/src/utils/category.ts
@@ -1,0 +1,23 @@
+export const DEFAULT_CATEGORIES = [
+  'Alumbrado',
+  'Bache',
+  'Limpieza',
+  'Arbolado',
+  'General'
+];
+
+function normalize(str: string): string {
+  return str
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[^\w\s]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function mapToKnownCategory(categoria?: string | null): string {
+  if (!categoria) return 'General';
+  const target = normalize(categoria);
+  const match = DEFAULT_CATEGORIES.find(c => normalize(c) === target);
+  return match || 'General';
+}

--- a/src/utils/contexto_municipio.ts
+++ b/src/utils/contexto_municipio.ts
@@ -1,5 +1,7 @@
 // src/utils/contexto_municipio.ts
 
+import { mapToKnownCategory } from './category';
+
 // Define la estructura del contexto específico para municipios.
 export interface MunicipioContext {
   estado_conversacion: 'inicio' | 'recolectando_info' | 'recolectando_datos_personales' | 'confirmando_reclamo' | 'reclamo_creado' | 'conversacion_general';
@@ -54,7 +56,7 @@ export function updateMunicipioContext(
     const { datos_estructura } = interaction.llmResponse;
     const reclamo = newContext.datos_reclamo;
 
-    if (datos_estructura.categoria) reclamo.categoria = datos_estructura.categoria;
+    if (datos_estructura.categoria) reclamo.categoria = mapToKnownCategory(datos_estructura.categoria);
     if (datos_estructura.descripcion) reclamo.descripcion = datos_estructura.descripcion;
     if (datos_estructura.ubicacion) reclamo.ubicacion = datos_estructura.ubicacion;
     if (datos_estructura.nombre_usuario_detectado) reclamo.nombre_ciudadano = datos_estructura.nombre_usuario_detectado;


### PR DESCRIPTION
## Summary
- define default complaint categories and helper to map unknown labels to existing ones
- normalize ticket categories on fetch and when grouping tickets
- refactor map initialization to use named async initializer with explicit invocation for cleaner setup and teardown

## Testing
- `npm install` *(fails: 403 Forbidden for mammoth package)*
- `npm test` *(fails: vitest: not found)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b84bc40fa4832282853ec8bee8a06c