### PR TITLE
feat: add accent color, custom bot logo options, and media permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ You can embed the floating chat widget on any site by loading `widget.js` and pa
     // s.setAttribute('data-cta-message', '¿Necesitás ayuda?');
     // Optional: force light or dark theme
     // s.setAttribute('data-theme', 'dark');
-    // The widget will set `allow="clipboard-write; geolocation"` on
-    // the iframe it injects so it can ask for location permissions.
+    // The widget will set `allow="clipboard-write; geolocation; microphone; camera"` on
+    // the iframe it injects so it can ask for location or audio permissions.
     document.body.appendChild(s); // append once the DOM is ready
   });
 </script>
@@ -149,9 +149,9 @@ to load its scripts from the wrong origin, leading to console errors and 403
 responses from `https://api.chatboc.ar`. If you see messages such as `attribute
 cx: Expected length` or `Access Forbidden`, verify that `data-domain` is set to
 `https://chatboc.ar`.
-The script automatically adds `allow="clipboard-write; geolocation"` to the underlying iframe so the widget can request GPS access.
+The script automatically adds `allow="clipboard-write; geolocation; microphone; camera"` to the underlying iframe so the widget can request GPS or media access.
 If your site embeds this script inside another `<iframe>`, be sure that outer frame also includes
-`allow="clipboard-write; geolocation"`. The permission must be granted at every level
+`allow="clipboard-write; geolocation; microphone; camera"`. The permission must be granted at every level
 for the browser to allow geolocation requests inside the widget.
 
 ### Customization
@@ -189,7 +189,7 @@ If your site blocks external JavaScript, you can embed the chatbot using an
   id="chatboc-iframe"
   src="https://chatboc.ar/iframe.html?entityToken=TU_TOKEN_AQUI&endpoint=pyme&rubro=comercio" <!-- or "municipio"; `tipo_chat` also works -->
   style="position:fixed;bottom:24px;right:24px;border:none;border-radius:50%;z-index:9999;box-shadow:0 4px 32px rgba(0,0,0,0.2);background:transparent;overflow:hidden;width:96px!important;height:96px!important;display:block"
-  allow="clipboard-write; geolocation"
+  allow="clipboard-write; geolocation; microphone; camera"
   loading="lazy"
 ></iframe>
 <script>
