### PR TITLE
fix: avoid widget token preflight redirect

### DIFF
--- a/docs/integracion.tsx
+++ b/docs/integracion.tsx
@@ -51,7 +51,7 @@ export default function Integracion() {
 
   async function refreshToken() {
     try {
-      const res = await fetch('https://chatboc.ar/auth/widget-token', {
+      const res = await fetch('https://chatboc.ar/auth/widget-token/', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ token: ENTITY_TOKEN })

--- a/src/pages/Integracion.tsx
+++ b/src/pages/Integracion.tsx
@@ -131,7 +131,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   async function loadWidget() {
     try {
-      const res = await fetch('https://chatboc.ar/auth/widget-token', {
+      const res = await fetch('https://chatboc.ar/auth/widget-token/', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ token: ENTITY_TOKEN })


### PR DESCRIPTION
## Summary
- ensure widget token requests hit non-redirecting endpoint to avoid CORS preflight failures

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/mammoth)*

------
https://chatgpt.com/codex/tasks/task_e_68b934257fe08322948276d237101563