### PR TITLE
Support origin coordinates in ticket map

### DIFF
--- a/docs/reclamos-flow.md
+++ b/docs/reclamos-flow.md
@@ -26,4 +26,8 @@ Este documento resume la lógica sugerida para manejar reclamos ciudadanos y con
 ## 6. Consulta de tickets
 - Permitir que el usuario ingrese su número de reclamo para obtener estado, fecha y comentarios. No abrir un chat nuevo a menos que lo solicite.
 
+- Si el ticket incluye coordenadas válidas, se muestra un mapa de Google que traza la ruta desde el municipio hasta la dirección del vecino.
+- Cuando no hay coordenadas, se intenta geolocalizar por la dirección textual.
+- La sección de historial presenta una línea de tiempo combinando los cambios de estado y los mensajes enviados por agentes y vecinos.
+
 Estas pautas están orientadas a mejorar la experiencia tanto del ciudadano como de los administradores del municipio, asegurando que se obtenga toda la información necesaria antes de crear un reclamo y que el seguimiento sea claro y eficiente.

--- a/src/components/TicketMap.tsx
+++ b/src/components/TicketMap.tsx
@@ -27,11 +27,22 @@ const buildFullAddress = (ticket: TicketLocation) => {
 const TicketMap: React.FC<{ ticket: TicketLocation }> = ({ ticket }) => {
   const direccionCompleta = buildFullAddress(ticket);
   const hasCoords =
-    typeof ticket.latitud === 'number' && typeof ticket.longitud === 'number';
-  const originLat = ticket.origen_latitud ?? ticket.municipio_latitud;
-  const originLon = ticket.origen_longitud ?? ticket.municipio_longitud;
-  const hasRoute =
-    hasCoords && typeof originLat === 'number' && typeof originLon === 'number';
+    typeof ticket.latitud === 'number' &&
+    typeof ticket.longitud === 'number' &&
+    (ticket.latitud !== 0 || ticket.longitud !== 0);
+  const originLat =
+    typeof ticket.origen_latitud === 'number' && ticket.origen_latitud !== 0
+      ? ticket.origen_latitud
+      : ticket.municipio_latitud;
+  const originLon =
+    typeof ticket.origen_longitud === 'number' && ticket.origen_longitud !== 0
+      ? ticket.origen_longitud
+      : ticket.municipio_longitud;
+  const hasOrigin =
+    typeof originLat === 'number' &&
+    typeof originLon === 'number' &&
+    (originLat !== 0 || originLon !== 0);
+  const hasRoute = hasCoords && hasOrigin;
   const mapSrc = hasRoute
     ? `https://www.google.com/maps/dir/?api=1&origin=${originLat},${originLon}&destination=${ticket.latitud},${ticket.longitud}&travelmode=driving&output=embed`
     : hasCoords

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -36,6 +36,10 @@ export interface Ticket {
   archivo_url?: string;        // URL a un archivo adjunto principal del ticket (diferente de los adjuntos en comentarios)
   categoria?: string;          // Categoría asignada al ticket
   municipio_nombre?: string;   // Nombre del municipio (relevante si tipo='municipio')
+  municipio_latitud?: number;  // Latitud del municipio u origen de la cuadrilla
+  municipio_longitud?: number; // Longitud del municipio u origen de la cuadrilla
+  origen_latitud?: number;     // Latitud específica de salida si difiere del municipio
+  origen_longitud?: number;    // Longitud específica de salida si difiere del municipio
 
   // Coordenadas geográficas
   latitud?: number | null;

--- a/src/types/tickets.ts
+++ b/src/types/tickets.ts
@@ -87,6 +87,11 @@ export interface Ticket {
   esquinas_cercanas?: string;
   latitud?: number;
   longitud?: number;
+  municipio_nombre?: string;
+  municipio_latitud?: number;
+  municipio_longitud?: number;
+  origen_latitud?: number;
+  origen_longitud?: number;
   avatarUrl?: string;
   history?: TicketHistoryEvent[];
 


### PR DESCRIPTION
## Summary
- handle 0,0 values in origin coordinates and fall back to municipality location
- expand Ticket types to carry municipality and origin coordinates
- document how ticket lookup shows a route map and combined status/message timeline

## Testing
- `npm install mammoth --no-audit --no-fund` (fails: 403 Forbidden for mammoth)
- `npm test` (fails: vitest not found)
- `npm run build` (fails: vite not found)


------
https://chatgpt.com/codex/tasks/task_e_68b872cd91bc8322bb4b897759c10008