### PR TITLE
Show full ticket status flow in lookup view

### DIFF
--- a/src/components/tickets/TicketStatusBar.tsx
+++ b/src/components/tickets/TicketStatusBar.tsx
@@ -18,10 +18,8 @@ const formatLabel = (s: string) =>
 const TicketStatusBar: React.FC<TicketStatusBarProps> = ({ status, flow = [] }) => {
   const current = normalize(status);
   const steps = React.useMemo(() => {
-    const set = new Set(flow.map(normalize));
-    if (set.size === 0) {
-      DEFAULT_FLOW.forEach((s) => set.add(s));
-    }
+    const set = new Set(DEFAULT_FLOW);
+    flow.map(normalize).forEach((s) => set.add(s));
     if (current) set.add(current);
     return Array.from(set).sort((a, b) => {
       const ia = DEFAULT_FLOW.indexOf(a);


### PR DESCRIPTION
## Summary
- always include default statuses in ticket status bar so all steps display in gray initially

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm install` *(fails: mammoth 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b95d95353883228fa26226f4118659