### PR TITLE
Fix ticket subject and Argentina timezone handling

### DIFF
--- a/src/components/chat/ChatMessageMunicipio.tsx
+++ b/src/components/chat/ChatMessageMunicipio.tsx
@@ -14,6 +14,7 @@ import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { useUser } from "@/hooks/useUser";
 import { User as UserIcon } from "lucide-react";
 import { getInitials } from "@/lib/utils";
+import { useDateSettings } from "@/hooks/useDateSettings";
 
 const messageVariants = {
   initial: (isBot: boolean) => ({
@@ -112,6 +113,7 @@ const ChatMessageMunicipio = React.forwardRef<HTMLDivElement, ChatMessageProps>(
 
   const safeText = typeof message.text === "string" && message.text !== "NaN" ? message.text : "";
   const sanitizedHtml = sanitizeMessageHtml(safeText);
+  const { timezone, locale } = useDateSettings();
 
   const bubbleClass = isBot
     ? "bg-muted text-muted-foreground" // Bot's bubble color
@@ -168,8 +170,17 @@ const ChatMessageMunicipio = React.forwardRef<HTMLDivElement, ChatMessageProps>(
             )
           )}
           {message.timestamp && (
-            <div className={`text-xs mt-1.5 ${isBot ? 'text-muted-foreground/80' : 'text-primary-foreground/70'} ${isBot ? 'text-left' : 'text-right'}`}>
-              {new Date(message.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: true })}
+            <div
+              className={`text-xs mt-1.5 ${isBot ? 'text-muted-foreground/80' : 'text-primary-foreground/70'} ${
+                isBot ? 'text-left' : 'text-right'
+              }`}
+            >
+              {new Date(message.timestamp).toLocaleTimeString(locale, {
+                hour: '2-digit',
+                minute: '2-digit',
+                hour12: true,
+                timeZone: timezone,
+              })}
             </div>
           )}
           {isBot && message.botones && message.botones.length > 0 && (

--- a/src/components/chat/ChatMessagePyme.tsx
+++ b/src/components/chat/ChatMessagePyme.tsx
@@ -14,6 +14,7 @@ import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { useUser } from "@/hooks/useUser";
 import { User as UserIcon } from "lucide-react";
 import { getInitials } from "@/lib/utils"; // Importar getInitials
+import { useDateSettings } from "@/hooks/useDateSettings";
 
 const messageVariants = {
   initial: (isBot: boolean) => ({
@@ -116,6 +117,7 @@ const ChatMessagePyme = React.forwardRef<HTMLDivElement, ChatMessageProps>( (
 
   const safeText = typeof message.text === "string" && message.text !== "NaN" ? message.text : "";
   const sanitizedHtml = sanitizeMessageHtml(safeText);
+  const { timezone, locale } = useDateSettings();
 
   let processedAttachmentInfo: AttachmentInfo | null = null;
 
@@ -175,7 +177,7 @@ const ChatMessagePyme = React.forwardRef<HTMLDivElement, ChatMessageProps>( (
           )}
           {message.timestamp && (
             <div className={`text-xs mt-1.5 ${isBot ? 'text-muted-foreground/80' : 'text-primary-foreground/70'} ${isBot ? 'text-left' : 'text-right'}`}>
-              {new Date(message.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: true })}
+              {new Date(message.timestamp).toLocaleTimeString(locale, { hour: '2-digit', minute: '2-digit', hour12: true, timeZone: timezone })}
             </div>
           )}
           {isBot && message.botones && message.botones.length > 0 && (

--- a/src/components/tickets/TicketListItem.tsx
+++ b/src/components/tickets/TicketListItem.tsx
@@ -4,6 +4,7 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
 import { FaWhatsapp } from 'react-icons/fa';
+import { useDateSettings } from '@/hooks/useDateSettings';
 
 interface TicketListItemProps {
   ticket: Ticket;
@@ -15,6 +16,16 @@ const TicketListItem: React.FC<TicketListItemProps> = ({ ticket, isSelected, onC
 const getInitials = (name: string) => {
     return name ? name.split(' ').map(n => n[0]).join('').toUpperCase() : '??';
   };
+
+  const { timezone, locale } = useDateSettings();
+  const formattedTime = new Date(ticket.fecha).toLocaleTimeString(locale, {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+    timeZone: timezone,
+  });
+
+  const subject = ticket.categoria || ticket.asunto || 'Sin asunto';
 
   return (
     <div
@@ -43,24 +54,23 @@ const getInitials = (name: string) => {
         </div>
         <div className="flex items-center gap-2">
           {ticket.channel === 'whatsapp' && <FaWhatsapp className="h-4 w-4 text-green-500" />}
-          <span className="text-xs text-muted-foreground">
-            {new Date(ticket.fecha).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
-          </span>
+          <span className="text-xs text-muted-foreground">{formattedTime}</span>
         </div>
       </div>
-      <p className="font-semibold text-sm ml-13 mb-2">{ticket.asunto || 'Sin asunto'}</p>
+      <p className="font-semibold text-sm ml-13 mb-2">{subject}</p>
       <p className="text-sm text-muted-foreground truncate ml-13">{ticket.lastMessage || '...'}</p>
       <div className="flex items-center justify-between mt-2 ml-13">
-         <Badge variant={ticket.estado === 'nuevo' ? 'default' : 'outline'}
-               className={cn(
-                'capitalize',
-                ticket.estado === 'nuevo' && 'bg-blue-500 text-white',
-                ticket.estado === 'abierto' && 'text-green-500 border-green-500',
-                ticket.estado === 'en_proceso' && 'text-yellow-500 border-yellow-500',
-               )}>
+         <Badge
+           variant={ticket.estado === 'nuevo' ? 'default' : 'outline'}
+           className={cn(
+             'capitalize',
+             ticket.estado === 'nuevo' && 'bg-blue-500 text-white',
+             ticket.estado === 'abierto' && 'text-green-500 border-green-500',
+             ticket.estado === 'en_proceso' && 'text-yellow-500 border-yellow-500',
+           )}
+         >
           {ticket.estado}
         </Badge>
-        {ticket.categoria && <p className="text-xs font-bold text-muted-foreground">{ticket.categoria}</p>}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- show ticket category instead of "Reclamo:" prefix
- format times using America/Argentina/Buenos_Aires timezone

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden for mammoth)*

------
https://chatgpt.com/codex/tasks/task_e_68c17e889d8c832283db71a8badb624a