### PR TITLE
feat: add gender and age filters

### DIFF
--- a/municipalAnalytics.js
+++ b/municipalAnalytics.js
@@ -1,17 +1,41 @@
 const { getTickets } = require('./db');
 
+function getAgeRange(age) {
+  if (age < 18) return '0-17';
+  if (age < 30) return '18-29';
+  if (age < 50) return '30-49';
+  return '50+';
+}
+
 function getMunicipalAnalytics() {
   const tickets = getTickets();
   const statsMap = new Map();
+  const genderTotals = {};
+  const ageTotals = {};
   for (const t of tickets) {
     const key = t.municipality;
     if (!statsMap.has(key)) {
-      statsMap.set(key, { total: 0, categories: {}, totalResponseMs: 0 });
+      statsMap.set(key, {
+        total: 0,
+        categories: {},
+        totalResponseMs: 0,
+        gender: {},
+        ages: {},
+      });
     }
     const s = statsMap.get(key);
     s.total += 1;
     s.categories[t.category] = (s.categories[t.category] || 0) + 1;
     s.totalResponseMs += t.responseMs || 0;
+    if (t.gender) {
+      s.gender[t.gender] = (s.gender[t.gender] || 0) + 1;
+      genderTotals[t.gender] = (genderTotals[t.gender] || 0) + 1;
+    }
+    if (typeof t.age === 'number') {
+      const range = getAgeRange(t.age);
+      s.ages[range] = (s.ages[range] || 0) + 1;
+      ageTotals[range] = (ageTotals[range] || 0) + 1;
+    }
   }
   const result = [];
   for (const [name, s] of statsMap.entries()) {
@@ -21,9 +45,11 @@ function getMunicipalAnalytics() {
       totalTickets: s.total,
       categories: s.categories,
       averageResponseHours: +(avgMs / 3600000).toFixed(2),
+      gender: s.gender,
+      ageRanges: s.ages,
     });
   }
-  return { municipalities: result };
+  return { municipalities: result, genderTotals, ageRanges: ageTotals };
 }
 
 module.exports = { getMunicipalAnalytics };

--- a/src/pages/IncidentsMap.tsx
+++ b/src/pages/IncidentsMap.tsx
@@ -34,6 +34,9 @@ export default function IncidentsMap() {
   const categoryRef = useRef<HTMLSelectElement>(null);
   const districtRef = useRef<HTMLInputElement>(null);
   const barrioRef = useRef<HTMLSelectElement>(null);
+  const genderRef = useRef<HTMLSelectElement>(null);
+  const ageMinRef = useRef<HTMLInputElement>(null);
+  const ageMaxRef = useRef<HTMLInputElement>(null);
 
   const ticketType = 'municipio';
 
@@ -48,6 +51,9 @@ export default function IncidentsMap() {
         categoria: categoryRef.current?.value,
         distrito: districtRef.current?.value,
         barrio: barrioRef.current?.value,
+        genero: genderRef.current?.value,
+        edad_min: ageMinRef.current?.value,
+        edad_max: ageMaxRef.current?.value,
       };
 
       const [heatmapPoints, stats] = await Promise.all([
@@ -210,6 +216,43 @@ export default function IncidentsMap() {
                   ref={districtRef}
                   className="mt-1 block w-full px-3 py-2 bg-input border-border text-foreground rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary sm:text-sm"
                   placeholder="Ej: Centro"
+                />
+              </div>
+              <div>
+                <label htmlFor="gender" className="block text-sm font-medium text-muted-foreground mb-1">
+                  Género
+                </label>
+                <select
+                  id="gender"
+                  ref={genderRef}
+                  className="mt-1 block w-full px-3 py-2 bg-input border-border text-foreground rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary sm:text-sm"
+                >
+                  <option value="">Todos</option>
+                  <option value="F">Femenino</option>
+                  <option value="M">Masculino</option>
+                  <option value="X">Otro</option>
+                </select>
+              </div>
+              <div>
+                <label htmlFor="ageMin" className="block text-sm font-medium text-muted-foreground mb-1">
+                  Edad mínima
+                </label>
+                <input
+                  type="number"
+                  id="ageMin"
+                  ref={ageMinRef}
+                  className="mt-1 block w-full px-3 py-2 bg-input border-border text-foreground rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary sm:text-sm"
+                />
+              </div>
+              <div>
+                <label htmlFor="ageMax" className="block text-sm font-medium text-muted-foreground mb-1">
+                  Edad máxima
+                </label>
+                <input
+                  type="number"
+                  id="ageMax"
+                  ref={ageMaxRef}
+                  className="mt-1 block w-full px-3 py-2 bg-input border-border text-foreground rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary sm:text-sm"
                 />
               </div>
               <div className="sm:col-span-full flex justify-between mt-2">

--- a/src/services/statsService.ts
+++ b/src/services/statsService.ts
@@ -25,6 +25,9 @@ export interface TicketStatsParams {
   fecha_fin?: string;
   categoria?: string;
   distrito?: string;
+  genero?: string;
+  edad_min?: number;
+  edad_max?: number;
 }
 
 export const getTicketStats = async (
@@ -33,7 +36,7 @@ export const getTicketStats = async (
   try {
     const qs = new URLSearchParams();
     Object.entries(params || {}).forEach(([k, v]) => {
-      if (v) qs.append(k, String(v));
+      if (v !== undefined && v !== null && String(v) !== '') qs.append(k, String(v));
     });
     const query = qs.toString();
     const resp = await apiFetch<TicketStatsResponse>(
@@ -74,6 +77,9 @@ export interface HeatmapParams {
   categoria?: string;
   estado?: string;
   distrito?: string;
+  genero?: string;
+  edad_min?: number;
+  edad_max?: number;
 }
 
 export const getHeatmapPoints = async (


### PR DESCRIPTION
## Summary
- extend stats services to accept gender and age range filters
- add gender and age inputs to incidents map filters
- show gender and age analytics in municipal dashboard

## Testing
- `npm test` *(fails: Failed to resolve import "../server/cart.cjs" and others)*

------
https://chatgpt.com/codex/tasks/task_e_68c58bc57ff88322ae4cd618a536b874