@@ -212,11 +212,11 @@ If your site blocks external JavaScript, you can embed the chatbot using an
   });
 </script>
 ```
-When embedding via `<iframe>`, include `allow="clipboard-write; geolocation"`
-so the widget can request GPS permissions from the browser. If this snippet is
+When embedding via `<iframe>`, include `allow="clipboard-write; geolocation; microphone; camera"`
+so the widget can request GPS or media permissions from the browser. If this snippet is
 loaded inside another `<iframe>`, that outer frame must have the same `allow`
-attribute. Without these permissions the browser will block GPS access and
-users will need to enter their address manually.
+attribute. Without these permissions the browser will block GPS, audio or camera access and
+users will need to enter their address manually or skip media features.
 
 ### Removing an existing widget
 If your site loads the script multiple times (for example when navigating a SPA), call `window.chatbocDestroyWidget('<TOKEN>')` before injecting a new one.

--- a/docs/integracion.tsx
+++ b/docs/integracion.tsx
@@ -15,8 +15,9 @@ const WIDGET_OPTIONS = {
   bottom: '20px',
   right: '20px',
   primaryColor: '#007aff',
-  // logoUrl: 'https://example.com/logo.png',
-  // headerLogoUrl: 'https://example.com/header-logo.png',
+  accentColor: '#007aff',
+  // logoUrl: 'https://example.com/logo.png', // usado en el botón y como fallback general
+  // headerLogoUrl: 'https://example.com/header-logo.png', // opcional: reemplaza el avatar del bot y el logo del encabezado
   // logoAnimation: 'spin 2s linear infinite',
   // welcomeTitle: '¡Hola! Soy tu asistente virtual',
   // welcomeSubtitle: 'Estoy aquí para ayudarte',
@@ -55,6 +56,7 @@ function injectWidget(token: string, opts = WIDGET_OPTIONS) {
   s.setAttribute('data-right', opts.right);
   s.setAttribute('data-endpoint', 'municipio');
   if (opts.primaryColor) s.setAttribute('data-primary-color', opts.primaryColor);
+  if (opts.accentColor) s.setAttribute('data-accent-color', opts.accentColor);
   if (opts.logoUrl) s.setAttribute('data-logo-url', opts.logoUrl);
   if (opts.headerLogoUrl) s.setAttribute('data-header-logo-url', opts.headerLogoUrl);
   if (opts.logoAnimation) s.setAttribute('data-logo-animation', opts.logoAnimation);

--- a/docs/widget-requirements.md
+++ b/docs/widget-requirements.md
@@ -48,7 +48,7 @@ Este documento resume los lineamientos para que el widget de Chatboc funcione de
 ## Permisos de GPS y CORS
 - Solo se solicitan coordenadas a usuarios registrados y se muestra un mensaje claro si se niegan permisos.
 - Documentar cualquier uso de cookies o configuración de CORS necesaria.
-- Si incrustás el widget con un `<iframe>`, incluí `allow="clipboard-write; geolocation"` para habilitar la solicitud de ubicación. Al usar el `<script>` `widget.js`, ese permiso se aplica automáticamente al iframe generado. Si tu página carga el widget dentro de otro iframe, ese contenedor externo también debe tener `allow="clipboard-write; geolocation"`.
+- Si incrustás el widget con un `<iframe>`, incluí `allow="clipboard-write; geolocation; microphone; camera"` para habilitar la solicitud de ubicación o medios. Al usar el `<script>` `widget.js`, ese permiso se aplica automáticamente al iframe generado. Si tu página carga el widget dentro de otro iframe, ese contenedor externo también debe tener `allow="clipboard-write; geolocation; microphone; camera"`.
 
 ## Soporte para `iframe` y `script`
 - Ambas formas deben comportarse de la misma manera. Documentar pros y contras.

--- a/prueba.html
+++ b/prueba.html
@@ -2,120 +2,305 @@
 <html lang="es">
 <head>
   <meta charset="UTF-8" />
-  <title>Demostración Chatboc Municipio</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+  <title>Demo Chatboc · Municipalidad de Junín</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet" />
+
   <style>
-    *{box-sizing:border-box;}
-    body{
-      margin:0;
-      font-family:'Poppins',sans-serif;
-      color:#fff;
-      background:#f5f5f5;
+    :root {
+      --prim:#006C3F;
+      --acento:#d4a01a;
+      --txt:#2c3e50;
+      --txt-2:#5a6a7a;
+      --fondo:#f5f8f7;
+      --radius:16px;
+      --shadow:0 10px 30px rgba(0,0,0,.08);
     }
-    header{
-      position:fixed;
-      top:0;left:0;
-      width:100%;
-      padding:0.5rem 1.5rem;
-      display:flex;
-      align-items:center;
-      justify-content:space-between;
-      background:rgba(0,0,0,0.3);
-      backdrop-filter:blur(6px);
-      z-index:1000;
+
+    * { box-sizing:border-box; margin:0; padding:0 }
+    body {
+      font-family:Poppins, Arial, sans-serif;
+      background: var(--fondo);
+      color: var(--txt);
     }
-    header img{
-      height:48px;
-      transition:transform .3s ease;
+
+    header {
+      position:sticky;top:0;z-index:1000;
+      background:rgba(255,255,255,.7);
+      backdrop-filter:blur(12px);
+      padding:10px 20px;
+      display:flex;align-items:center;justify-content:space-between;
+      box-shadow:var(--shadow);
     }
-    header nav a{
-      margin-left:1rem;
-      color:#fff;
-      text-decoration:none;
-      font-weight:500;
+
+    header img { width:46px;height:46px;border-radius:50%;border:2px solid var(--prim);object-fit:cover; }
+    nav a { margin:0 12px;font-weight:500;color:var(--txt-2);transition:color .2s; }
+    nav a:hover { color:var(--prim); }
+
+    /* Hero */
+    .hero {
+      display:grid;grid-template-columns:1fr 1fr;gap:30px;
+      padding:50px 20px;max-width:1200px;margin:0 auto;align-items:center;
     }
-    .hero{
-      height:100vh;
-      display:flex;
-      align-items:center;
-      justify-content:center;
-      text-align:center;
-      background:linear-gradient(rgba(0,108,63,.85),rgba(0,108,63,.85)), url('https://images.unsplash.com/photo-1502920917128-1aa500764b1c?auto=format&fit=crop&w=1650&q=80') center/cover no-repeat;
+    .hero-text h1 {
+      font-size:2.4rem;line-height:1.2;color:var(--prim);margin-bottom:12px;
     }
-    .hero h1{
-      font-size:3rem;
-      margin-bottom:.5rem;
+    .hero-text p {
+      font-size:1.1rem;color:var(--txt-2);margin-bottom:24px;
     }
-    .hero p{
-      font-size:1.25rem;
-      margin:0;
+    .cta-group { display:flex;gap:16px;flex-wrap:wrap; }
+    .cta {
+      padding:12px 24px;border-radius:999px;background:var(--acento);
+      color:#fff;font-weight:600;box-shadow:0 8px 22px rgba(212,160,26,.35);
+      transition:transform .3s ease, box-shadow .3s ease, filter .3s ease;
     }
-    @keyframes spin{from{transform:rotate(0deg);}to{transform:rotate(360deg);}}
-    @keyframes pulse{0%{transform:scale(1);}50%{transform:scale(1.08);}100%{transform:scale(1);}}
-    .rotateOnce{animation:spin 1s linear;}
+    .cta:hover {
+      transform: translateY(-3px);
+      box-shadow: 0 12px 28px rgba(212,160,26,.45);
+      filter: brightness(1.05);
+    }
+
+    /* ChatWidget embebido */
+    .chat-preview {
+      border-radius: 20px;
+      box-shadow: var(--shadow);
+      overflow: hidden;
+      height: 480px;
+      max-width: 420px;
+      margin-left: auto;
+      margin-right: auto;
+      display: flex;
+      flex-direction: column;
+    }
+    .chat-header {
+      background:var(--prim);color:white;padding:12px;
+      font-weight:600;display:flex;align-items:center;gap:12px;
+    }
+    .chat-header img {
+      width:40px;height:40px;border-radius:50%;object-fit:cover;
+    }
+    iframe {
+      border:none;
+      flex-grow:1;
+    }
+
+    .chat-body {
+      background-color: #fff;
+      padding: 20px;
+      flex-grow: 1;
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+    @keyframes bubble-in {
+      from {
+        opacity: 0;
+        transform: translateY(10px) scale(0.95);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+      }
+    }
+    .chat-bubble {
+      padding: 10px 15px;
+      border-radius: 18px;
+      max-width: 80%;
+      font-size: .95rem;
+      line-height: 1.4;
+      opacity: 0;
+      animation: bubble-in 0.4s ease-out forwards;
+    }
+    .chat-bubble:nth-child(1) { animation-delay: 0.5s; }
+    .chat-bubble:nth-child(2) { animation-delay: 1.5s; }
+    .chat-bubble:nth-child(3) { animation-delay: 2.5s; }
+    .chat-bubble:nth-child(4) { animation-delay: 3.5s; }
+    .chat-bubble.user {
+      background-color: var(--acento);
+      color: white;
+      align-self: flex-end;
+      border-bottom-right-radius: 4px;
+    }
+    .chat-bubble.bot {
+      background-color: #e5e5ea;
+      color: var(--txt);
+      align-self: flex-start;
+      border-bottom-left-radius: 4px;
+    }
+
+    footer {
+      margin-top:40px;padding:20px;text-align:center;
+      color:var(--txt-2);font-size:.95rem;
+    }
+
+    /* Services */
+    .services { padding: 40px 20px; }
+    .services h2 { text-align: center; margin-bottom: 24px; font-size: 2rem; color: var(--prim); }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 20px;
+      max-width: 1200px;
+      margin: 0 auto;
+    }
+    .card {
+      background: #fff;
+      border-radius: var(--radius);
+      padding: 20px;
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      box-shadow: var(--shadow);
+      transition: transform .3s ease, box-shadow .3s ease;
+    }
+    .card:hover {
+      transform: translateY(-6px);
+      box-shadow: 0 18px 40px rgba(0,0,0,.12);
+    }
+    .icon {
+      width: 48px;
+      height: 48px;
+      display: grid;
+      place-items: center;
+      border-radius: 12px;
+      background: rgba(0,108,63,.08);
+      flex-shrink: 0;
+      transition: background-color .3s ease, transform .3s ease;
+    }
+    .card:hover .icon {
+      background-color: var(--prim);
+      transform: scale(1.1);
+    }
+    .card:hover .icon svg {
+      color: white;
+    }
+    .icon svg {
+      width: 28px;
+      height: 28px;
+      color: var(--prim);
+    }
+    .card span {
+      font-weight: 600;
+      font-size: 1.05rem;
+    }
+
+    @media(max-width:900px){
+      .hero{grid-template-columns:1fr;text-align:center;}
+      .cta-group{justify-content:center;}
+    }
   </style>
 </head>
 <body>
   <header>
-    <img id="municipal-logo" src="./juni-logo.svg" alt="Municipio de Junín" />
+    <img id="logoHeader" src="https://chatboc-demo-widget-oigs.vercel.app/junilogo.png" alt="Logo Junín" onerror="this.src=window.__FALLBACK_LOGO" />
     <nav>
-      <a href="#">Inicio</a>
-      <a href="#">Trámites</a>
-      <a href="#">Contacto</a>
+      <a href="#">Noticias</a>
+      <a href="#">Obras</a>
+      <a href="#">Cultura</a>
+      <a href="#">Turismo</a>
     </nav>
   </header>
-  <main class="hero">
-    <div class="hero-content">
-      <h1>Municipalidad de Junín</h1>
-      <p>Demostración del asistente virtual</p>
+
+  <section class="hero">
+    <!-- Texto -->
+    <div class="hero-text">
+      <h1>Atención al ciudadano, 24/7 y sin espera</h1>
+      <p>El asistente <b>JUNI</b> resuelve trámites, reclamos, tasas y consultas en segundos.
+      Integrado a WhatsApp y web, con seguimiento y tickets.</p>
+      <div class="cta-group">
+        <a class="cta" onclick="window.postMessage({type:'chatboc:open'}, '*')">Probar el asistente</a>
+        <a class="cta" style="background:#25D366;">WhatsApp</a>
+        <a class="cta" style="background:#007BFF;">Consultar reclamos</a>
+      </div>
     </div>
-  </main>
 
+    <!-- Vista previa del chat -->
+    <div class="chat-preview">
+      <div class="chat-header">
+        <img src="https://chatboc-demo-widget-oigs.vercel.app/junilogo.png" alt="Juni" onerror="this.src=window.__FALLBACK_LOGO">
+        <span>Asistente Virtual JUNI</span>
+      </div>
+      <div class="chat-body">
+        <div class="chat-bubble bot">
+            ¡Hola! Soy JUNI, tu asistente virtual. ¿En qué puedo ayudarte hoy?
+        </div>
+        <div class="chat-bubble user">
+            Quiero pagar mis tasas municipales.
+        </div>
+        <div class="chat-bubble bot">
+            Claro, puedo ayudarte con eso. Por favor, indicame tu número de DNI o CUIT para buscar tus tasas.
+        </div>
+        <div class="chat-bubble user">
+            Mi DNI es 12.345.678
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="services">
+    <h2>Servicios Municipales</h2>
+    <div class="grid">
+      <div class="card">
+        <div class="icon">
+          <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"></path></svg>
+        </div>
+        <span>Atención al Ciudadano</span>
+      </div>
+      <div class="card">
+        <div class="icon">
+          <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"></path></svg>
+        </div>
+        <span>Trámites</span>
+      </div>
+      <div class="card">
+        <div class="icon">
+          <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+        </div>
+        <span>Información</span>
+      </div>
+    </div>
+  </section>
+
+  <footer>
+    Demostración oficial · Chatboc.ar para Municipalidad de Junín
+  </footer>
+
+  <!-- WIDGET SCRIPT -->
   <script>
-    const municipalLogo=document.getElementById('municipal-logo');
-    function spinLogo(){
-      municipalLogo.classList.remove('rotateOnce');
-      void municipalLogo.offsetWidth;
-      municipalLogo.classList.add('rotateOnce');
-    }
-    window.addEventListener('message',(event)=>{
-      if(event.data && (event.data.type==='chatboc:open' || event.data==='chatboc_widget_opened')){
-        spinLogo();
-      }
+    document.addEventListener('DOMContentLoaded', function () {
+      // Fallback logo SVG
+      window.__FALLBACK_LOGO =
+        'data:image/svg+xml;utf8,' +
+        encodeURIComponent(`<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256">
+          <circle cx="128" cy="128" r="120" fill="#006C3F"/>
+          <text x="50%" y="55%" text-anchor="middle" font-family="Arial" font-size="140" fill="#fff" font-weight="700">J</text>
+        </svg>`);
+
+      const ENTITY_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjo0LCJleHAiOjE3NTc2OTAxNTF9._vI8DgAfyMBnxgK32L1MwgPjwPK2KJrtcoYOHqlXcPQ";
+
+      const s = document.createElement('script');
+      s.src = 'https://chatboc.ar/widget.js';
+      s.async = true;
+      s.setAttribute('data-entity-token', ENTITY_TOKEN);
+      s.setAttribute('data-endpoint', 'municipio');
+      s.setAttribute('data-primary-color', '#006C3F');
+      s.setAttribute('data-accent-color', '#d4a01a');
+      s.setAttribute('data-logo-url', 'https://chatboc-demo-widget-oigs.vercel.app/junilogo.png');
+      s.setAttribute('data-logo-animation', 'pulse 5s ease-in-out infinite');
+      s.setAttribute('data-welcome-title', '¡Hola! Soy JUNI');
+      s.setAttribute('data-welcome-subtitle', 'Asistente Virtual de Junín');
+      s.setAttribute('data-bottom', '20px');
+      s.setAttribute('data-right', '20px');
+      s.setAttribute('data-width', '460px');
+      s.setAttribute('data-height', '680px');
+      s.setAttribute('data-closed-width', '112px');
+      s.setAttribute('data-closed-height', '112px');
+      document.body.appendChild(s);
     });
-  </script>
-
-  <script>
-  document.addEventListener('DOMContentLoaded', function () {
-    if (window.chatbocDestroyWidget) {
-      window.chatbocDestroyWidget('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjo0LCJleHAiOjE3NTc1NDI2Nzl9.FtoJGSfL9OmaWHxYw8hyhp6nIbiBaFUKUdgzODwY3tk');
-    }
-    window.APP_TARGET = 'municipio';
-
-    var s = document.createElement('script');
-    s.src = 'https://chatboc.ar/widget.js';
-    s.async = true;
-    s.setAttribute('data-entity-token','eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjo0LCJleHAiOjE3NTc1NDI2Nzl9.FtoJGSfL9OmaWHxYw8hyhp6nIbiBaFUKUdgzODwY3tk');
-    s.setAttribute('data-default-open','false');
-    s.setAttribute('data-width','460px');
-    s.setAttribute('data-height','680px');
-    s.setAttribute('data-closed-width','112px');
-    s.setAttribute('data-closed-height','112px');
-    s.setAttribute('data-bottom','20px');
-    s.setAttribute('data-right','20px');
-    s.setAttribute('data-endpoint','municipio');
-    s.setAttribute('data-primary-color','#006C3F');
-    s.setAttribute('data-logo-url','./juni-logo.svg');
-    s.setAttribute('data-logo-animation','pulse 6s ease-in-out infinite');
-
-    document.body.appendChild(s);
-
-    s.onload = function() { console.log('Chatboc Widget cargado y listo.'); };
-    s.onerror = function() { console.error('Error al cargar Chatboc Widget.'); };
-  });
   </script>
 </body>
 </html>
+

--- a/pruebaiframe.html
+++ b/pruebaiframe.html
@@ -2,7 +2,7 @@
   id="chatboc-iframe"
   src="https://chatboc.ar/iframe?entityToken=ef403b5b-e0df-4b35-be34-35b9dac0d6f1&tipo_chat=municipio"
   style="position:fixed; bottom:20px; right:20px; border:none; border-radius:50%; z-index:9999; box-shadow:0 4px 32px rgba(0,0,0,0.2); background:transparent; overflow:hidden; width:112px; height:112px; display:block; transition: width 0.3s ease, height 0.3s ease, border-radius 0.3s ease;"
-  allow="clipboard-write; geolocation"
+  allow="clipboard-write; geolocation; microphone; camera"
   loading="lazy"
   title="Chatboc Widget"
 ></iframe>
@@ -12,8 +12,8 @@ document.addEventListener('DOMContentLoaded', function () {
   var chatIframe = document.getElementById('chatboc-iframe');
 
   // Es crucial que si este código de iframe se inserta dentro de OTRO iframe en tu sitio,
-  // ese iframe contenedor también debe tener 'allow="clipboard-write; geolocation"'.
-  // Ejemplo: <iframe src="pagina_con_este_codigo.html" allow="clipboard-write; geolocation"></iframe>
+  // ese iframe contenedor también debe tener 'allow="clipboard-write; geolocation; microphone; camera"'.
+  // Ejemplo: <iframe src="pagina_con_este_codigo.html" allow="clipboard-write; geolocation; microphone; camera"></iframe>
 
   // Comunicación con el iframe para ajustar tamaño y forma
   window.addEventListener('message', function (event) {

--- a/pruebascr.html
+++ b/pruebascr.html
@@ -25,11 +25,11 @@ document.addEventListener('DOMContentLoaded', function () {
   s.setAttribute('data-welcome-title', '¡Hola! Soy tu asistente');
   s.setAttribute('data-welcome-subtitle', 'Estoy aquí para ayudarte');
   
-  // Importante para la geolocalización y el portapapeles:
-  // widget.js establecerá allow="clipboard-write; geolocation" en su iframe interno.
+  // Importante para la geolocalización, micrófono y portapapeles:
+  // widget.js establecerá allow="clipboard-write; geolocation; microphone; camera" en su iframe interno.
   // Si este script se inserta dentro de un iframe en tu sitio, ese iframe contenedor
-  // también debe incluir allow="clipboard-write; geolocation" en sus atributos.
-  // Ejemplo: <iframe src="tu_pagina_con_widget.html" allow="clipboard-write; geolocation"></iframe>
+  // también debe incluir allow="clipboard-write; geolocation; microphone; camera" en sus atributos.
+  // Ejemplo: <iframe src="tu_pagina_con_widget.html" allow="clipboard-write; geolocation; microphone; camera"></iframe>
 
   document.body.appendChild(s); // Añade el script al final del body
 

--- a/public/iframe.html
+++ b/public/iframe.html
@@ -62,6 +62,7 @@
         bottom: params.get('bottom') || '20px',
         right: params.get('right') || '20px',
         primaryColor: params.get('primaryColor') || '#007aff',
+        accentColor: params.get('accentColor') || '',
         logoUrl: params.get('logoUrl') || '',
         headerLogoUrl: params.get('headerLogoUrl') || params.get('logoUrl') || '',
         logoAnimation: params.get('logoAnimation') || '',

--- a/public/widget.js
+++ b/public/widget.js
@@ -36,6 +36,7 @@
     bottom: ds.bottom || "20px",
     right: ds.right || "20px",
     primaryColor: ds.primaryColor || "#007aff",
+    accentColor: ds.accentColor || "",
     logoUrl: ds.logoUrl || "",
     headerLogoUrl: ds.headerLogoUrl || ds.logoUrl || "",
     logoAnimation: ds.logoAnimation || "",
@@ -56,6 +57,7 @@
     widgetId: iframeId,
     hostDomain: window.location.origin,
     primaryColor: cfg.primaryColor,
+    accentColor: cfg.accentColor,
     logoUrl: cfg.logoUrl,
     headerLogoUrl: cfg.headerLogoUrl,
     logoAnimation: cfg.logoAnimation,
@@ -77,7 +79,7 @@
   iframe.src = iframeSrc;
   iframe.style.cssText =
     "width: 100%; height: 100%; border: none; background: transparent;";
-  iframe.allow = "microphone; geolocation; clipboard-write";
+  iframe.allow = "microphone; geolocation; clipboard-write; camera";
   iframe.sandbox =
     "allow-forms allow-popups allow-modals allow-scripts allow-same-origin allow-downloads";
 

--- a/src/components/chat/ChatHeader.tsx
+++ b/src/components/chat/ChatHeader.tsx
@@ -36,8 +36,8 @@ const ChatHeader: React.FC<Props> = ({
       className={`
         flex items-center justify-between flex-shrink-0 w-full
         px-2 sm:px-4 py-3 border-b border-border
