### PR TITLE
fix: restore ticket categories and map details

### DIFF
--- a/src/components/TicketMap.tsx
+++ b/src/components/TicketMap.tsx
@@ -4,6 +4,8 @@ interface TicketLocation {
   latitud?: number | null;
   longitud?: number | null;
   direccion?: string | null;
+  esquinas_cercanas?: string | null;
+  distrito?: string | null;
   municipio_nombre?: string | null;
   tipo?: 'pyme' | 'municipio';
   origen_latitud?: number | null;
@@ -13,15 +15,20 @@ interface TicketLocation {
 }
 
 const buildFullAddress = (ticket: TicketLocation) => {
-  const direccion = ticket.direccion || '';
+  const parts: string[] = [];
+  if (ticket.direccion) parts.push(ticket.direccion);
+  if (ticket.esquinas_cercanas) parts.push(ticket.esquinas_cercanas);
+  if (ticket.distrito) parts.push(ticket.distrito);
   if (
     ticket.tipo !== 'pyme' &&
     ticket.municipio_nombre &&
-    !direccion.toLowerCase().includes(ticket.municipio_nombre.toLowerCase())
+    !parts.some(p =>
+      p.toLowerCase().includes(ticket.municipio_nombre!.toLowerCase())
+    )
   ) {
-    return `${direccion ? `${direccion}, ` : ''}${ticket.municipio_nombre}`;
+    parts.push(ticket.municipio_nombre);
   }
-  return direccion;
+  return parts.join(', ');
 };
 
 const TicketMap: React.FC<{ ticket: TicketLocation }> = ({ ticket }) => {

--- a/src/components/TicketMap.tsx
+++ b/src/components/TicketMap.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-interface TicketLocation {
+export interface TicketLocation {
   latitud?: number | null;
   longitud?: number | null;
   direccion?: string | null;
@@ -14,7 +14,7 @@ interface TicketLocation {
   municipio_longitud?: number | null;
 }
 
-const buildFullAddress = (ticket: TicketLocation) => {
+export const buildFullAddress = (ticket: TicketLocation) => {
   const parts: string[] = [];
   if (ticket.direccion) parts.push(ticket.direccion);
   if (ticket.esquinas_cercanas) parts.push(ticket.esquinas_cercanas);

--- a/src/components/tickets/DetailsPanel.tsx
+++ b/src/components/tickets/DetailsPanel.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Mail, MapPin, Ticket as TicketIcon, Info, FileDown, User, ExternalLink, MessageCircle, Building, Hash, Copy, ChevronDown, ChevronUp, UserCheck, Bot } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { motion } from 'framer-motion';
-import TicketMap from '../TicketMap';
+import TicketMap, { buildFullAddress } from '../TicketMap';
 import TicketTimeline from './TicketTimeline';
 import { useTickets } from '@/context/TicketContext';
 import { exportToPdf, exportToXlsx } from '@/services/exportService';
@@ -111,13 +111,8 @@ const DetailsPanel: React.FC = () => {
       );
       return;
     }
-    const address = [
-      ticket.direccion,
-      ticket.esquinas_cercanas,
-      ticket.distrito,
-    ]
-      .filter(Boolean)
-      .join(', ');
+    const address = buildFullAddress(ticket);
+    if (!address) return;
     window.open(
       `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(address)}`,
       '_blank'

--- a/src/components/tickets/DetailsPanel.tsx
+++ b/src/components/tickets/DetailsPanel.tsx
@@ -104,10 +104,24 @@ const DetailsPanel: React.FC = () => {
 
   const openGoogleMaps = () => {
     if (!ticket) return;
-    const url = ticket.latitud && ticket.longitud
-      ? `https://www.google.com/maps/search/?api=1&query=${ticket.latitud},${ticket.longitud}`
-      : `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(ticket.direccion || '')}`;
-    window.open(url, '_blank');
+    if (ticket.latitud && ticket.longitud) {
+      window.open(
+        `https://www.google.com/maps/search/?api=1&query=${ticket.latitud},${ticket.longitud}`,
+        '_blank'
+      );
+      return;
+    }
+    const address = [
+      ticket.direccion,
+      ticket.esquinas_cercanas,
+      ticket.distrito,
+    ]
+      .filter(Boolean)
+      .join(', ');
+    window.open(
+      `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(address)}`,
+      '_blank'
+    );
   };
 
   React.useEffect(() => {

--- a/src/context/TicketContext.tsx
+++ b/src/context/TicketContext.tsx
@@ -54,7 +54,7 @@ export const TicketProvider: React.FC<{ children: ReactNode }> = ({ children }) 
       if (Array.isArray(fetchedTickets)) {
         const normalizedTickets = fetchedTickets.map((t: Ticket) => ({
           ...t,
-          categoria: mapToKnownCategory(t.categoria),
+          categoria: mapToKnownCategory(t.categoria, t.categories),
         }));
         setTickets(normalizedTickets);
         setSelectedTicket((prev) => prev ?? (normalizedTickets[0] || null));

--- a/src/types/tickets.ts
+++ b/src/types/tickets.ts
@@ -84,6 +84,10 @@ export interface Ticket {
   estado: TicketStatus;
   fecha: string; // ISO format
   categoria?: string;
+  categories?: string[];
+  categoria_principal?: string;
+  categoria_secundaria?: string;
+  categoria_simple?: string;
   direccion?: string;
   distrito?: string;
   esquinas_cercanas?: string;

--- a/src/utils/category.ts
+++ b/src/utils/category.ts
@@ -1,23 +1,3 @@
-export const DEFAULT_CATEGORIES = [
-  'Alumbrado',
-  'Bache',
-  'Limpieza',
-  'Arbolado',
-  'General'
-];
-
-function normalize(str: string): string {
-  return str
-    .toLowerCase()
-    .normalize('NFD')
-    .replace(/[^\w\s]/g, '')
-    .replace(/\s+/g, ' ')
-    .trim();
-}
-
 export function mapToKnownCategory(categoria?: string | null): string {
-  if (!categoria) return 'General';
-  const target = normalize(categoria);
-  const match = DEFAULT_CATEGORIES.find(c => normalize(c) === target);
-  return match || 'General';
+  return categoria?.toString().trim() || 'General';
 }

--- a/src/utils/category.ts
+++ b/src/utils/category.ts
@@ -1,3 +1,16 @@
-export function mapToKnownCategory(categoria?: string | null): string {
-  return categoria?.toString().trim() || 'General';
+export function mapToKnownCategory(
+  categoria?: string | null,
+  categories?: (string | null | undefined)[] | null
+): string {
+  const direct = categoria?.toString().trim();
+  if (direct) return direct;
+
+  if (Array.isArray(categories)) {
+    for (const c of categories) {
+      const trimmed = c?.toString().trim();
+      if (trimmed) return trimmed;
+    }
+  }
+
+  return 'General';
 }


### PR DESCRIPTION
## Summary
- stop forcing tickets into predefined categories
- include intersections and districts in map addresses

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b909c3ca9c83229cb0b1cd645beab5