### PR TITLE
feat: assign categories to employees

### DIFF
--- a/src/pages/InternalUsers.tsx
+++ b/src/pages/InternalUsers.tsx
@@ -12,6 +12,7 @@ interface InternalUser {
   email: string;
   rol?: string | null;
   atendidos?: number | null;
+  categoria_id?: number | null;
 }
 
 interface Category {
@@ -45,14 +46,12 @@ useRequireRole(['admin', 'super_admin'] as Role[]);
         }
         setLoading(false);
       });
-    apiFetch<Category[]>('/municipal/categorias')
+    apiFetch<{ categorias: Category[] }>('/municipal/categorias', { sendEntityToken: true })
       .then((data) => {
-        if (Array.isArray(data)) {
-          setCategories(data);
+        if (Array.isArray(data.categorias)) {
+          setCategories(data.categorias);
         } else {
-          // Log an error or handle unexpected data format if necessary
-          console.warn("Categories data is not an array:", data);
-          setCategories([]); // Default to an empty array
+          setCategories([]);
         }
       })
       .catch((err: any) => {
@@ -154,23 +153,28 @@ useRequireRole(['admin', 'super_admin'] as Role[]);
             <th className="p-2">Nombre</th>
             <th className="p-2">Email</th>
             <th className="p-2">Rol</th>
+            <th className="p-2">Categoría</th>
             <th className="p-2">Tickets atendidos</th>
             <th className="p-2">Acciones</th>
           </tr>
         </thead>
         <tbody>
-          {users.map((u) => (
-            <tr key={u.id} className="border-t">
-              <td className="p-2">{u.nombre}</td>
-              <td className="p-2">{u.email}</td>
-              <td className="p-2">{u.rol || '-'}</td>
-              <td className="p-2">{u.atendidos || 0}</td>
-              <td className="p-2">
-                <Button variant="outline" size="sm" className="mr-2">Editar</Button>
-                <Button variant="destructive" size="sm" onClick={() => handleDelete(u.id)}>Eliminar</Button>
-              </td>
-            </tr>
-          ))}
+          {users.map((u) => {
+            const categoriaNombre = categories.find((c) => c.id === u.categoria_id)?.nombre;
+            return (
+              <tr key={u.id} className="border-t">
+                <td className="p-2">{u.nombre}</td>
+                <td className="p-2">{u.email}</td>
+                <td className="p-2">{u.rol || '-'}</td>
+                <td className="p-2">{categoriaNombre || '-'}</td>
+                <td className="p-2">{u.atendidos || 0}</td>
+                <td className="p-2">
+                  <Button variant="outline" size="sm" className="mr-2">Editar</Button>
+                  <Button variant="destructive" size="sm" onClick={() => handleDelete(u.id)}>Eliminar</Button>
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </div>

--- a/src/pages/Perfil.tsx
+++ b/src/pages/Perfil.tsx
@@ -400,10 +400,12 @@ export default function Perfil() {
 
   const fetchCategories = useCallback(async () => {
     try {
-      const data = await apiFetch<{ id: number; nombre: string }[]>(
+      const data = await apiFetch<{ categorias: { id: number; nombre: string }[] }>(
         '/municipal/categorias'
       );
-      setAvailableCategories(data.map((c) => c.nombre));
+      setAvailableCategories(
+        Array.isArray(data.categorias) ? data.categorias.map((c) => c.nombre) : []
+      );
     } catch (error) {
       console.error('Error fetching ticket categories:', error);
     }

--- a/src/pages/UsuariosPage.tsx
+++ b/src/pages/UsuariosPage.tsx
@@ -113,6 +113,7 @@ export default function UsuariosPage() {
                   <th className="p-2 cursor-pointer" onClick={() => requestSort('telefono')}>
                     Teléfono {sortConfig?.key === 'telefono' ? (sortConfig.direction === 'asc' ? '▲' : '▼') : ''}
                   </th>
+                  <th className="p-2">Etiquetas</th>
                 </tr>
               </thead>
               <tbody>
@@ -121,6 +122,7 @@ export default function UsuariosPage() {
                     <td className="p-2">{u.nombre}</td>
                     <td className="p-2">{u.email}</td>
                     <td className="p-2">{u.telefono || '-'}</td>
+                    <td className="p-2">{u.etiquetas && u.etiquetas.length > 0 ? u.etiquetas.join(', ') : '-'}</td>
                   </tr>
                 ))}
               </tbody>

--- a/src/pages/admin/CategoryManagementPage.tsx
+++ b/src/pages/admin/CategoryManagementPage.tsx
@@ -30,8 +30,8 @@ const CategoryManagementPage: React.FC = () => {
   const fetchCategories = useCallback(async () => {
     setIsLoading(true);
     try {
-      const data = await apiFetch<Category[]>('/municipal/categorias', { sendEntityToken: true });
-      setCategories(data);
+      const data = await apiFetch<{ categorias: Category[] }>('/municipal/categorias', { sendEntityToken: true });
+      setCategories(Array.isArray(data.categorias) ? data.categorias : []);
       setError(null);
     } catch (err) {
       const message = err instanceof ApiError ? err.message : 'Ocurrió un error al cargar las categorías.';

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -64,6 +64,7 @@ export async function apiFetch<T>(
   }
   if (effectiveEntityToken) {
     headers["X-Entity-Token"] = effectiveEntityToken;
+    headers["token"] = effectiveEntityToken;
   }
   // Log request details without exposing full tokens
   const mask = (t: string | null) => (t ? `${t.slice(0, 8)}...` : null);


### PR DESCRIPTION
## Summary
- adapt category requests to backend's {categorias: []} response shape
- include entity token in `token` header for API calls

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68b90d6dfd44832296ecdef8830968d0