### PR TITLE
feat: add auto-refresh widget integration snippet

### DIFF
--- a/src/pages/iframe.tsx
+++ b/src/pages/iframe.tsx
@@ -35,12 +35,16 @@ const Iframe = () => {
     const cfg = getChatbocConfig();
     const urlParams = new URLSearchParams(window.location.search);
 
-    setEntityToken(cfg.entityToken || null);
+    const tokenFromUrl = urlParams.get("entityToken") || '';
+    setEntityToken(cfg.entityToken || tokenFromUrl || null);
 
+    const endpointFromUrl = urlParams.get("endpoint") || urlParams.get("tipo_chat");
     const endpointParam =
       cfg.endpoint === 'pyme' || cfg.endpoint === 'municipio'
         ? (cfg.endpoint as 'pyme' | 'municipio')
-        : null;
+        : endpointFromUrl === 'pyme' || endpointFromUrl === 'municipio'
+          ? (endpointFromUrl as 'pyme' | 'municipio')
+          : null;
     if (endpointParam) {
       setTipoChat(endpointParam);
     }


### PR DESCRIPTION
## Summary
- ensure integration snippet loads widget with static token fallback and schedules automatic token refreshes
- restore live widget preview so clients can test configuration before embedding

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bae773fe248322a380b90a9f37a62d