### PR TITLE
Add dyslexia accessibility options to chat widget

### DIFF
--- a/src/components/chat/AccessibilityToggle.tsx
+++ b/src/components/chat/AccessibilityToggle.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from "react";
+
+export type Prefs = {
+  dyslexia: boolean;
+  simplified: boolean;
+};
+
+const LS_KEY = "chatboc_accessibility";
+
+export default function AccessibilityToggle({
+  onChange,
+}: {
+  onChange?: (p: Prefs) => void;
+}) {
+  const [prefs, setPrefs] = useState<Prefs>(() => {
+    try {
+      return (
+        JSON.parse(localStorage.getItem(LS_KEY) || "") || {
+          dyslexia: false,
+          simplified: true,
+        }
+      );
+    } catch {
+      return { dyslexia: false, simplified: true };
+    }
+  });
+
+  useEffect(() => {
+    localStorage.setItem(LS_KEY, JSON.stringify(prefs));
+    onChange?.(prefs);
+    const root = document.documentElement;
+    root.classList.toggle("a11y-dyslexia", !!prefs.dyslexia);
+    root.classList.toggle("a11y-simplified", !!prefs.simplified);
+  }, [prefs, onChange]);
+
+  return (
+    <div className="flex items-center gap-1">
+      <button
+        className={`px-2 py-1 rounded text-xs border ${
+          prefs.dyslexia ? "bg-amber-100" : "bg-white"
+        }`}
+        onClick={() => setPrefs((p) => ({ ...p, dyslexia: !p.dyslexia }))}
+        aria-pressed={prefs.dyslexia}
+        title="Modo Dislexia"
+      >
+        Dislexia
+      </button>
+      <button
+        className={`px-2 py-1 rounded text-xs border ${
+          prefs.simplified ? "bg-amber-100" : "bg-white"
+        }`}
+        onClick={() => setPrefs((p) => ({ ...p, simplified: !p.simplified }))}
+        aria-pressed={prefs.simplified}
+        title="Texto simplificado"
+      >
+        Simple
+      </button>
+    </div>
+  );
+}
+

--- a/src/components/chat/ChatHeader.tsx
+++ b/src/components/chat/ChatHeader.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { X, User, ChevronLeft, Volume2, VolumeX, ShoppingCart } from "lucide-react";
 import ChatbocLogoAnimated from "./ChatbocLogoAnimated";
