### PR TITLE
feat: improve ticket timeline and map reliability

### DIFF
--- a/src/services/ticketService.ts
+++ b/src/services/ticketService.ts
@@ -210,8 +210,9 @@ export const getTicketTimeline = async (
         });
       } else {
         history.push({
-          status: evt.estado || '',
+          status: evt.estado || (evt.tipo === 'ticket_creado' ? 'ticket_creado' : ''),
           date: evt.fecha,
+          notes: evt.texto || (evt as any).comentario || undefined,
         });
       }
     });


### PR DESCRIPTION
## Summary
- use Google Maps with OpenStreetMap fallback for ticket location widget
- preserve notes and ticket creation events in timeline history

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - mammoth)*

------
https://chatgpt.com/codex/tasks/task_e_68b8daa54524832282ed61bfc70478b6