### PR TITLE
fix: handle base64url tokens in integration widget

### DIFF
--- a/docs/integracion.tsx
+++ b/docs/integracion.tsx
@@ -5,7 +5,9 @@ const ENTITY_TOKEN = 'REPLACE_WITH_STATIC_ENTITY_TOKEN';
 
 function decodeExpiration(jwt: string): number {
   const [, payload] = jwt.split('.');
-  const { exp } = JSON.parse(atob(payload));
+  const base64 = payload.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = base64.padEnd(base64.length + (4 - (base64.length % 4)) % 4, '=');
+  const { exp } = JSON.parse(atob(padded));
   return exp * 1000; // exp comes in seconds, convert to ms
 }
 

--- a/src/pages/Integracion.tsx
+++ b/src/pages/Integracion.tsx
@@ -177,7 +177,9 @@ ${customLines ? customLines + "\n" : ""}  // Importante para la geolocalización
       };
 
       const [, payload] = token.split('.');
-      const { exp } = JSON.parse(atob(payload));
+      const base64 = payload.replace(/-/g, '+').replace(/_/g, '/');
+      const padded = base64.padEnd(base64.length + (4 - (base64.length % 4)) % 4, '=');
+      const { exp } = JSON.parse(atob(padded));
       const refreshMs = exp * 1000 - Date.now() - 60000;
       setTimeout(loadWidget, Math.max(refreshMs, 30000));
     } catch (err) {


### PR DESCRIPTION
## Summary
- decode widget tokens with base64url-safe logic
- update sample integration script to refresh using decoded expiration

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b926951a948322830b4b72f71da4b6