+import AccessibilityToggle, { Prefs } from "./AccessibilityToggle";
 
 interface Props {
   onClose: () => void;
@@ -15,6 +16,7 @@ interface Props {
   title?: string;
   subtitle?: string;
   logoAnimation?: string;
+  onA11yChange?: (p: Prefs) => void;
 }
 
 const ChatHeader: React.FC<Props> = ({
@@ -30,6 +32,7 @@ const ChatHeader: React.FC<Props> = ({
   title,
   subtitle,
   logoAnimation,
+  onA11yChange,
 }) => {
   return (
     <div
@@ -70,6 +73,7 @@ const ChatHeader: React.FC<Props> = ({
         </div>
       </div>
       <div className="flex items-center gap-1 sm:gap-2"> {/* Reduced gap for mobile */}
+        <AccessibilityToggle onChange={onA11yChange} />
         <span
           className="text-primary-foreground text-xs font-semibold flex items-center"
           aria-label="Estado del bot: Online"

--- a/src/components/chat/ChatMessageBase.tsx
+++ b/src/components/chat/ChatMessageBase.tsx
@@ -1,5 +1,5 @@
 // src/components/chat/ChatMessageBase.tsx
-import React from "react";
+import React, { useState, useMemo } from "react";
 import { Message, SendPayload, StructuredContentItem } from "@/types/chat";
 import ChatButtons from "./ChatButtons";
 import CategorizedButtons from "./CategorizedButtons";
@@ -7,6 +7,7 @@ import AudioPlayer from "./AudioPlayer";
 import { motion } from "framer-motion";
 import ChatbocLogoAnimated from "./ChatbocLogoAnimated";
 import sanitizeMessageHtml from "@/utils/sanitizeMessageHtml";
+import { simplify } from "@/lib/simplify";
 import AttachmentPreview from "./AttachmentPreview";
 import { deriveAttachmentInfo, AttachmentInfo } from "@/utils/attachment";
 import MessageBubble from "./MessageBubble";
@@ -188,6 +189,42 @@ const ChatMessageBase = React.forwardRef<HTMLDivElement, ChatMessageBaseProps>( 
 
   const safeText = typeof message.text === "string" && message.text !== "NaN" ? message.text : "";
   const sanitizedHtml = sanitizeMessageHtml(safeText);
+  const plainText = useMemo(() => safeText.replace(/<[^>]+>/g, ""), [safeText]);
+  const simplified = useMemo(() => simplify(plainText), [plainText]);
+  const [simple, setSimple] = useState<boolean>(() => {
+    try {
+      const p = JSON.parse(localStorage.getItem("chatboc_accessibility") || "{}");
+      return !!p?.simplified;
+    } catch {
+      return true;
+    }
+  });
+
+  const renderText = simple ? (
+    <pre className="whitespace-pre-wrap text-justify max-w-none text-sm mb-2 chat-message">{simplified}</pre>
+  ) : (
+    <div
+      className="whitespace-pre-wrap text-justify max-w-none text-sm [&_p]:my-0 mb-2 chat-message"
+      dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
+    />
+  );
+
+  const textBlock = sanitizedHtml
+    ? isBot
+      ? (
+          <>
+            {renderText}
+            <div className="mt-1 text-[12px] flex gap-2">
+              <button className="underline" onClick={() => setSimple((s) => !s)}>
+                {simple ? "Ver completo" : "Ver simple"}
+              </button>
+            </div>
+          </>
+        )
+      : (
+          renderText
+        )
+    : null;
 
   let processedAttachmentInfo: AttachmentInfo | null = null;
 
@@ -266,12 +303,7 @@ const ChatMessageBase = React.forwardRef<HTMLDivElement, ChatMessageBaseProps>( 
           )}
 
           {/* Prioridad al texto si no hay otros contenidos especiales */}
-          {(!showAttachmentOrMap && !showStructuredContent && sanitizedHtml) && (
-            <div
-              className="whitespace-pre-wrap text-justify max-w-none text-sm [&_p]:my-0 mb-2"
-              dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
-            />
-          )}
+          {!showAttachmentOrMap && !showStructuredContent && textBlock}
 
           {/* Mostrar adjunto o mapa */}
           {showAttachmentOrMap && (
@@ -287,12 +319,7 @@ const ChatMessageBase = React.forwardRef<HTMLDivElement, ChatMessageBaseProps>( 
           {showStructuredContent && (
             <>
               {/* Si hay texto Y contenido estructurado, el texto puede ser una introducción */}
-              {sanitizedHtml && !showAttachmentOrMap && (
-                 <div
-                    className="whitespace-pre-wrap text-justify max-w-none text-sm [&_p]:my-0 mb-2"
-                    dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
-                />
-              )}
+              {sanitizedHtml && !showAttachmentOrMap && textBlock}
               <StructuredContentDisplay items={message.structuredContent!} />
             </>
           )}

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect, useCallback } from "react";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
 import ChatHeader from "./ChatHeader";
+import type { Prefs } from "./AccessibilityToggle";
 import ChatMessage from "./ChatMessage";
 import TypingIndicator from "./TypingIndicator";
 import UserTypingIndicator from "./UserTypingIndicator";
@@ -64,6 +65,8 @@ interface ChatPanelProps {
   welcomeTitle?: string;
   welcomeSubtitle?: string;
   logoAnimation?: string;
+  onA11yChange?: (p: Prefs) => void;
+  a11yPrefs?: Prefs;
 }
 
 const ChatPanel = ({
@@ -84,6 +87,8 @@ const ChatPanel = ({
   welcomeTitle,
   welcomeSubtitle,
   logoAnimation,
+  onA11yChange,
+  a11yPrefs,
 }: ChatPanelProps) => {
   const isMobile = useIsMobile();
   const chatContainerRef = useRef<HTMLDivElement>(null);
@@ -270,7 +275,7 @@ const ChatPanel = ({
   }, []);
 
   return (
-    <div className={cn("flex flex-col w-full h-full bg-card text-card-foreground overflow-hidden relative", isMobile ? undefined : "rounded-[inherit]")}> 
+    <div className={cn("chat-root flex flex-col w-full h-full bg-card text-card-foreground overflow-hidden relative", isMobile ? undefined : "rounded-[inherit]")}> 
       <ChatHeader
         onClose={onClose}
         onProfile={onOpenUserPanel}
@@ -281,11 +286,12 @@ const ChatPanel = ({
         title={welcomeTitle}
         subtitle={welcomeSubtitle}
         logoAnimation={logoAnimation}
+        onA11yChange={onA11yChange}
       />
       <div ref={chatContainerRef} className="flex-1 p-2 sm:p-4 min-h-0 flex flex-col gap-3 overflow-y-auto">
-        {messages.map((msg) =>
+        {messages.map((msg) => (
           <ChatMessage
-            key={msg.id}
+            key={`${msg.id}-${a11yPrefs?.simplified ? "s" : "f"}`}
             message={msg}
             isTyping={isTyping}
             onButtonClick={handleSend}
@@ -294,7 +300,7 @@ const ChatPanel = ({
             botLogoUrl={headerLogoUrl}
             logoAnimation={logoAnimation}
           />
-        )}
+        ))}
         {isTyping && <TypingIndicator />}
         {userTyping && <UserTypingIndicator />}
         <div ref={messagesEndRef} />

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -15,6 +15,8 @@ import ChatUserPanel from "./ChatUserPanel";
 import ChatHeader from "./ChatHeader";
 import EntityInfoPanel from "./EntityInfoPanel";
 import ChatPanel from "./ChatPanel";
+import ReadingRuler from "./ReadingRuler";
+import type { Prefs } from "./AccessibilityToggle";
 
 interface ChatWidgetProps {
   mode?: "standalone" | "iframe" | "script";
@@ -43,6 +45,8 @@ const PROACTIVE_MESSAGES = [
   "¿Tienes alguna consulta? ¡Pregúntame!",
   "Explora nuestros servicios, ¡te ayudo!",
 ];
+
+const LS_KEY = "chatboc_accessibility";
 
 const ChatWidget: React.FC<ChatWidgetProps> = ({
   mode = "standalone",
@@ -109,6 +113,34 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
   const [proactiveCycle, setProactiveCycle] = useState(0);
   const [selectedRubro, setSelectedRubro] = useState<string | null>(initialRubro || null);
   const [hasSetInitialRubro, setHasSetInitialRubro] = useState(false);
+  const [a11yPrefs, setA11yPrefs] = useState<Prefs>(() => {
+    try {
+      return (
+        JSON.parse(localStorage.getItem(LS_KEY) || "") || {
+          dyslexia: false,
+          simplified: true,
+        }
+      );
+    } catch {
+      return { dyslexia: false, simplified: true };
+    }
+  });
+
+  useEffect(() => {
+    const handleStorage = () => {
+      try {
+        const p = JSON.parse(localStorage.getItem(LS_KEY) || "") || {
+          dyslexia: false,
+          simplified: true,
+        };
+        setA11yPrefs(p);
+      } catch {
+        /* ignore */
+      }
+    };
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, []);
 
   useEffect(() => {
     if (initialRubro && !hasSetInitialRubro) {
@@ -177,7 +209,7 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
   const closedWidthPx = parseInt(finalClosedWidth.replace('px', ''), 10);
   const calculatedLogoSize = Math.floor(closedWidthPx * logoSizeFactor);
 
-  const commonPanelStyles = cn("bg-card border shadow-lg", "flex flex-col overflow-hidden");
+  const commonPanelStyles = cn("chat-root bg-card border shadow-lg", "flex flex-col overflow-hidden");
   const commonButtonStyles = cn(
     "rounded-full flex items-center justify-center",
     "bg-primary text-primary-foreground hover:bg-primary/90",
@@ -434,6 +466,7 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
         )}
         style={containerStyle}
       >
+        {isOpen && a11yPrefs.dyslexia && <ReadingRuler />}
         {isProfileLoading ? (
           <div className="w-full h-full flex items-center justify-center bg-card rounded-2xl">
             <div className="w-8 h-8 border-4 border-primary border-t-transparent rounded-full animate-spin"></div>
@@ -464,6 +497,7 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
                   title={welcomeTitle}
                   subtitle={welcomeSubtitle}
                   logoAnimation={logoAnimation}
+                  onA11yChange={setA11yPrefs}
                 />
               )}
               {view === "register" ? <ChatUserRegisterPanel onSuccess={() => setView("chat")} onShowLogin={() => setView("login")} entityToken={ownerToken} />
@@ -491,6 +525,8 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
                     welcomeTitle={welcomeTitle}
                     welcomeSubtitle={welcomeSubtitle}
                     logoAnimation={logoAnimation}
+                    onA11yChange={setA11yPrefs}
+                    a11yPrefs={a11yPrefs}
                   />}
             </motion.div>
           ) : (

--- a/src/components/chat/ReadingRuler.tsx
+++ b/src/components/chat/ReadingRuler.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+
+export default function ReadingRuler() {
+  const [y, setY] = useState(0);
+
+  useEffect(() => {
+    const h = (e: MouseEvent) => setY(e.clientY);
+    window.addEventListener("mousemove", h);
+    return () => window.removeEventListener("mousemove", h);
+  }, []);
+
+  return (
+    <div
+      aria-hidden
+      className="pointer-events-none fixed left-0 right-0"
+      style={{ top: y - 18, height: 36, boxShadow: "0 0 0 9999px rgba(0,0,0,0.12)", transition: "top 60ms" }}
+    />
+  );
+}
+

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Lexend&display=swap');
 
 @tailwind base;
 @tailwind components;
@@ -189,4 +190,30 @@ body,
   .text-primary-dark {
     color: hsl(var(--primary-dark));
   }
+}
+
+:root.a11y-dyslexia {
+  --chat-font: 'Lexend', system-ui, -apple-system, Segoe UI, Roboto, Arial;
+  --chat-line-height: 1.8;
+  --chat-letter-spacing: 0.0125em;
+  --chat-max-width: 52ch;
+}
+
+:root.a11y-simplified .chat-message p {
+  margin-bottom: 0.65rem;
+}
+
+.chat-root {
+  font-family: var(--chat-font, system-ui);
+}
+
+.chat-message {
+  line-height: var(--chat-line-height, 1.6);
+  letter-spacing: var(--chat-letter-spacing, 0);
+  max-width: var(--chat-max-width, 64ch);
+}
+
+.chat-message strong {
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }

--- a/src/lib/simplify.ts
+++ b/src/lib/simplify.ts
@@ -1,0 +1,9 @@
+export function simplify(text: string): string {
+  const parts = text
+    .split(/(?<=[\.\!\?])\s+/g)
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const chunks = parts.flatMap((p) => (p.length > 140 ? p.split(/,|;|\sy\s/gi) : [p]));
+  return chunks.map((c) => `• ${c.trim()}`).join('\n');
+}
+


### PR DESCRIPTION
## Summary
- store dyslexia/simplified preferences in localStorage and apply root classes
- drop backend accessibility service and rely solely on local data
- show reading ruler when widget open and dyslexia mode active; each bot message has "Ver simple/Ver completo" toggle

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/mammoth)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68beee41cf2083228b87dd38dc1f5355