### PR TITLE
feat: support accent color and fix widget theming

### DIFF
--- a/docs/integracion.tsx
+++ b/docs/integracion.tsx
@@ -15,8 +15,12 @@ const WIDGET_OPTIONS = {
   bottom: '20px',
   right: '20px',
   primaryColor: '#007aff',
+  // accentColor: '#d4a01a',
   // logoUrl: 'https://example.com/logo.png',
+  // headerLogoUrl: 'https://example.com/header-logo.png',
   // logoAnimation: 'spin 2s linear infinite',
+  // welcomeTitle: '¡Hola! Soy tu asistente virtual',
+  // welcomeSubtitle: 'Estoy aquí para ayudarte',
 };
 
 function decodeExpiration(jwt: string): number {
@@ -52,8 +56,12 @@ function injectWidget(token: string, opts = WIDGET_OPTIONS) {
   s.setAttribute('data-right', opts.right);
   s.setAttribute('data-endpoint', 'municipio');
   if (opts.primaryColor) s.setAttribute('data-primary-color', opts.primaryColor);
+  if (opts.accentColor) s.setAttribute('data-accent-color', opts.accentColor);
   if (opts.logoUrl) s.setAttribute('data-logo-url', opts.logoUrl);
+  if (opts.headerLogoUrl) s.setAttribute('data-header-logo-url', opts.headerLogoUrl);
   if (opts.logoAnimation) s.setAttribute('data-logo-animation', opts.logoAnimation);
+  if (opts.welcomeTitle) s.setAttribute('data-welcome-title', opts.welcomeTitle);
+  if (opts.welcomeSubtitle) s.setAttribute('data-welcome-subtitle', opts.welcomeSubtitle);
 
   s.onload = () => console.log('Chatboc Widget cargado y listo.');
   s.onerror = () => console.error('Error al cargar Chatboc Widget.');

--- a/pruebascr.html
+++ b/pruebascr.html
@@ -18,6 +18,12 @@ document.addEventListener('DOMContentLoaded', function () {
   s.setAttribute('data-bottom', '20px'); // Posición desde abajo
   s.setAttribute('data-right', '20px'); // Posición desde la derecha
   s.setAttribute('data-endpoint', 'municipio'); // Tipo de chat (pyme o municipio)
+  s.setAttribute('data-primary-color', '#006C3F'); // Color personalizado
+  s.setAttribute('data-logo-url', 'https://example.com/logo.png'); // Logo del launcher
+  s.setAttribute('data-header-logo-url', 'https://example.com/header-logo.png'); // Logo del encabezado
+  s.setAttribute('data-logo-animation', 'bounce 2s infinite'); // Animación del logo
+  s.setAttribute('data-welcome-title', '¡Hola! Soy tu asistente');
+  s.setAttribute('data-welcome-subtitle', 'Estoy aquí para ayudarte');
   
   // Importante para la geolocalización y el portapapeles:
   // widget.js establecerá allow="clipboard-write; geolocation" en su iframe interno.

--- a/public/iframe.html
+++ b/public/iframe.html
@@ -60,7 +60,14 @@
         closedWidth: params.get('closedWidth') || '72px',
         closedHeight: params.get('closedHeight') || '72px',
         bottom: params.get('bottom') || '20px',
-        right: params.get('right') || '20px'
+        right: params.get('right') || '20px',
+        primaryColor: params.get('primaryColor') || '#007aff',
+        accentColor: params.get('accentColor') || '',
+        logoUrl: params.get('logoUrl') || '',
+        headerLogoUrl: params.get('headerLogoUrl') || params.get('logoUrl') || '',
+        logoAnimation: params.get('logoAnimation') || '',
+        welcomeTitle: params.get('welcomeTitle') || '',
+        welcomeSubtitle: params.get('welcomeSubtitle') || ''
       };
     })();
   </script>

--- a/public/widget.js
+++ b/public/widget.js
@@ -35,6 +35,13 @@
     closedHeight: ds.closedHeight || "72px",
     bottom: ds.bottom || "20px",
     right: ds.right || "20px",
+    primaryColor: ds.primaryColor || "#007aff",
+    accentColor: ds.accentColor || "",
+    logoUrl: ds.logoUrl || "",
+    headerLogoUrl: ds.headerLogoUrl || ds.logoUrl || "",
+    logoAnimation: ds.logoAnimation || "",
+    welcomeTitle: ds.welcomeTitle || "",
+    welcomeSubtitle: ds.welcomeSubtitle || "",
   };
 
   const qs = new URLSearchParams({
@@ -49,6 +56,13 @@
     right: cfg.right,
     widgetId: iframeId,
     hostDomain: window.location.origin,
+    primaryColor: cfg.primaryColor,
+    accentColor: cfg.accentColor,
+    logoUrl: cfg.logoUrl,
+    headerLogoUrl: cfg.headerLogoUrl,
+    logoAnimation: cfg.logoAnimation,
+    welcomeTitle: cfg.welcomeTitle,
+    welcomeSubtitle: cfg.welcomeSubtitle,
   });
 
   const iframeSrc = `${cfg.host}${cfg.iframePath}?${qs.toString()}`;

