### PR TITLE
feat(map-ux): unify profile map and add animations

### DIFF
--- a/src/components/MapLibreMap.tsx
+++ b/src/components/MapLibreMap.tsx
@@ -10,6 +10,7 @@ type Props = {
   onSelect?: (lat: number, lon: number, address?: string) => void;
   heatmapData?: HeatPoint[];
   showHeatmap?: boolean;
+  marker?: [number, number];
   className?: string;
 };
 
@@ -26,11 +27,13 @@ export default function MapLibreMap({
   onSelect,
   heatmapData = [],
   showHeatmap = true,
+  marker,
   className,
 }: Props) {
   const mapContainerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<Map | null>(null);
   const libRef = useRef<any>(null);
+  const markerRef = useRef<any>(null);
   const apiKey = import.meta.env.VITE_MAPTILER_KEY;
 
   // Effect for map initialization and cleanup
@@ -211,6 +214,42 @@ export default function MapLibreMap({
     map.setLayoutProperty("tickets-heat", "visibility", showHeatmap ? "visible" : "none");
     map.setLayoutProperty("tickets-circles", "visibility", showHeatmap ? "none" : "visible");
   }, [showHeatmap]);
+
+  // Effect for pulsing heatmap intensity
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !showHeatmap) return;
+    let frame: number;
+    const animate = () => {
+      const t = (Date.now() % 2000) / 2000;
+      const intensity = 1 + 0.5 * Math.sin(t * Math.PI * 2);
+      map.setPaintProperty("tickets-heat", "heatmap-intensity", intensity);
+      frame = requestAnimationFrame(animate);
+    };
+    animate();
+    return () => cancelAnimationFrame(frame);
+  }, [showHeatmap]);
+
+  // Effect for adding/updating municipality marker
+  useEffect(() => {
+    const map = mapRef.current;
+    const maplibre = libRef.current;
+    if (!map) return;
+    if (marker) {
+      if (markerRef.current) {
+        markerRef.current.setLngLat(marker);
+      } else if (maplibre) {
+        const el = document.createElement("div");
+        el.className = "pulse-marker";
+        markerRef.current = new maplibre.Marker({ element: el })
+          .setLngLat(marker)
+          .addTo(map);
+      }
+    } else if (markerRef.current) {
+      markerRef.current.remove();
+      markerRef.current = null;
+    }
+  }, [marker]);
 
   return (
     <div

--- a/src/index.css
+++ b/src/index.css
@@ -15,6 +15,15 @@
   .chat-container {
     @apply flex flex-col gap-4 p-4;
   }
+  .pulse-marker {
+    @apply w-4 h-4 rounded-full bg-blue-500 relative;
+  }
+  .pulse-marker::after {
+    content: "";
+    @apply absolute inset-0 rounded-full bg-blue-500 opacity-50;
+    animation: pulse 2s infinite;
+    transform-origin: center;
+  }
 }
 
 @layer base {
@@ -117,6 +126,20 @@
   html {
     scroll-behavior: smooth;
   }
+
+@keyframes pulse {
+  0% {
+    transform: scale(1);
+    opacity: 0.6;
+  }
+  70% {
+    transform: scale(2);
+    opacity: 0;
+  }
+  100% {
+    opacity: 0;
+  }
+}
   * {
     @apply border-border;
   }

--- a/src/pages/IncidentsMap.tsx
+++ b/src/pages/IncidentsMap.tsx
@@ -240,6 +240,7 @@ export default function IncidentsMap() {
       <div className="relative mb-6 border border-border rounded-lg shadow bg-muted/20 dark:bg-slate-800/30">
         <MapLibreMap
           center={center ? [center.lng, center.lat] : undefined}
+          marker={center ? [center.lng, center.lat] : undefined}
           heatmapData={heatmapData}
           showHeatmap={showHeatmap}
           className="h-[600px]"

--- a/src/pages/Perfil.tsx
+++ b/src/pages/Perfil.tsx
@@ -59,7 +59,6 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { toast } from "@/components/ui/use-toast";
 import { cn } from "@/lib/utils";
 import MapLibreMap from "@/components/MapLibreMap";
-import LocationMap from "@/components/LocationMap";
 import TicketStatsCharts from "@/components/TicketStatsCharts";
 import { useNavigate } from "react-router-dom";
 import QuickLinksCard from "@/components/QuickLinksCard";
@@ -296,6 +295,11 @@ export default function Perfil() {
   const [heatmapData, setHeatmapData] = useState<HeatPoint[]>([]);
   const [mapCenter, setMapCenter] = useState<{ lat: number; lng: number } | null>(null);
   const [charts, setCharts] = useState<TicketStatsResponse['charts']>([]);
+
+  const municipalityCoords =
+    perfil.latitud !== null && perfil.longitud !== null
+      ? [perfil.longitud, perfil.latitud] as [number, number]
+      : undefined;
 
   // --- Estados para el nuevo modal de carga de catálogo ---
   const [isMappingModalOpen, setIsMappingModalOpen] = useState(false);
@@ -912,20 +916,6 @@ export default function Perfil() {
                   </div>
                 </div>
 
-                {/* Ubicación en el Mapa - Integrado en la tarjeta de Datos */}
-                {(perfil.direccion || (perfil.latitud !== null && perfil.longitud !== null)) && (
-                  <div className="mt-4 flex flex-col flex-grow"> {/* Add margin top, flex-grow and flex-col */}
-                    <Label className="text-muted-foreground text-sm mb-1 block">
-                      Ubicación en el Mapa
-                    </Label>
-                    <LocationMap
-                      lat={perfil.latitud ?? undefined}
-                      lng={perfil.longitud ?? undefined}
-                      onSelect={handleMapSelect}
-                      className="h-[400px]"
-                    />
-                  </div>
-                )}
 
                 <div>
                   <Label className="text-muted-foreground text-sm block mb-2">
@@ -1055,7 +1045,7 @@ export default function Perfil() {
               </form>
             </CardContent>
           </Card>
-          {ticketLocations.length > 0 && (
+          {(ticketLocations.length > 0 || municipalityCoords) && (
             <Card className="bg-card shadow-xl rounded-xl border border-border backdrop-blur-sm">
               <CardHeader>
                 <CardTitle className="text-xl font-semibold text-primary">
@@ -1147,10 +1137,12 @@ export default function Perfil() {
                     </div>
                   </div>
                 )}
-                {heatmapData.length > 0 ? (
+                {heatmapData.length > 0 || municipalityCoords ? (
                   <MapLibreMap
-                    center={mapCenter ? [mapCenter.lng, mapCenter.lat] : undefined}
+                    center={mapCenter ? [mapCenter.lng, mapCenter.lat] : municipalityCoords}
                     heatmapData={heatmapData}
+                    marker={mapCenter ? [mapCenter.lng, mapCenter.lat] : municipalityCoords}
+                    onSelect={handleMapSelect}
                     className="h-[600px]"
                   />
                 ) : (


### PR DESCRIPTION
## Summary
- show municipality location marker within heatmap
- remove redundant profile map section
- animate map heatmap and add pulsing admin marker
- fix marker reference in reusable map component

## Testing
- `npm test` (fails: Syntax error in address autocomplete test, unresolved imports for server modules, assertion mismatch in agenda parser test)


------
https://chatgpt.com/codex/tasks/task_e_68c58056b9e4832284c85822a2ac2986