### PR TITLE
Use primary theme color for typing indicators

### DIFF
--- a/src/components/chat/TypingIndicator.tsx
+++ b/src/components/chat/TypingIndicator.tsx
@@ -6,7 +6,7 @@ const LOGO_BOT = "/favicon/favicon-512x512.png";
 const TypingIndicator: React.FC = () => (
   <div className="flex items-end gap-2.5 justify-start">
     {/* Avatar del bot, bien integrado */}
-    <div className="flex-shrink-0 w-10 h-10 rounded-full bg-card flex items-center justify-center border border-blue-100 dark:border-blue-800 shadow">
+    <div className="flex-shrink-0 w-10 h-10 rounded-full bg-card flex items-center justify-center border border-primary/20 dark:border-primary/40 shadow">
       <img
         src={LOGO_BOT}
         alt="Chatboc"

--- a/src/components/chat/UserTypingIndicator.tsx
+++ b/src/components/chat/UserTypingIndicator.tsx
@@ -5,7 +5,7 @@ import UserAvatarAnimated from "./UserAvatarAnimated";
 const UserTypingIndicator: React.FC = () => (
   <div className="flex items-end gap-2.5 justify-end">
     <motion.div
-      className="flex-shrink-0 w-9 h-9 rounded-full bg-secondary flex items-center justify-center border border-blue-300 shadow"
+      className="flex-shrink-0 w-9 h-9 rounded-full bg-secondary flex items-center justify-center border border-primary/40 shadow"
       initial={{ scale: 0.8, opacity: 0 }}
       animate={{ scale: 1, opacity: 1 }}
       transition={{ type: "spring", stiffness: 200, damping: 20 }}
@@ -13,7 +13,7 @@ const UserTypingIndicator: React.FC = () => (
       <UserAvatarAnimated size={20} talking />
     </motion.div>
     <motion.div
-      className="px-4 py-3 max-w-[320px] shadow-md relative bg-gradient-to-tr from-blue-500 to-blue-700 text-white rounded-b-2xl rounded-tl-2xl after:content-[''] after:absolute after:bottom-0 after:right-[-8px] after:w-0 after:h-0 after:border-8 after:border-transparent after:border-t-blue-700 after:border-l-blue-700"
+      className="px-4 py-3 max-w-[320px] shadow-md relative bg-primary text-primary-foreground rounded-b-2xl rounded-tl-2xl after:content-[''] after:absolute after:bottom-0 after:right-[-8px] after:w-0 after:h-0 after:border-8 after:border-transparent after:border-t-primary after:border-l-primary"
       initial={{ opacity: 0, y: 10, scale: 0.98 }}
       animate={{ opacity: 1, y: 0, scale: 1 }}
       transition={{ duration: 0.3, ease: "easeOut" }}


### PR DESCRIPTION
## Summary
- align bot typing indicator avatar border with theme primary color
- style user typing indicator using primary/foreground colors instead of hard-coded blues

## Testing
- `npm install` *(fails: 403 Forbidden retrieving mammoth)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bec0b2ada883228678bb2ad1da8c32