### PR TITLE
revert: restore static widget integration snippet

### DIFF
--- a/src/pages/Integracion.tsx
+++ b/src/pages/Integracion.tsx
@@ -125,70 +125,40 @@ const Integracion = () => {
 
     return `<script>
 document.addEventListener('DOMContentLoaded', function () {
-  const ENTITY_TOKEN = '${entityToken}';
-  let currentToken = null;
-  let currentScript = null;
-
-  async function loadWidget() {
-    try {
-      const res = await fetch('https://chatboc.ar/auth/widget-token/', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ token: ENTITY_TOKEN })
-      });
-      const data = await res.json();
-      const token = data.token;
-
-      if (currentScript) {
-        currentScript.remove();
-      }
-      if (window.chatbocDestroyWidget && currentToken) {
-        window.chatbocDestroyWidget(currentToken);
-      }
-      currentToken = token;
-      window.APP_TARGET = '${endpoint}';
-
-      var s = document.createElement('script');
-      s.src = 'https://chatboc.ar/widget.js';
-      s.async = true;
-      s.setAttribute('data-entity-token', token);
-      s.setAttribute('data-default-open', 'false');
-      s.setAttribute('data-width', '${WIDGET_STD_WIDTH}');
-      s.setAttribute('data-height', '${WIDGET_STD_HEIGHT}');
-      s.setAttribute('data-closed-width', '${WIDGET_STD_CLOSED_WIDTH}');
-      s.setAttribute('data-closed-height', '${WIDGET_STD_CLOSED_HEIGHT}');
-      s.setAttribute('data-bottom', '${WIDGET_STD_BOTTOM}');
-      s.setAttribute('data-right', '${WIDGET_STD_RIGHT}');
-      s.setAttribute('data-endpoint', '${endpoint}');
-${customLines ? customLines + "\n" : ""}  // Importante para la geolocalización y el portapapeles:
-      // widget.js establecerá allow="clipboard-write; geolocation" en su iframe interno.
-      // Si este script se inserta dentro de un iframe en tu sitio, ese iframe contenedor
-      // también debe incluir allow="clipboard-write; geolocation" en sus atributos.
-      // Ejemplo: <iframe src="tu_pagina_con_widget.html" allow="clipboard-write; geolocation"></iframe>
-
-      document.body.appendChild(s);
-      currentScript = s;
-
-      s.onload = function() {
-        console.log('Chatboc Widget cargado y listo.');
-      };
-      s.onerror = function() {
-        console.error('Error al cargar Chatboc Widget.');
-      };
-
-      const [, payload] = token.split('.');
-      const base64 = payload.replace(/-/g, '+').replace(/_/g, '/');
-      const padded = base64.padEnd(base64.length + (4 - (base64.length % 4)) % 4, '=');
-      const { exp } = JSON.parse(atob(padded));
-      const refreshMs = exp * 1000 - Date.now() - 60000;
-      setTimeout(loadWidget, Math.max(refreshMs, 30000));
-    } catch (err) {
-      console.error('No se pudo obtener un nuevo token', err);
-      setTimeout(loadWidget, 30000);
-    }
+  // Asegura que el widget se destruya y se vuelva a crear si ya existe
+  if (window.chatbocDestroyWidget) {
+    window.chatbocDestroyWidget('${entityToken}');
   }
+  window.APP_TARGET = '${endpoint}'; // Define el endpoint antes de cargar el script
 
-  loadWidget();
+  var s = document.createElement('script');
+  s.src = 'https://chatboc.ar/widget.js'; // URL del script del widget
+  s.async = true; // Carga asíncrona para no bloquear el renderizado de la página
+  s.setAttribute('data-entity-token', '${entityToken}'); // Token de la entidad para el widget
+  s.setAttribute('data-default-open', 'false'); // El widget comienza cerrado por defecto
+  s.setAttribute('data-width', '${WIDGET_STD_WIDTH}'); // Ancho del widget abierto
+  s.setAttribute('data-height', '${WIDGET_STD_HEIGHT}'); // Alto del widget abierto
+  s.setAttribute('data-closed-width', '${WIDGET_STD_CLOSED_WIDTH}'); // Ancho del widget cerrado (burbuja)
+  s.setAttribute('data-closed-height', '${WIDGET_STD_CLOSED_HEIGHT}'); // Alto del widget cerrado (burbuja)
+  s.setAttribute('data-bottom', '${WIDGET_STD_BOTTOM}'); // Posición desde abajo
+  s.setAttribute('data-right', '${WIDGET_STD_RIGHT}'); // Posición desde la derecha
+  s.setAttribute('data-endpoint', '${endpoint}'); // Tipo de chat (pyme o municipio)
+${customLines ? customLines + "\n" : ""}  // Importante para la geolocalización y el portapapeles:
+  // widget.js establecerá allow="clipboard-write; geolocation" en su iframe interno.
+  // Si este script se inserta dentro de un iframe en tu sitio, ese iframe contenedor
+  // también debe incluir allow="clipboard-write; geolocation" en sus atributos.
+  // Ejemplo: <iframe src="tu_pagina_con_widget.html" allow="clipboard-write; geolocation"></iframe>
+
+  document.body.appendChild(s); // Añade el script al final del body
+
+  // Opcional: Escuchar evento de widget cargado
+  s.onload = function() {
+    console.log('Chatboc Widget cargado y listo.');
+    // Puedes añadir lógica adicional aquí si es necesario
+  };
+  s.onerror = function() {
+    console.error('Error al cargar Chatboc Widget.');
+  };
 });
 </script>`;
   }, [entityToken, endpoint, primaryColor, logoUrl, logoAnimation]);

--- a/src/pages/iframe.tsx
+++ b/src/pages/iframe.tsx
@@ -35,12 +35,16 @@ const Iframe = () => {
     const cfg = getChatbocConfig();
     const urlParams = new URLSearchParams(window.location.search);
 
-    setEntityToken(cfg.entityToken || null);
+    const tokenFromUrl = urlParams.get("entityToken") || '';
+    setEntityToken(cfg.entityToken || tokenFromUrl || null);
 
+    const endpointFromUrl = urlParams.get("endpoint") || urlParams.get("tipo_chat");
     const endpointParam =
       cfg.endpoint === 'pyme' || cfg.endpoint === 'municipio'
         ? (cfg.endpoint as 'pyme' | 'municipio')
-        : null;
+        : endpointFromUrl === 'pyme' || endpointFromUrl === 'municipio'
+          ? (endpointFromUrl as 'pyme' | 'municipio')
+          : null;
     if (endpointParam) {
       setTipoChat(endpointParam);
     }


### PR DESCRIPTION
## Summary
- revert integration page to the original static script snippet so clients can embed the widget without token refresh logic

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bae773fe248322a380b90a9f37a62d