### PR TITLE
fix: correct MapLibreMap init closure

### DIFF
--- a/src/components/MapLibreMap.tsx
+++ b/src/components/MapLibreMap.tsx
@@ -253,8 +253,7 @@ export default function MapLibreMap({
               console.error("MapLibreMap: failed to configure map", err);
             }
           });
-      }
-      };
+        };
 
       init();
     return () => {


### PR DESCRIPTION
## Summary
- fix syntax error in MapLibreMap initialization

## Testing
- `npm install` *(fails: 403 Forbidden for mammoth)*
- `npm test` *(fails: vitest: not found)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b880a533608322900a1d298cf352b4