### PR TITLE
feat: auto-refresh widget token in integration page

### DIFF
--- a/src/pages/Integracion.tsx
+++ b/src/pages/Integracion.tsx
@@ -115,17 +115,24 @@ const Integracion = () => {
   const WIDGET_STD_RIGHT = "20px";
   
   const codeScript = useMemo(() => {
-    const customLines = [
-      primaryColor && `  s.setAttribute('data-primary-color', '${primaryColor}'); // Color del launcher`,
-      logoUrl && `  s.setAttribute('data-logo-url', '${logoUrl}'); // URL del icono`,
-      logoAnimation && `  s.setAttribute('data-logo-animation', '${logoAnimation}'); // Animación del icono`,
-    ]
-      .filter(Boolean)
-      .join("\n");
+    const opts: Record<string, string> = {
+      width: WIDGET_STD_WIDTH,
+      height: WIDGET_STD_HEIGHT,
+      closedWidth: WIDGET_STD_CLOSED_WIDTH,
+      closedHeight: WIDGET_STD_CLOSED_HEIGHT,
+      bottom: WIDGET_STD_BOTTOM,
+      right: WIDGET_STD_RIGHT,
+    };
+    if (primaryColor) opts.primaryColor = primaryColor;
+    if (logoUrl) opts.logoUrl = logoUrl;
+    if (logoAnimation) opts.logoAnimation = logoAnimation;
+
+    const optionsJson = JSON.stringify(opts, null, 2);
 
     return `<script>
 document.addEventListener('DOMContentLoaded', function () {
   const ENTITY_TOKEN = '${entityToken}';
+  const WIDGET_OPTIONS = ${optionsJson};
   let currentToken = null;
   let currentScript = null;
 
@@ -153,21 +160,22 @@ document.addEventListener('DOMContentLoaded', function () {
       s.async = true;
       s.setAttribute('data-entity-token', token);
       s.setAttribute('data-default-open', 'false');
-      s.setAttribute('data-width', '${WIDGET_STD_WIDTH}');
-      s.setAttribute('data-height', '${WIDGET_STD_HEIGHT}');
-      s.setAttribute('data-closed-width', '${WIDGET_STD_CLOSED_WIDTH}');
-      s.setAttribute('data-closed-height', '${WIDGET_STD_CLOSED_HEIGHT}');
-      s.setAttribute('data-bottom', '${WIDGET_STD_BOTTOM}');
-      s.setAttribute('data-right', '${WIDGET_STD_RIGHT}');
+      s.setAttribute('data-width', WIDGET_OPTIONS.width);
+      s.setAttribute('data-height', WIDGET_OPTIONS.height);
+      s.setAttribute('data-closed-width', WIDGET_OPTIONS.closedWidth);
+      s.setAttribute('data-closed-height', WIDGET_OPTIONS.closedHeight);
+      s.setAttribute('data-bottom', WIDGET_OPTIONS.bottom);
+      s.setAttribute('data-right', WIDGET_OPTIONS.right);
       s.setAttribute('data-endpoint', '${endpoint}');
-${customLines ? customLines + "\n" : ""}  // Importante para la geolocalización y el portapapeles:
+      if (WIDGET_OPTIONS.primaryColor) s.setAttribute('data-primary-color', WIDGET_OPTIONS.primaryColor);
+      if (WIDGET_OPTIONS.logoUrl) s.setAttribute('data-logo-url', WIDGET_OPTIONS.logoUrl);
+      if (WIDGET_OPTIONS.logoAnimation) s.setAttribute('data-logo-animation', WIDGET_OPTIONS.logoAnimation);
+
+      // Importante para la geolocalización y el portapapeles:
       // widget.js establecerá allow="clipboard-write; geolocation" en su iframe interno.
       // Si este script se inserta dentro de un iframe en tu sitio, ese iframe contenedor
       // también debe incluir allow="clipboard-write; geolocation" en sus atributos.
       // Ejemplo: <iframe src="tu_pagina_con_widget.html" allow="clipboard-write; geolocation"></iframe>
-
-      document.body.appendChild(s);
-      currentScript = s;
 
       s.onload = function() {
         console.log('Chatboc Widget cargado y listo.');
@@ -175,6 +183,9 @@ ${customLines ? customLines + "\n" : ""}  // Importante para la geolocalización
       s.onerror = function() {
         console.error('Error al cargar Chatboc Widget.');
       };
+
+      document.body.appendChild(s);
+      currentScript = s;
 
       const [, payload] = token.split('.');
       const base64 = payload.replace(/-/g, '+').replace(/_/g, '/');


### PR DESCRIPTION
## Summary
- generate integration script that refreshes widget token automatically
- expose widget customization options via `WIDGET_OPTIONS`

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/mammoth)*

------
https://chatgpt.com/codex/tasks/task_e_68bae773fe248322a380b90a9f37a62d