-        bg-card/90 backdrop-blur-md
-        text-card-foreground
+        bg-primary backdrop-blur-md
+        text-primary-foreground
         transition-all rounded-t-[inherit] overflow-hidden
       `}
     >
@@ -64,23 +64,23 @@ const ChatHeader: React.FC<Props> = ({
           <span className="font-extrabold text-base tracking-wide" style={{ letterSpacing: ".02em" }}>
             {title || 'Chatboc'}
           </span>
-          <span className="text-xs text-muted-foreground" style={{ fontWeight: 500 }}>
+          <span className="text-xs text-primary-foreground/80" style={{ fontWeight: 500 }}>
             {subtitle || 'Asistente Virtual'}
           </span>
         </div>
       </div>
       <div className="flex items-center gap-1 sm:gap-2"> {/* Reduced gap for mobile */}
         <span
-          className="text-primary text-xs font-semibold flex items-center"
+          className="text-primary-foreground text-xs font-semibold flex items-center"
           aria-label="Estado del bot: Online"
         >
-          <span className="w-2 h-2 bg-primary rounded-full mr-1 sm:mr-1.5"></span> {/* Reduced margin for mobile */}
+          <span className="w-2 h-2 bg-primary-foreground rounded-full mr-1 sm:mr-1.5"></span> {/* Reduced margin for mobile */}
           <span className="hidden sm:inline">Online</span> {/* Hide "Online" text on very small screens */}
         </span>
         {onBack ? (
           <button
             onClick={onBack}
-            className="text-muted-foreground hover:text-foreground transition"
+            className="text-primary-foreground/80 hover:text-primary-foreground transition"
             aria-label="Volver"
           >
             <ChevronLeft size={20} />
@@ -88,7 +88,7 @@ const ChatHeader: React.FC<Props> = ({
         ) : onProfile && showProfile ? (
           <button
             onClick={onProfile}
-            className="text-muted-foreground hover:text-foreground transition"
+            className="text-primary-foreground/80 hover:text-primary-foreground transition"
             aria-label="Mi perfil"
           >
             <User size={20} />
@@ -97,7 +97,7 @@ const ChatHeader: React.FC<Props> = ({
         {onCart && (
           <button
             onClick={onCart}
-            className="text-muted-foreground hover:text-foreground transition"
+            className="text-primary-foreground/80 hover:text-primary-foreground transition"
             aria-label="Ver carrito"
           >
             <ShoppingCart size={20} />
@@ -106,7 +106,7 @@ const ChatHeader: React.FC<Props> = ({
         {onToggleSound && (
           <button
             onClick={onToggleSound}
-            className="text-muted-foreground hover:text-foreground transition"
+            className="text-primary-foreground/80 hover:text-primary-foreground transition"
             aria-label={muted ? 'Activar sonido' : 'Silenciar sonido'}
           >
             {muted ? <VolumeX size={20} /> : <Volume2 size={20} />}
@@ -114,7 +114,7 @@ const ChatHeader: React.FC<Props> = ({
         )}
         <button
           onClick={onClose}
-          className="text-muted-foreground hover:text-foreground transition"
+          className="text-primary-foreground/80 hover:text-primary-foreground transition"
           aria-label="Cerrar chat"
         >
           <X size={20} />

--- a/src/components/chat/ChatMessageBase.tsx
+++ b/src/components/chat/ChatMessageBase.tsx
@@ -42,20 +42,33 @@ function normalizeAttachment(msg: any): RawAttachment | null {
 }
 
 // --- Avatares (reutilizados de ChatMessagePyme/Municipio) ---
-const AvatarBot: React.FC<{ isTyping: boolean }> = ({ isTyping }) => (
+const AvatarBot: React.FC<{ isTyping: boolean; logoUrl?: string; logoAnimation?: string }> = ({
+  isTyping,
+  logoUrl,
+  logoAnimation,
+}) => (
   <motion.div
     initial={{ scale: 0.8, opacity: 0 }}
     animate={{ scale: 1, opacity: 1 }}
     transition={{ type: "spring", stiffness: 300, damping: 20, delay: 0.1 }}
     className="flex-shrink-0 w-8 h-8 flex items-center justify-center bg-muted rounded-full shadow"
   >
-    <ChatbocLogoAnimated
-      size={24}
-      smiling={isTyping}
-      movingEyes={isTyping}
-      blinking
-      pulsing
-    />
+    {logoUrl ? (
+      <img
+        src={logoUrl}
+        alt="Bot"
+        className="w-6 h-6 rounded-full"
+        style={{ animation: logoAnimation || undefined }}
+      />
+    ) : (
+      <ChatbocLogoAnimated
+        size={24}
+        smiling={isTyping}
+        movingEyes={isTyping}
+        blinking
+        pulsing
+      />
+    )}
   </motion.div>
 );
 
@@ -147,6 +160,8 @@ export interface ChatMessageBaseProps {
   onButtonClick: (valueToSend: SendPayload) => void;
   onInternalAction?: (action: string) => void;
   tipoChat?: "pyme" | "municipio"; // Puede usarse para alguna lógica residual muy específica
+  botLogoUrl?: string;
+  logoAnimation?: string;
 }
 
 const ChatMessageBase = React.forwardRef<HTMLDivElement, ChatMessageBaseProps>( (
@@ -155,6 +170,8 @@ const ChatMessageBase = React.forwardRef<HTMLDivElement, ChatMessageBaseProps>( 
     isTyping,
     onButtonClick,
     onInternalAction,
+    botLogoUrl,
+    logoAnimation,
     // tipoChat, // tipoChat podría usarse si hay alguna variación mínima que no dependa del contenido del mensaje
   },
   ref
@@ -237,7 +254,7 @@ const ChatMessageBase = React.forwardRef<HTMLDivElement, ChatMessageBaseProps>( 
       // layout // Podría causar problemas con scroll, evaluar
     >
       <div className={`flex items-end gap-2 ${isBot ? "" : "flex-row-reverse"}`}>
-        {isBot && <AvatarBot isTyping={isTyping} />}
+        {isBot && <AvatarBot isTyping={isTyping} logoUrl={botLogoUrl} logoAnimation={logoAnimation} />}
 
         <MessageBubble className={cn(bubbleBaseClass, bubbleStyleClass, message.isError && "bg-destructive/20 border border-destructive/50")}>
           {/* Icono de error */}

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -284,11 +284,15 @@ const ChatPanel = ({
       />
       <div ref={chatContainerRef} className="flex-1 p-2 sm:p-4 min-h-0 flex flex-col gap-3 overflow-y-auto">
         {messages.map((msg) =>
-          <ChatMessage key={msg.id} message={msg}
+          <ChatMessage
+            key={msg.id}
+            message={msg}
             isTyping={isTyping}
             onButtonClick={handleSend}
             onInternalAction={handleInternalAction}
             tipoChat={tipoChat}
+            botLogoUrl={headerLogoUrl}
+            logoAnimation={logoAnimation}
           />
         )}
         {isTyping && <TypingIndicator />}

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -502,6 +502,8 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
                 message={proactiveMessage || ""}
                 onClick={toggleChat}
                 visible={showProactiveBubble && !showCta}
+                logoUrl={headerLogoUrl || customLauncherLogoUrl || entityInfo?.logo_url}
+                logoAnimation={logoAnimation}
               />
               {showCta && ctaMessage && !showProactiveBubble && (
                 <motion.div

--- a/src/components/chat/ProactiveBubble.tsx
+++ b/src/components/chat/ProactiveBubble.tsx
@@ -7,12 +7,16 @@ interface ProactiveBubbleProps {
   message: string;
   onClick: () => void;
   visible: boolean;
+  logoUrl?: string;
+  logoAnimation?: string;
 }
 
 const ProactiveBubble: React.FC<ProactiveBubbleProps> = ({
   message,
   onClick,
   visible,
+  logoUrl,
+  logoAnimation,
 }) => {
   if (!visible) return null;
 
@@ -56,7 +60,16 @@ const ProactiveBubble: React.FC<ProactiveBubbleProps> = ({
         initial={{ scale: 0, opacity: 0, x: 10 }}
         animate={{ scale: 1, opacity: 1, x: 0, transition: { type: "spring", stiffness: 260, damping: 18, delay: 0.4 } }}
       >
-        <ChatbocLogoAnimated size={26} blinking />
+        {logoUrl ? (
+          <img
+            src={logoUrl}
+            alt="Bot"
+            className="w-6 h-6 rounded-full"
+            style={{ animation: logoAnimation || undefined }}
+          />
+        ) : (
+          <ChatbocLogoAnimated size={26} blinking />
+        )}
       </motion.div>
     </motion.div>
   );

--- a/src/pages/Integracion.tsx
+++ b/src/pages/Integracion.tsx
@@ -43,6 +43,7 @@ const Integracion = () => {
   const [copiado, setCopiado] = useState<"iframe" | "script" | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [primaryColor, setPrimaryColor] = useState("#007aff");
+  const [accentColor, setAccentColor] = useState("#007aff");
   const [logoUrl, setLogoUrl] = useState("");
   const [logoAnimation, setLogoAnimation] = useState("");
   const [headerLogoUrl, setHeaderLogoUrl] = useState("");
@@ -120,6 +121,7 @@ const Integracion = () => {
   const codeScript = useMemo(() => {
     const customLines = [
       primaryColor && `      s.setAttribute('data-primary-color', '${primaryColor}'); // Color del launcher`,
