### PR TITLE
feat: add widget auth script

### DIFF
--- a/cdn/widget/v1.js
+++ b/cdn/widget/v1.js
@@ -1,0 +1,60 @@
+(function () {
+  const S = document.currentScript;
+  const API = (S?.dataset?.apiBase || "https://chatboc.ar").replace(/\x2f+$/, "");
+  let token = null, timer = null;
+
+  function decode(t) {
+    try {
+      const p = t.split(".")[1].replace(/-/g, "+").replace(/_/g, "/");
+      return JSON.parse(atob(p));
+    } catch { return {}; }
+  }
+
+  async function mint() {
+    const r = await fetch(API + "/auth/widget-token", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}"
+    });
+    const j = await r.json();
+    if (!r.ok || !j.token) throw new Error("mint_failed");
+    return j.token;
+  }
+
+  async function refresh(old) {
+    const r = await fetch(API + "/auth/widget-refresh", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: old })
+    });
+    const j = await r.json();
+    if (!r.ok || !j.token) throw new Error("refresh_failed");
+    return j.token;
+  }
+
+  function schedule(t) {
+    const { exp } = decode(t), now = Math.floor(Date.now() / 1000);
+    const secs = (exp || 0) - now, wait = Math.max(secs - 120, 15) * 1000;
+    clearTimeout(timer);
+    timer = setTimeout(async () => {
+      try { token = await refresh(token); schedule(token); }
+      catch { token = await mint(); schedule(token); }
+    }, wait);
+  }
+
+  async function ensureToken() {
+    if (!token) { token = await mint(); schedule(token); }
+    return token;
+  }
+
+  async function apiFetch(url, init) {
+    const t = await ensureToken();
+    const opts = Object.assign({}, init || {}, {
+      headers: Object.assign({}, (init && init.headers) || {}, { "Authorization": "Bearer " + t })
+    });
+    return fetch(url, opts);
+  }
+
+  window.chatbocAuth = { ensureToken, apiFetch };
+})();
+

--- a/cdn/widget/v1.js
+++ b/cdn/widget/v1.js
@@ -37,8 +37,17 @@
     const secs = (exp || 0) - now, wait = Math.max(secs - 120, 15) * 1000;
     clearTimeout(timer);
     timer = setTimeout(async () => {
-      try { token = await refresh(token); schedule(token); }
-      catch { token = await mint(); schedule(token); }
+      try {
+        token = await refresh(token);
+      } catch {
+        try {
+          token = await mint();
+        } catch {
+          schedule(token);
+          return;
+        }
+      }
+      schedule(token);
     }, wait);
   }
 


### PR DESCRIPTION
## Summary
- provide client-side widget script that mints and refreshes auth tokens
- remove backend auth routes from the frontend repo

## Testing
- `npm test` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be1626e7748322943533cb58142a9e