### PR TITLE
Add WhatsApp promotion broadcast form

### DIFF
--- a/src/components/MapLibreMap.tsx
+++ b/src/components/MapLibreMap.tsx
@@ -58,7 +58,7 @@ export default function MapLibreMap({
       let styleImageMissingHandler: any;
       let loadHandler: any;
 
-      (async () => {
+      const init = async () => {
         async function loadLocal() {
         try {
           const libMod = await import("maplibre-gl");
@@ -249,7 +249,9 @@ export default function MapLibreMap({
       } catch (err) {
         console.error("MapLibreMap: failed to configure map", err);
       }
-      })();
+      };
+
+      init();
     return () => {
       isMounted = false;
       // Remove marker and all event listeners safely

--- a/src/components/admin/PromotionForm.tsx
+++ b/src/components/admin/PromotionForm.tsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+import { Button } from '@/components/ui/button';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Loader2 } from 'lucide-react';
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+const ACCEPTED_IMAGE_TYPES = [
+  'image/jpeg',
+  'image/jpg',
+  'image/png',
+  'image/webp',
+];
+
+const promotionFormSchema = z.object({
+  title: z
+    .string()
+    .min(3, { message: 'El título debe tener al menos 3 caracteres.' })
+    .max(100),
+  description: z
+    .string()
+    .min(5, { message: 'La descripción debe tener al menos 5 caracteres.' }),
+  link: z
+    .string()
+    .url({ message: 'Por favor, introduce una URL válida.' }),
+  flyer: z
+    .any()
+    .optional()
+    .refine(
+      (files) => {
+        if (!files || files.length === 0) return true;
+        return files?.[0]?.size <= MAX_FILE_SIZE;
+      },
+      `El tamaño máximo de la imagen es 5MB.`
+    )
+    .refine(
+      (files) => {
+        if (!files || files.length === 0) return true;
+        return ACCEPTED_IMAGE_TYPES.includes(files?.[0]?.type);
+      },
+      'Solo se aceptan formatos .jpg, .png, y .webp.'
+    ),
+});
+
+export type PromotionFormValues = z.infer<typeof promotionFormSchema>;
+
+interface PromotionFormProps {
+  onSubmit: (values: PromotionFormValues) => void;
+  onCancel: () => void;
+  isSubmitting?: boolean;
+}
+
+export const PromotionForm: React.FC<PromotionFormProps> = ({
+  onSubmit,
+  onCancel,
+  isSubmitting,
+}) => {
+  const form = useForm<PromotionFormValues>({
+    resolver: zodResolver(promotionFormSchema),
+    defaultValues: {
+      title: '',
+      description: '',
+      link: '',
+      flyer: undefined,
+    },
+  });
+
+  function handleFormSubmit(values: PromotionFormValues) {
+    onSubmit(values);
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(handleFormSubmit)} className="space-y-6">
+        <FormField
+          control={form.control}
+          name="title"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Título</FormLabel>
+              <FormControl>
+                <Input placeholder="Ej: Promoción de verano" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="description"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Descripción</FormLabel>
+              <FormControl>
+                <Textarea
+                  placeholder="Describe tu promoción..."
+                  className="resize-y"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="link"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Enlace</FormLabel>
+              <FormControl>
+                <Input placeholder="https://..." {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="flyer"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Flyer (Opcional)</FormLabel>
+              <FormControl>
+                <Input
+                  type="file"
+                  accept="image/*"
+                  onChange={(e) => field.onChange(e.target.files)}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <div className="flex justify-end gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onCancel}
+            className="w-full sm:w-auto"
+          >
+            Cancelar
+          </Button>
+          <Button type="submit" disabled={isSubmitting} className="w-full sm:w-auto">
+            {isSubmitting && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+            Enviar Promoción
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+};
+
+export default PromotionForm;
+

--- a/src/pages/Perfil.tsx
+++ b/src/pages/Perfil.tsx
@@ -21,8 +21,10 @@ import {
   FileCog, // Icono general para formatos/mapeos
   Wand2, // Icono para sugerencias
   Loader2, // Icono de carga
+  Megaphone, // Icono para promociones
 } from "lucide-react";
 import { EventForm } from "@/components/admin/EventForm";
+import { PromotionForm, PromotionFormValues } from "@/components/admin/PromotionForm";
 import { AgendaPasteForm } from "@/components/admin/AgendaPasteForm";
 import MunicipioIcon from "@/components/ui/MunicipioIcon";
 import { Badge } from "@/components/ui/badge";
@@ -145,7 +147,19 @@ export default function Perfil() {
   const [horariosOpen, setHorariosOpen] = useState(false);
   const [isEventModalOpen, setIsEventModalOpen] = useState(false);
   const [isSubmittingEvent, setIsSubmittingEvent] = useState(false);
-  const [activeEventTab, setActiveEventTab] = useState<"event" | "news" | "paste">("event");
+  const [activeEventTab, setActiveEventTab] = useState<
+    "event" | "news" | "paste" | "promotion"
+  >("event");
+  const [isSubmittingPromotion, setIsSubmittingPromotion] = useState(false);
+  const [hasSentPromotionToday, setHasSentPromotionToday] = useState(false);
+
+  useEffect(() => {
+    const lastPromotionDate = safeLocalStorage.getItem('lastPromotionDate');
+    const today = new Date().toISOString().slice(0, 10);
+    if (lastPromotionDate === today) {
+      setHasSentPromotionToday(true);
+    }
+  }, []);
 
   const handleSubmitPost = async (values: any) => {
     setIsSubmittingEvent(true);
@@ -202,6 +216,42 @@ export default function Perfil() {
       });
     } finally {
       setIsSubmittingEvent(false);
+    }
+  };
+
+  const handleSubmitPromotion = async (values: PromotionFormValues) => {
+    setIsSubmittingPromotion(true);
+    try {
+      const formData = new FormData();
+      formData.append('title', values.title);
+      formData.append('description', values.description);
+      formData.append('link', values.link);
+      formData.append('languages', 'es');
+      if (values.flyer && values.flyer.length > 0) {
+        formData.append('flyer_image', values.flyer[0]);
+      }
+
+      await apiFetch('/municipal/promotions', {
+        method: 'POST',
+        body: formData,
+      });
+
+      toast({
+        title: "Éxito",
+        description: "La promoción se ha enviado correctamente.",
+      });
+      const today = new Date().toISOString().slice(0, 10);
+      safeLocalStorage.setItem('lastPromotionDate', today);
+      setHasSentPromotionToday(true);
+      setIsEventModalOpen(false);
+    } catch (error) {
+      toast({
+        variant: "destructive",
+        title: "Error al enviar la promoción",
+        description: getErrorMessage(error, "No se pudo enviar la promoción. Intenta de nuevo."),
+      });
+    } finally {
+      setIsSubmittingPromotion(false);
     }
   };
   const [ticketLocations, setTicketLocations] = useState<HeatPoint[]>([]);
@@ -1406,6 +1456,22 @@ export default function Perfil() {
                     <UploadCloud className="w-4 h-4 mr-2" />
                     Subir Información
                   </Button>
+                  <Button
+                    onClick={() => {
+                      setActiveEventTab("promotion");
+                      setIsEventModalOpen(true);
+                    }}
+                    disabled={hasSentPromotionToday}
+                    className="w-full bg-primary hover:bg-primary/90 text-primary-foreground py-2.5"
+                  >
+                    <Megaphone className="w-4 h-4 mr-2" />
+                    Promocionar en WhatsApp
+                  </Button>
+                  {hasSentPromotionToday && (
+                    <p className="text-xs text-muted-foreground text-center">
+                      Ya enviaste una promoción hoy. Podrás enviar otra mañana.
+                    </p>
+                  )}
                 </div>
               </CardContent>
             </Card>
@@ -1572,10 +1638,11 @@ export default function Perfil() {
           </DialogHeader>
           <div className="py-4 max-h-[70vh] overflow-y-auto px-2">
             <Tabs value={activeEventTab} onValueChange={setActiveEventTab}>
-              <TabsList className="mb-4 grid w-full grid-cols-3">
+              <TabsList className="mb-4 grid w-full grid-cols-4">
                 <TabsTrigger value="event">Evento</TabsTrigger>
                 <TabsTrigger value="news">Noticia</TabsTrigger>
                 <TabsTrigger value="paste">Subir Información</TabsTrigger>
+                <TabsTrigger value="promotion">Promocionar</TabsTrigger>
               </TabsList>
               <TabsContent value="event">
                 <EventForm
@@ -1595,6 +1662,13 @@ export default function Perfil() {
               </TabsContent>
               <TabsContent value="paste">
                 <AgendaPasteForm onCancel={() => setIsEventModalOpen(false)} />
+              </TabsContent>
+              <TabsContent value="promotion">
+                <PromotionForm
+                  onCancel={() => setIsEventModalOpen(false)}
+                  isSubmitting={isSubmittingPromotion}
+                  onSubmit={handleSubmitPromotion}
+                />
               </TabsContent>
             </Tabs>
           </div>


### PR DESCRIPTION
## Summary
- allow admins to launch WhatsApp promotions from the profile's events section
- load MapLibre asynchronously to avoid top-level await build errors

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/mammoth)*
- `npm test` *(fails: vitest: not found)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b861d11ab08322b8cfe311b759509c