### PR TITLE
Improve geolocation and tracking map

### DIFF
--- a/docs/reclamos-flow.md
+++ b/docs/reclamos-flow.md
@@ -26,4 +26,8 @@ Este documento resume la lógica sugerida para manejar reclamos ciudadanos y con
 ## 6. Consulta de tickets
 - Permitir que el usuario ingrese su número de reclamo para obtener estado, fecha y comentarios. No abrir un chat nuevo a menos que lo solicite.
 
+- Si el ticket incluye coordenadas válidas, se muestra un mapa basado en OpenStreetMap que traza la ruta desde el municipio hasta la dirección del vecino.
+- Cuando no hay coordenadas, se intenta geolocalizar por la dirección textual utilizando el buscador de OpenStreetMap.
+- La sección de historial presenta una línea de tiempo en orden cronológico combinando los cambios de estado y los mensajes enviados por agentes y vecinos.
+
 Estas pautas están orientadas a mejorar la experiencia tanto del ciudadano como de los administradores del municipio, asegurando que se obtenga toda la información necesaria antes de crear un reclamo y que el seguimiento sea claro y eficiente.

--- a/src/components/TicketMap.tsx
+++ b/src/components/TicketMap.tsx
@@ -27,17 +27,30 @@ const buildFullAddress = (ticket: TicketLocation) => {
 const TicketMap: React.FC<{ ticket: TicketLocation }> = ({ ticket }) => {
   const direccionCompleta = buildFullAddress(ticket);
   const hasCoords =
-    typeof ticket.latitud === 'number' && typeof ticket.longitud === 'number';
-  const originLat = ticket.origen_latitud ?? ticket.municipio_latitud;
-  const originLon = ticket.origen_longitud ?? ticket.municipio_longitud;
-  const hasRoute =
-    hasCoords && typeof originLat === 'number' && typeof originLon === 'number';
+    typeof ticket.latitud === 'number' &&
+    typeof ticket.longitud === 'number' &&
+    (ticket.latitud !== 0 || ticket.longitud !== 0);
+  const originLat =
+    typeof ticket.origen_latitud === 'number' && ticket.origen_latitud !== 0
+      ? ticket.origen_latitud
+      : ticket.municipio_latitud;
+  const originLon =
+    typeof ticket.origen_longitud === 'number' && ticket.origen_longitud !== 0
+      ? ticket.origen_longitud
+      : ticket.municipio_longitud;
+  const hasOrigin =
+    typeof originLat === 'number' &&
+    typeof originLon === 'number' &&
+    (originLat !== 0 || originLon !== 0);
+  const hasRoute = hasCoords && hasOrigin;
   const mapSrc = hasRoute
-    ? `https://www.google.com/maps/dir/?api=1&origin=${originLat},${originLon}&destination=${ticket.latitud},${ticket.longitud}&travelmode=driving&output=embed`
+    ? `https://www.openstreetmap.org/directions?engine=fossgis_osrm_car&route=${originLat},${originLon};${ticket.latitud},${ticket.longitud}`
     : hasCoords
-      ? `https://www.google.com/maps?q=${ticket.latitud},${ticket.longitud}&output=embed`
-      : `https://www.google.com/maps?q=${encodeURIComponent(direccionCompleta)}&output=embed`;
-  return ticket.direccion || hasCoords ? (
+      ? `https://www.openstreetmap.org/export/embed.html?mlat=${ticket.latitud}&mlon=${ticket.longitud}&marker=${ticket.latitud},${ticket.longitud}&zoom=15&layer=mapnik`
+      : direccionCompleta
+        ? `https://www.openstreetmap.org/search?query=${encodeURIComponent(direccionCompleta)}`
+        : '';
+  return mapSrc ? (
     <div className="mb-6">
       <h4 className="font-semibold mb-2">Ubicación aproximada</h4>
       {/* Responsive height for the map container */}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -36,6 +36,10 @@ export interface Ticket {
   archivo_url?: string;        // URL a un archivo adjunto principal del ticket (diferente de los adjuntos en comentarios)
   categoria?: string;          // Categoría asignada al ticket
   municipio_nombre?: string;   // Nombre del municipio (relevante si tipo='municipio')
+  municipio_latitud?: number;  // Latitud del municipio u origen de la cuadrilla
+  municipio_longitud?: number; // Longitud del municipio u origen de la cuadrilla
+  origen_latitud?: number;     // Latitud específica de salida si difiere del municipio
+  origen_longitud?: number;    // Longitud específica de salida si difiere del municipio
 
   // Coordenadas geográficas
   latitud?: number | null;

--- a/src/types/tickets.ts
+++ b/src/types/tickets.ts
@@ -87,6 +87,11 @@ export interface Ticket {
   esquinas_cercanas?: string;
   latitud?: number;
   longitud?: number;
+  municipio_nombre?: string;
+  municipio_latitud?: number;
+  municipio_longitud?: number;
+  origen_latitud?: number;
+  origen_longitud?: number;
   avatarUrl?: string;
   history?: TicketHistoryEvent[];
 


### PR DESCRIPTION
## Summary
- show routes using OpenStreetMap from municipality origin to ticket address
- fall back to OpenStreetMap search when only textual address is available
- document ticket lookup timeline combining messages and status changes

## Testing
- `npm install --no-audit --no-fund` (fails: 403 Forbidden - GET https://registry.npmjs.org/mammoth)
- `npm test` (fails: vitest not found)
- `npm run build` (fails: vite not found)


------
https://chatgpt.com/codex/tasks/task_e_68b872cd91bc8322bb4b897759c10008