--- a/src/components/chat/ChatHeader.tsx
+++ b/src/components/chat/ChatHeader.tsx
@@ -11,6 +11,10 @@ interface Props {
   muted?: boolean;
   onToggleSound?: () => void;
   onCart?: () => void;
+  logoUrl?: string;
+  title?: string;
+  subtitle?: string;
+  logoAnimation?: string;
 }
 
 const ChatHeader: React.FC<Props> = ({
@@ -22,35 +26,45 @@ const ChatHeader: React.FC<Props> = ({
   muted = false,
   onToggleSound,
   onCart,
+  logoUrl,
+  title,
+  subtitle,
+  logoAnimation,
 }) => {
   return (
     <div
       className={`
         flex items-center justify-between flex-shrink-0 w-full
         px-2 sm:px-4 py-3 border-b border-border
-        bg-card/90 backdrop-blur-md
-        text-card-foreground
+        bg-primary backdrop-blur-md text-primary-foreground
         transition-all rounded-t-[inherit] overflow-hidden
       `}
     >
       {/* Logo y nombre sin cuadrado */}
       <div className="flex items-center gap-2 sm:gap-3"> {/* Reduced gap for mobile */}
         <div className="flex items-center justify-center w-10 h-10">
-          {/* Sin fondo ni border ni shadow: que use tu PNG o SVG de logo */}
-          <ChatbocLogoAnimated
-            size={32}
-            smiling={isTyping}
-            movingEyes={isTyping}
-            blinking
-            pulsing
-          />
+          {logoUrl ? (
+            <img
+              src={logoUrl}
+              alt="Logo"
+              style={{ width: 32, height: 32, borderRadius: "50%", animation: logoAnimation || undefined }}
+            />
+          ) : (
+            <ChatbocLogoAnimated
+              size={32}
+              smiling={isTyping}
+              movingEyes={isTyping}
+              blinking
+              pulsing
+            />
+          )}
         </div>
         <div className="ml-1 flex flex-col leading-tight">
           <span className="font-extrabold text-base tracking-wide" style={{ letterSpacing: ".02em" }}>
-            Chatboc
+            {title || 'Chatboc'}
           </span>
           <span className="text-xs text-muted-foreground" style={{ fontWeight: 500 }}>
-            Asistente Virtual
+            {subtitle || 'Asistente Virtual'}
           </span>
         </div>
       </div>

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -60,6 +60,10 @@ interface ChatPanelProps {
   muted?: boolean;
   onToggleSound?: () => void;
   onCart?: () => void;
+  headerLogoUrl?: string;
+  welcomeTitle?: string;
+  welcomeSubtitle?: string;
+  logoAnimation?: string;
 }
 
 const ChatPanel = ({
@@ -76,6 +80,10 @@ const ChatPanel = ({
   onRubroSelect,
   mode,
   entityToken: propEntityToken,
+  headerLogoUrl,
+  welcomeTitle,
+  welcomeSubtitle,
+  logoAnimation,
 }: ChatPanelProps) => {
   const isMobile = useIsMobile();
   const chatContainerRef = useRef<HTMLDivElement>(null);
@@ -263,7 +271,17 @@ const ChatPanel = ({
 
   return (
     <div className={cn("flex flex-col w-full h-full bg-card text-card-foreground overflow-hidden relative", isMobile ? undefined : "rounded-[inherit]")}> 
-      <ChatHeader onClose={onClose} onProfile={onOpenUserPanel} muted={muted} onToggleSound={onToggleSound} onCart={onCart} />
+      <ChatHeader
+        onClose={onClose}
+        onProfile={onOpenUserPanel}
+        muted={muted}
+        onToggleSound={onToggleSound}
+        onCart={onCart}
+        logoUrl={headerLogoUrl}
+        title={welcomeTitle}
+        subtitle={welcomeSubtitle}
+        logoAnimation={logoAnimation}
+      />
       <div ref={chatContainerRef} className="flex-1 p-2 sm:p-4 min-h-0 flex flex-col gap-3 overflow-y-auto">
         {messages.map((msg) =>
           <ChatMessage key={msg.id} message={msg}

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -30,6 +30,11 @@ interface ChatWidgetProps {
   closedHeight?: string;
   tipoChat?: "pyme" | "municipio";
   ctaMessage?: string;
+  customLauncherLogoUrl?: string;
+  logoAnimation?: string;
+  headerLogoUrl?: string;
+  welcomeTitle?: string;
+  welcomeSubtitle?: string;
 }
 
 const PROACTIVE_MESSAGES = [
@@ -53,6 +58,11 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
   tipoChat = getCurrentTipoChat(),
   initialPosition = { bottom: 32, right: 32 },
   ctaMessage,
+  customLauncherLogoUrl,
+  logoAnimation,
+  headerLogoUrl,
+  welcomeTitle,
+  welcomeSubtitle,
 }) => {
   const proactiveMessageTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const hideProactiveBubbleTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -443,7 +453,18 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
               {...panelAnimation}
             >
               {(view === "register" || view === "login" || view === "user" || view === "info") && (
-                <ChatHeader onClose={toggleChat} onBack={() => setView("chat")} showProfile={false} muted={muted} onToggleSound={toggleMuted} onCart={openCart} />
+                <ChatHeader
+                  onClose={toggleChat}
+                  onBack={() => setView("chat")}
+                  showProfile={false}
+                  muted={muted}
+                  onToggleSound={toggleMuted}
+                  onCart={openCart}
+                  logoUrl={headerLogoUrl || customLauncherLogoUrl || entityInfo?.logo_url}
+                  title={welcomeTitle}
+                  subtitle={welcomeSubtitle}
+                  logoAnimation={logoAnimation}
+                />
               )}
               {view === "register" ? <ChatUserRegisterPanel onSuccess={() => setView("chat")} onShowLogin={() => setView("login")} entityToken={entityToken} />
                 : view === "login" ? <ChatUserLoginPanel onSuccess={() => setView("chat")} onShowRegister={() => setView("register")} />
@@ -466,6 +487,10 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
                     onCart={openCart}
                     selectedRubro={entityInfo?.rubro || selectedRubro}
                     onRubroSelect={setSelectedRubro}
+                    headerLogoUrl={headerLogoUrl || customLauncherLogoUrl || entityInfo?.logo_url}
+                    welcomeTitle={welcomeTitle}
+                    welcomeSubtitle={welcomeSubtitle}
+                    logoAnimation={logoAnimation}
                   />}
             </motion.div>
           ) : (
@@ -513,14 +538,15 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
                   animate={isOpen ? "open" : "closed"}
                   transition={openSpring}
                 >
-                  {entityInfo?.logo_url ? (
+                  {entityInfo?.logo_url || customLauncherLogoUrl ? (
                     <img
-                      src={entityInfo.logo_url}
+                      src={entityInfo?.logo_url || customLauncherLogoUrl}
                       alt="Logo"
                       style={{
                         width: calculatedLogoSize,
                         height: calculatedLogoSize,
                         borderRadius: "50%",
+                        animation: logoAnimation || undefined,
                       }}
                     />
                   ) : (

--- a/src/pages/Integracion.tsx
+++ b/src/pages/Integracion.tsx
@@ -43,8 +43,12 @@ const Integracion = () => {
   const [copiado, setCopiado] = useState<"iframe" | "script" | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [primaryColor, setPrimaryColor] = useState("#007aff");
+  const [accentColor, setAccentColor] = useState("#d4a01a");
   const [logoUrl, setLogoUrl] = useState("");
   const [logoAnimation, setLogoAnimation] = useState("");
+  const [headerLogoUrl, setHeaderLogoUrl] = useState("");
+  const [welcomeTitle, setWelcomeTitle] = useState("");
+  const [welcomeSubtitle, setWelcomeSubtitle] = useState("");
 
   const validarAcceso = (currentUser: User | null) => {
     if (!currentUser) {
@@ -117,8 +121,12 @@ const Integracion = () => {
   const codeScript = useMemo(() => {
     const customLines = [
       primaryColor && `      s.setAttribute('data-primary-color', '${primaryColor}'); // Color del launcher`,
+      accentColor && `      s.setAttribute('data-accent-color', '${accentColor}'); // Color de acento`,
       logoUrl && `      s.setAttribute('data-logo-url', '${logoUrl}'); // URL del icono`,
+      headerLogoUrl && `      s.setAttribute('data-header-logo-url', '${headerLogoUrl}'); // Logo del encabezado`,
       logoAnimation && `      s.setAttribute('data-logo-animation', '${logoAnimation}'); // Animación del icono`,
+      welcomeTitle && `      s.setAttribute('data-welcome-title', '${welcomeTitle}'); // Título de bienvenida`,
+      welcomeSubtitle && `      s.setAttribute('data-welcome-subtitle', '${welcomeSubtitle}'); // Subtítulo de bienvenida`,
     ]
       .filter(Boolean)
       .join("\n");
@@ -215,17 +223,21 @@ ${customLines ? customLines + "\n" : ""}  // Importante para la geolocalización
   refreshToken();
 });
 </script>`;
-  }, [entityToken, endpoint, primaryColor, logoUrl, logoAnimation]);
+  }, [entityToken, endpoint, primaryColor, accentColor, logoUrl, headerLogoUrl, logoAnimation, welcomeTitle, welcomeSubtitle]);
 
   const iframeSrcUrl = useMemo(() => {
     const url = new URL("https://chatboc.ar/iframe");
     url.searchParams.set("entityToken", entityToken);
     url.searchParams.set("tipo_chat", endpoint);
     if (primaryColor) url.searchParams.set("primaryColor", primaryColor);
+    if (accentColor) url.searchParams.set("accentColor", accentColor);
     if (logoUrl) url.searchParams.set("logoUrl", logoUrl);
+    if (headerLogoUrl) url.searchParams.set("headerLogoUrl", headerLogoUrl);
     if (logoAnimation) url.searchParams.set("logoAnimation", logoAnimation);
+    if (welcomeTitle) url.searchParams.set("welcomeTitle", welcomeTitle);
+    if (welcomeSubtitle) url.searchParams.set("welcomeSubtitle", welcomeSubtitle);
     return url.toString();
-  }, [entityToken, endpoint, primaryColor, logoUrl, logoAnimation]);
+  }, [entityToken, endpoint, primaryColor, accentColor, logoUrl, headerLogoUrl, logoAnimation, welcomeTitle, welcomeSubtitle]);
   
   const codeIframe = useMemo(() => `<iframe
   id="chatboc-iframe"
@@ -422,12 +434,30 @@ document.addEventListener('DOMContentLoaded', function () {
               />
             </div>
             <div className="flex flex-col space-y-2">
+              <Label htmlFor="accentColor">Color de acento</Label>
+              <Input
+                id="accentColor"
+                type="color"
+                value={accentColor}
+                onChange={(e) => setAccentColor(e.target.value)}
+              />
+            </div>
+            <div className="flex flex-col space-y-2">
               <Label htmlFor="logoUrl">URL del logo</Label>
               <Input
                 id="logoUrl"
                 placeholder="https://..."
                 value={logoUrl}
                 onChange={(e) => setLogoUrl(e.target.value)}
+              />
+            </div>
+            <div className="flex flex-col space-y-2">
+              <Label htmlFor="headerLogoUrl">URL del logo del encabezado</Label>
+              <Input
+                id="headerLogoUrl"
+                placeholder="https://..."
+                value={headerLogoUrl}
+                onChange={(e) => setHeaderLogoUrl(e.target.value)}
               />
             </div>
             <div className="flex flex-col space-y-2 sm:col-span-2">
@@ -442,6 +472,24 @@ document.addEventListener('DOMContentLoaded', function () {
                   <SelectItem value="spin 2s linear infinite">Spin</SelectItem>
                 </SelectContent>
               </Select>
+            </div>
+            <div className="flex flex-col space-y-2 sm:col-span-2">
+              <Label htmlFor="welcomeTitle">Título de bienvenida</Label>
+              <Input
+                id="welcomeTitle"
+                placeholder="¡Hola! Soy tu asistente virtual"
+                value={welcomeTitle}
+                onChange={(e) => setWelcomeTitle(e.target.value)}
+              />
+            </div>
+            <div className="flex flex-col space-y-2 sm:col-span-2">
+              <Label htmlFor="welcomeSubtitle">Subtítulo de bienvenida</Label>
+              <Input
+                id="welcomeSubtitle"
+                placeholder="Estoy aquí para ayudarte"
+                value={welcomeSubtitle}
+                onChange={(e) => setWelcomeSubtitle(e.target.value)}
+              />
             </div>
           </CardContent>
         </Card>

--- a/src/pages/iframe.tsx
+++ b/src/pages/iframe.tsx
@@ -6,6 +6,7 @@ import { GoogleOAuthProvider } from "@react-oauth/google";
 import ErrorBoundary from '../components/ErrorBoundary';
 import { MemoryRouter } from "react-router-dom";
 import { getChatbocConfig } from "@/utils/config";
+import { hexToHsl } from "@/utils/color";
 import { safeLocalStorage } from "@/utils/safeLocalStorage";
 
 const DEFAULTS = {
@@ -35,6 +36,13 @@ const Iframe = () => {
   useEffect(() => {
     const cfg = getChatbocConfig();
     const urlParams = new URLSearchParams(window.location.search);
+
+    const primaryColor = urlParams.get("primaryColor") || cfg.primaryColor || "#007aff";
+    document.documentElement.style.setProperty("--primary", hexToHsl(primaryColor));
+    const accentColor = urlParams.get("accentColor") || cfg.accentColor || "";
+    if (accentColor) {
+      document.documentElement.style.setProperty("--accent", hexToHsl(accentColor));
+    }
 
     const tokenFromUrl = urlParams.get("entityToken") || cfg.entityToken || '';
     if (tokenFromUrl) {
@@ -69,6 +77,13 @@ const Iframe = () => {
       endpoint: endpointParam || undefined,
       bottom: parseInt(urlParams.get("bottom") || cfg.bottom || String(DEFAULTS.bottom), 10),
       right: parseInt(urlParams.get("right") || cfg.right || String(DEFAULTS.right), 10),
+      primaryColor,
+      accentColor,
+      logoUrl: urlParams.get("logoUrl") || cfg.logoUrl || '',
+      headerLogoUrl: urlParams.get("headerLogoUrl") || cfg.headerLogoUrl || '',
+      logoAnimation: urlParams.get("logoAnimation") || cfg.logoAnimation || '',
+      welcomeTitle: urlParams.get("welcomeTitle") || cfg.welcomeTitle || '',
+      welcomeSubtitle: urlParams.get("welcomeSubtitle") || cfg.welcomeSubtitle || '',
     });
 
     setIsLoading(false);
@@ -113,6 +128,11 @@ const Iframe = () => {
       ctaMessage={widgetParams.ctaMessage}
       initialView={widgetParams.view}
       initialRubro={widgetParams.rubro}
+      customLauncherLogoUrl={widgetParams.logoUrl}
+      logoAnimation={widgetParams.logoAnimation}
+      headerLogoUrl={widgetParams.headerLogoUrl}
+      welcomeTitle={widgetParams.welcomeTitle}
+      welcomeSubtitle={widgetParams.welcomeSubtitle}
     />
   );
 

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,0 +1,30 @@
+export function hexToHsl(hex: string): string {
+  const normalized = hex.trim().replace('#', '');
+  if (normalized.length !== 3 && normalized.length !== 6) {
+    return '217 100% 50%';
+  }
+  const r = parseInt(normalized.length === 3 ? normalized[0] + normalized[0] : normalized.substring(0,2), 16) / 255;
+  const g = parseInt(normalized.length === 3 ? normalized[1] + normalized[1] : normalized.substring(2,4), 16) / 255;
+  const b = parseInt(normalized.length === 3 ? normalized[2] + normalized[2] : normalized.substring(4,6), 16) / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  let h = 0, s = 0;
+  const l = (max + min) / 2;
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0);
+        break;
+      case g:
+        h = (b - r) / d + 2;
+        break;
+      default:
+        h = (r - g) / d + 4;
+        break;
+    }
+    h /= 6;
+  }
+  return `${Math.round(h * 360)} ${Math.round(s * 100)}% ${Math.round(l * 100)}%`;
+}

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -10,7 +10,14 @@ export function getChatbocConfig() {
     closedWidth: g.closedWidth || '72px',
     closedHeight: g.closedHeight || '72px',
     bottom: g.bottom || '20px',
-    right: g.right || '20px'
+    right: g.right || '20px',
+    primaryColor: g.primaryColor || '#007aff',
+    accentColor: g.accentColor || '',
+    logoUrl: g.logoUrl || '',
+    headerLogoUrl: g.headerLogoUrl || g.logoUrl || '',
+    logoAnimation: g.logoAnimation || '',
+    welcomeTitle: g.welcomeTitle || '',
+    welcomeSubtitle: g.welcomeSubtitle || ''
   };
 }
 

--- a/widget.js
+++ b/widget.js
@@ -74,9 +74,14 @@
     const ctaMessageAttr = script.getAttribute("data-cta-message") || "";
     const langAttr = script.getAttribute("data-lang") || "";
     const primaryColor = script.getAttribute("data-primary-color") || "#007aff";
+    const accentColorAttr = script.getAttribute("data-accent-color") || "";
     const logoUrlAttr = script.getAttribute("data-logo-url");
+    const headerLogoUrlAttr = script.getAttribute("data-header-logo-url");
     const logoAnimationAttr = script.getAttribute("data-logo-animation") || "";
+    const welcomeTitleAttr = script.getAttribute("data-welcome-title") || "";
+    const welcomeSubtitleAttr = script.getAttribute("data-welcome-subtitle") || "";
     const logoUrl = logoUrlAttr || `${chatbocDomain}/chatboc_widget_64x64.webp`;
+    const headerLogoUrl = headerLogoUrlAttr || logoUrl;
     const endpointAttr = script.getAttribute("data-endpoint");
     const tipoChat =
       endpointAttr === "municipio" || endpointAttr === "pyme"
@@ -212,6 +217,13 @@
       if (rubroAttr) iframeSrc.searchParams.set("rubro", rubroAttr);
       if (finalCta) iframeSrc.searchParams.set("ctaMessage", finalCta);
       if (langAttr) iframeSrc.searchParams.set("lang", langAttr);
+      if (primaryColor) iframeSrc.searchParams.set("primaryColor", primaryColor);
+      if (accentColorAttr) iframeSrc.searchParams.set("accentColor", accentColorAttr);
+      if (logoUrlAttr) iframeSrc.searchParams.set("logoUrl", logoUrlAttr);
+      if (headerLogoUrlAttr) iframeSrc.searchParams.set("headerLogoUrl", headerLogoUrlAttr);
+      if (logoAnimationAttr) iframeSrc.searchParams.set("logoAnimation", logoAnimationAttr);
+      if (welcomeTitleAttr) iframeSrc.searchParams.set("welcomeTitle", welcomeTitleAttr);
+      if (welcomeSubtitleAttr) iframeSrc.searchParams.set("welcomeSubtitle", welcomeSubtitleAttr);
       iframe.src = iframeSrc.toString();
 
       if (langAttr) iframe.setAttribute("lang", langAttr);


### PR DESCRIPTION
## Summary
- convert hex branding colors to HSL and apply them to CSS variables
- add accent color option throughout widget loaders and integration UI
- style chat header with primary brand color for proper theming

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/mammoth)
- `npm test` (fails: vitest: not found)


------
https://chatgpt.com/codex/tasks/task_e_68bb1aec67188322b117ab4a30735dba