### PR TITLE
feat: allow camera capture for image attachments

### DIFF
--- a/src/components/ui/AdjuntarArchivo.tsx
+++ b/src/components/ui/AdjuntarArchivo.tsx
@@ -126,6 +126,7 @@ const AdjuntarArchivo = forwardRef<AdjuntarArchivoHandle, AdjuntarArchivoProps>(
         className="hidden"
         onChange={handleFileChange}
         disabled={disabled}
+        capture={allowedFileTypes?.some(type => type.startsWith('image/')) ? 'environment' : undefined}
       />
       {/* El span de error local se ha eliminado. Los errores se muestran mediante toasts. */}
     </div>


### PR DESCRIPTION
## Summary
- enable camera capture in AdjuntarArchivo when accepting images

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c14be84ad883229e15d2729e1a0234