### PR TITLE
Add WhatsApp promotion trigger in event creation

### DIFF
--- a/src/components/admin/EventForm.tsx
+++ b/src/components/admin/EventForm.tsx
@@ -66,9 +66,21 @@ interface EventFormProps {
   isSubmitting?: boolean;
   initialData?: Partial<EventFormValues>;
   fixedTipoPost?: 'noticia' | 'evento';
+  onPromote?: (values: EventFormValues) => void;
+  isPromoting?: boolean;
+  disablePromote?: boolean;
 }
 
-export const EventForm: React.FC<EventFormProps> = ({ onSubmit, onCancel, isSubmitting, initialData, fixedTipoPost }) => {
+export const EventForm: React.FC<EventFormProps> = ({
+  onSubmit,
+  onCancel,
+  isSubmitting,
+  initialData,
+  fixedTipoPost,
+  onPromote,
+  isPromoting,
+  disablePromote,
+}) => {
   const form = useForm<EventFormValues>({
     resolver: zodResolver(eventFormSchema),
     defaultValues: {
@@ -389,10 +401,26 @@ export const EventForm: React.FC<EventFormProps> = ({ onSubmit, onCancel, isSubm
           )}
         />
         <div className="flex justify-end gap-4 pt-4">
-          <Button type="button" variant="ghost" onClick={onCancel} disabled={isSubmitting}>
+          <Button type="button" variant="ghost" onClick={onCancel} disabled={isSubmitting || isPromoting}>
             Cancelar
           </Button>
-          <Button type="submit" disabled={isSubmitting}>
+          {onPromote && (
+            <Button
+              type="button"
+              onClick={form.handleSubmit(onPromote)}
+              disabled={isPromoting || disablePromote}
+            >
+              {isPromoting ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Enviando...
+                </>
+              ) : (
+                'Promocionar'
+              )}
+            </Button>
+          )}
+          <Button type="submit" disabled={isSubmitting || isPromoting}>
             {isSubmitting ? (
               <>
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />

--- a/src/components/admin/PromotionForm.tsx
+++ b/src/components/admin/PromotionForm.tsx
@@ -15,14 +15,6 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Loader2 } from 'lucide-react';
 
-const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
-const ACCEPTED_IMAGE_TYPES = [
-  'image/jpeg',
-  'image/jpg',
-  'image/png',
-  'image/webp',
-];
-
 const promotionFormSchema = z.object({
   title: z
     .string()
@@ -34,23 +26,11 @@ const promotionFormSchema = z.object({
   link: z
     .string()
     .url({ message: 'Por favor, introduce una URL válida.' }),
-  flyer: z
-    .any()
+  imageUrl: z
+    .string()
+    .url({ message: 'Por favor, introduce una URL válida.' })
     .optional()
-    .refine(
-      (files) => {
-        if (!files || files.length === 0) return true;
-        return files?.[0]?.size <= MAX_FILE_SIZE;
-      },
-      `El tamaño máximo de la imagen es 5MB.`
-    )
-    .refine(
-      (files) => {
-        if (!files || files.length === 0) return true;
-        return ACCEPTED_IMAGE_TYPES.includes(files?.[0]?.type);
-      },
-      'Solo se aceptan formatos .jpg, .png, y .webp.'
-    ),
+    .or(z.literal('')),
 });
 
 export type PromotionFormValues = z.infer<typeof promotionFormSchema>;
@@ -72,7 +52,7 @@ export const PromotionForm: React.FC<PromotionFormProps> = ({
       title: '',
       description: '',
       link: '',
-      flyer: undefined,
+      imageUrl: '',
     },
   });
 
@@ -128,16 +108,12 @@ export const PromotionForm: React.FC<PromotionFormProps> = ({
         />
         <FormField
           control={form.control}
-          name="flyer"
+          name="imageUrl"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Flyer (Opcional)</FormLabel>
+              <FormLabel>URL de la Imagen (Opcional)</FormLabel>
               <FormControl>
-                <Input
-                  type="file"
-                  accept="image/*"
-                  onChange={(e) => field.onChange(e.target.files)}
-                />
+                <Input placeholder="https://ejemplo.com/flyer.jpg" {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>


### PR DESCRIPTION
## Summary
- Allow events or news to trigger WhatsApp promotions directly from the creation form
- Switch promotion form to use image URLs and call `/api/whatsapp/promocionar`
- Query backend for daily promotion availability and handle limit errors

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden fetching mammoth)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d53317408322b91a6b9d89da09c5