+      accentColor && `      s.setAttribute('data-accent-color', '${accentColor}'); // Color de acento`,
       logoUrl && `      s.setAttribute('data-logo-url', '${logoUrl}'); // URL del icono`,
       headerLogoUrl && `      s.setAttribute('data-header-logo-url', '${headerLogoUrl}'); // Logo del encabezado`,
       logoAnimation && `      s.setAttribute('data-logo-animation', '${logoAnimation}'); // Animación del icono`,
@@ -155,9 +157,9 @@ document.addEventListener('DOMContentLoaded', function () {
     s.setAttribute('data-right', '${WIDGET_STD_RIGHT}');
     s.setAttribute('data-endpoint', '${endpoint}');
 ${customLines ? customLines + "\n" : ""}    // Importante para la geolocalización y el portapapeles:
-    // widget.js establecerá allow="clipboard-write; geolocation" en su iframe interno.
+    // widget.js establecerá allow="clipboard-write; geolocation; microphone; camera" en su iframe interno.
     // Si este script se inserta dentro de un iframe en tu sitio, ese iframe contenedor
-    // también debe incluir allow="clipboard-write; geolocation" en sus atributos.
+    // también debe incluir allow="clipboard-write; geolocation; microphone; camera" en sus atributos.
 
     document.body.appendChild(s);
     currentScript = s;
@@ -209,10 +211,10 @@ ${customLines ? customLines + "\n" : ""}    // Importante para la geolocalizaci�
   s.setAttribute('data-right', '${WIDGET_STD_RIGHT}'); // Posición desde la derecha
   s.setAttribute('data-endpoint', '${endpoint}'); // Tipo de chat (pyme o municipio)
 ${customLines ? customLines + "\n" : ""}  // Importante para la geolocalización y el portapapeles:
-  // widget.js establecerá allow="clipboard-write; geolocation" en su iframe interno.
+  // widget.js establecerá allow="clipboard-write; geolocation; microphone; camera" en su iframe interno.
   // Si este script se inserta dentro de un iframe en tu sitio, ese iframe contenedor
-  // también debe incluir allow="clipboard-write; geolocation" en sus atributos.
-  // Ejemplo: <iframe src="tu_pagina_con_widget.html" allow="clipboard-write; geolocation"></iframe>
+  // también debe incluir allow="clipboard-write; geolocation; microphone; camera" en sus atributos.
+  // Ejemplo: <iframe src="tu_pagina_con_widget.html" allow="clipboard-write; geolocation; microphone; camera"></iframe>
 
   document.body.appendChild(s); // Añade el script al final del body
 
@@ -221,26 +223,27 @@ ${customLines ? customLines + "\n" : ""}  // Importante para la geolocalización
   refreshToken();
 });
 </script>`;
-  }, [entityToken, endpoint, primaryColor, logoUrl, headerLogoUrl, logoAnimation, welcomeTitle, welcomeSubtitle]);
+  }, [entityToken, endpoint, primaryColor, accentColor, logoUrl, headerLogoUrl, logoAnimation, welcomeTitle, welcomeSubtitle]);
 
   const iframeSrcUrl = useMemo(() => {
     const url = new URL("https://chatboc.ar/iframe");
     url.searchParams.set("entityToken", entityToken);
     url.searchParams.set("tipo_chat", endpoint);
     if (primaryColor) url.searchParams.set("primaryColor", primaryColor);
+    if (accentColor) url.searchParams.set("accentColor", accentColor);
     if (logoUrl) url.searchParams.set("logoUrl", logoUrl);
     if (headerLogoUrl) url.searchParams.set("headerLogoUrl", headerLogoUrl);
     if (logoAnimation) url.searchParams.set("logoAnimation", logoAnimation);
     if (welcomeTitle) url.searchParams.set("welcomeTitle", welcomeTitle);
     if (welcomeSubtitle) url.searchParams.set("welcomeSubtitle", welcomeSubtitle);
     return url.toString();
-  }, [entityToken, endpoint, primaryColor, logoUrl, headerLogoUrl, logoAnimation, welcomeTitle, welcomeSubtitle]);
+  }, [entityToken, endpoint, primaryColor, accentColor, logoUrl, headerLogoUrl, logoAnimation, welcomeTitle, welcomeSubtitle]);
   
   const codeIframe = useMemo(() => `<iframe
   id="chatboc-iframe"
   src="${iframeSrcUrl}"
   style="position:fixed; bottom:${WIDGET_STD_BOTTOM}; right:${WIDGET_STD_RIGHT}; border:none; border-radius:50%; z-index:9999; box-shadow:0 4px 32px rgba(0,0,0,0.2); background:transparent; overflow:hidden; width:${WIDGET_STD_CLOSED_WIDTH}; height:${WIDGET_STD_CLOSED_HEIGHT}; display:block; transition: width 0.3s ease, height 0.3s ease, border-radius 0.3s ease;"
-  allow="clipboard-write; geolocation"
+  allow="clipboard-write; geolocation; microphone; camera"
   loading="lazy"
   title="Chatboc Widget"
 ></iframe>
@@ -250,8 +253,8 @@ document.addEventListener('DOMContentLoaded', function () {
   var chatIframe = document.getElementById('chatboc-iframe');
 
   // Es crucial que si este código de iframe se inserta dentro de OTRO iframe en tu sitio,
-  // ese iframe contenedor también debe tener 'allow="clipboard-write; geolocation"'.
-  // Ejemplo: <iframe src="pagina_con_este_codigo.html" allow="clipboard-write; geolocation"></iframe>
+  // ese iframe contenedor también debe tener 'allow="clipboard-write; geolocation; microphone; camera"'.
+  // Ejemplo: <iframe src="pagina_con_este_codigo.html" allow="clipboard-write; geolocation; microphone; camera"></iframe>
 
   // Comunicación con el iframe para ajustar tamaño y forma
   window.addEventListener('message', function (event) {
@@ -431,6 +434,15 @@ document.addEventListener('DOMContentLoaded', function () {
               />
             </div>
             <div className="flex flex-col space-y-2">
+              <Label htmlFor="accentColor">Color de acento</Label>
+              <Input
+                id="accentColor"
+                type="color"
+                value={accentColor}
+                onChange={(e) => setAccentColor(e.target.value)}
+              />
+            </div>
+            <div className="flex flex-col space-y-2">
               <Label htmlFor="logoUrl">URL del logo</Label>
               <Input
                 id="logoUrl"
@@ -501,7 +513,7 @@ document.addEventListener('DOMContentLoaded', function () {
             </CardHeader>
             <CardContent className="text-sm space-y-2">
               <p><strong>Ventajas:</strong> Mayor flexibilidad, actualizaciones automáticas del widget, mejor integración con la página anfitriona.</p>
-              <p><strong>Geolocalización y Portapapeles:</strong> Si tu página (donde pegas este script) ya está dentro de un iframe, asegúrate de que ese iframe contenedor tenga el atributo <code>allow="clipboard-write; geolocation"</code> para que estas funciones del chatbot operen correctamente.</p>
+              <p><strong>Geolocalización, micrófono y portapapeles:</strong> Si tu página (donde pegas este script) ya está dentro de un iframe, asegúrate de que ese iframe contenedor tenga el atributo <code>allow="clipboard-write; geolocation; microphone; camera"</code> para que estas funciones del chatbot operen correctamente.</p>
               <p><strong>Personalización:</strong> Puedes modificar los atributos <code>data-*</code> en el script para ajustar la apariencia y comportamiento iniciales del widget. Por ejemplo, <code>data-default-open="true"</code> para que el chat se abra al cargar la página.</p>
             </CardContent>
           </Card>
@@ -515,7 +527,7 @@ document.addEventListener('DOMContentLoaded', function () {
             </CardHeader>
             <CardContent className="text-sm space-y-2">
               <p><strong>Ventajas:</strong> Aislamiento completo del contenido del widget, puede ser más simple de implementar en algunas plataformas con restricciones de scripts.</p>
-              <p><strong>Geolocalización y Portapapeles:</strong> Similar al método script, si la página donde insertas este iframe está a su vez dentro de otro iframe, el iframe más externo debe incluir <code>allow="clipboard-write; geolocation"</code>.</p>
+              <p><strong>Geolocalización, micrófono y portapapeles:</strong> Similar al método script, si la página donde insertas este iframe está a su vez dentro de otro iframe, el iframe más externo debe incluir <code>allow="clipboard-write; geolocation; microphone; camera"</code>.</p>
               <p><strong>Limitaciones:</strong> Menos flexibilidad para la comunicación directa con la página anfitriona en comparación con el método script. Las actualizaciones del widget se manejan dentro del iframe.</p>
             </CardContent>
           </Card>
@@ -562,7 +574,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     }}
                     loading="lazy"
                     title="Vista previa del Chatbot Chatboc"
-                    allow="clipboard-write; geolocation"
+                    allow="clipboard-write; geolocation; microphone; camera"
                   />
                 ) : (
                   <div className="p-4 text-center text-muted-foreground">
@@ -596,9 +608,9 @@ document.addEventListener('DOMContentLoaded', function () {
               En Tiendanube, por ejemplo, puedes necesitar usar la opción de "Editar Código Avanzado".
             </p>
             <p>
-              <strong>Problemas de Geolocalización o Portapapeles:</strong>
-              Asegúrate de que tu sitio se sirva a través de <strong>HTTPS</strong>, ya que muchas funciones del navegador, incluida la geolocalización, lo requieren.
-              Si tu página está incrustada en otro iframe, el iframe contenedor DEBE tener el atributo <code>allow="clipboard-write; geolocation"</code>.
+              <strong>Problemas de Geolocalización, micrófono o Portapapeles:</strong>
+              Asegúrate de que tu sitio se sirva a través de <strong>HTTPS</strong>, ya que muchas funciones del navegador, incluida la geolocalización y el acceso al micrófono, lo requieren.
+              Si tu página está incrustada en otro iframe, el iframe contenedor DEBE tener el atributo <code>allow="clipboard-write; geolocation; microphone; camera"</code>.
             </p>
              <p>
               <strong>Conflictos de Estilos o Scripts:</strong>

--- a/src/pages/iframe.tsx
+++ b/src/pages/iframe.tsx
@@ -8,6 +8,41 @@ import { MemoryRouter } from "react-router-dom";
 import { getChatbocConfig } from "@/utils/config";
 import { safeLocalStorage } from "@/utils/safeLocalStorage";
 
+function hexToHsl(hex: string): string {
+  let r = 0, g = 0, b = 0;
+  const normalized = hex.replace('#', '');
+  if (normalized.length === 3) {
+    r = parseInt(normalized[0] + normalized[0], 16);
+    g = parseInt(normalized[1] + normalized[1], 16);
+    b = parseInt(normalized[2] + normalized[2], 16);
+  } else if (normalized.length === 6) {
+    r = parseInt(normalized.substring(0, 2), 16);
+    g = parseInt(normalized.substring(2, 4), 16);
+    b = parseInt(normalized.substring(4, 6), 16);
+  }
+  r /= 255; g /= 255; b /= 255;
+  const max = Math.max(r, g, b), min = Math.min(r, g, b);
+  let h = 0, s = 0;
+  const l = (max + min) / 2;
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0);
+        break;
+      case g:
+        h = (b - r) / d + 2;
+        break;
+      case b:
+        h = (r - g) / d + 4;
+        break;
+    }
+    h /= 6;
+  }
+  return `${Math.round(h * 360)} ${Math.round(s * 100)}% ${Math.round(l * 100)}%`;
+}
+
 const DEFAULTS = {
   openWidth: "460px",
   openHeight: "680px",
@@ -36,8 +71,12 @@ const Iframe = () => {
     const cfg = getChatbocConfig();
     const urlParams = new URLSearchParams(window.location.search);
 
-    const primaryColor = urlParams.get("primaryColor") || cfg.primaryColor || "#007aff";
-    document.documentElement.style.setProperty("--primary", primaryColor);
+    const primaryColorHex = urlParams.get("primaryColor") || cfg.primaryColor || "#007aff";
+    document.documentElement.style.setProperty("--primary", hexToHsl(primaryColorHex));
+    const accentColorHex = urlParams.get("accentColor") || cfg.accentColor || "";
+    if (accentColorHex) {
+      document.documentElement.style.setProperty("--accent", hexToHsl(accentColorHex));
+    }
 
     const tokenFromUrl = urlParams.get("entityToken") || cfg.entityToken || '';
     if (tokenFromUrl) {
@@ -72,7 +111,8 @@ const Iframe = () => {
       endpoint: endpointParam || undefined,
       bottom: parseInt(urlParams.get("bottom") || cfg.bottom || String(DEFAULTS.bottom), 10),
       right: parseInt(urlParams.get("right") || cfg.right || String(DEFAULTS.right), 10),
-      primaryColor,
+      primaryColor: primaryColorHex,
+      accentColor: accentColorHex,
       logoUrl: urlParams.get("logoUrl") || cfg.logoUrl || '',
       headerLogoUrl: urlParams.get("headerLogoUrl") || cfg.headerLogoUrl || '',
       logoAnimation: urlParams.get("logoAnimation") || cfg.logoAnimation || '',

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -12,6 +12,7 @@ export function getChatbocConfig() {
     bottom: g.bottom || '20px',
     right: g.right || '20px',
     primaryColor: g.primaryColor || '#007aff',
+    accentColor: g.accentColor || '',
     logoUrl: g.logoUrl || '',
     headerLogoUrl: g.headerLogoUrl || g.logoUrl || '',
     logoAnimation: g.logoAnimation || '',

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
     {
       "source": "/(.*)",
       "headers": [
-        { "key": "Permissions-Policy", "value": "microphone=*, geolocation=*, clipboard-write=*"},
+        { "key": "Permissions-Policy", "value": "microphone=*, geolocation=*, clipboard-write=*, camera=*"},
         { "key": "Cross-Origin-Opener-Policy", "value": "same-origin-allow-popups" },
         { "key": "Cross-Origin-Embedder-Policy", "value": "unsafe-none" },
         { "key": "X-Frame-Options", "value": "ALLOWALL" }

--- a/widget.js
+++ b/widget.js
@@ -74,6 +74,7 @@
     const ctaMessageAttr = script.getAttribute("data-cta-message") || "";
     const langAttr = script.getAttribute("data-lang") || "";
     const primaryColor = script.getAttribute("data-primary-color") || "#007aff";
+    const accentColor = script.getAttribute("data-accent-color") || "";
     const logoUrlAttr = script.getAttribute("data-logo-url");
     const headerLogoUrlAttr = script.getAttribute("data-header-logo-url");
     const logoAnimationAttr = script.getAttribute("data-logo-animation") || "";
@@ -217,6 +218,7 @@
       if (finalCta) iframeSrc.searchParams.set("ctaMessage", finalCta);
       if (langAttr) iframeSrc.searchParams.set("lang", langAttr);
       if (primaryColor) iframeSrc.searchParams.set("primaryColor", primaryColor);
+      if (accentColor) iframeSrc.searchParams.set("accentColor", accentColor);
       if (logoUrlAttr) iframeSrc.searchParams.set("logoUrl", logoUrlAttr);
       if (headerLogoUrlAttr) iframeSrc.searchParams.set("headerLogoUrl", headerLogoUrlAttr);
       if (logoAnimationAttr) iframeSrc.searchParams.set("logoAnimation", logoAnimationAttr);
@@ -239,7 +241,7 @@
       iframe.setAttribute("width", "100%");
       iframe.setAttribute("height", "100%");
       iframe.setAttribute("frameborder", "0");
-      iframe.allow = "clipboard-write; geolocation";
+      iframe.allow = "clipboard-write; geolocation; microphone; camera";
       iframe.setAttribute("title", "Chatboc Asistente Virtual");
       widgetContainer.appendChild(iframe);
 


### PR DESCRIPTION
## Summary
- allow widget consumers to specify an accent color via `data-accent-color`
- propagate custom header logo to bot avatar and proactive bubble for full theming
- enable photo upload, location sharing, and voice notes by adding microphone and camera permissions to iframe and documentation
- convert incoming color hex codes to HSL for CSS variables, preventing fallback to default blue
- style chat header with primary foreground so icons and subtitles stay legible on dark themes

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install vitest` *(fails: 403 Forbidden - GET https://registry.npmjs.org/mammoth)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1ded79388322b760a18302237bde