### PR TITLE
Enable mobile ticket details

### DIFF
--- a/src/components/TicketMap.tsx
+++ b/src/components/TicketMap.tsx
@@ -20,6 +20,7 @@ export interface TicketLocation {
   municipio_longitud?: number | null;
   tiempo_estimado?: string | null;
   eta?: string | null;
+  estado?: string | null;
 }
 
 export const buildFullAddress = (ticket: TicketLocation) => {
@@ -78,7 +79,12 @@ const TicketMap: React.FC<{ ticket: TicketLocation }> = ({ ticket }) => {
     typeof originLon === 'number' &&
     (originLat !== 0 || originLon !== 0);
   const hasRoute = hasCoords && hasOrigin;
-  const eta = ticket.tiempo_estimado || ticket.eta;
+  const eta =
+    ticket.tiempo_estimado ||
+    ticket.eta ||
+    (ticket.estado && ticket.estado.toLowerCase().includes('proceso')
+      ? '4h'
+      : undefined);
 
   // -------- MapLibre dynamic map for active routes ---------
   const mapContainer = useRef<HTMLDivElement>(null);
@@ -123,7 +129,13 @@ const TicketMap: React.FC<{ ticket: TicketLocation }> = ({ ticket }) => {
           source: 'route',
           paint: { 'line-color': '#2563eb', 'line-width': 4 },
         });
-        markerRef.current = new maplibre.Marker().setLngLat([originLon as number, originLat as number]).addTo(map);
+        const el = document.createElement('div');
+        el.textContent = '🚚';
+        el.style.fontSize = '24px';
+        el.style.lineHeight = '24px';
+        markerRef.current = new maplibre.Marker({ element: el, anchor: 'center' })
+          .setLngLat([originLon as number, originLat as number])
+          .addTo(map);
         routeRef.current = [[originLon as number, originLat as number]];
       });
     })();

--- a/src/components/tickets/ConversationPanel.tsx
+++ b/src/components/tickets/ConversationPanel.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { Send, PanelLeft, MessageSquare, PanelLeftClose, MessageCircle, Mic, MicOff, X, FileText, ChevronDown } from 'lucide-react';
+import { Send, PanelLeft, MessageSquare, PanelLeftClose, MessageCircle, Mic, MicOff, X, FileText, ChevronDown, Info } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Ticket, TicketStatus, Message as TicketMessage } from '@/types/tickets';
 import { Message as ChatMessageData, SendPayload, AttachmentInfo } from '@/types/chat';
@@ -263,6 +263,11 @@ const ConversationPanel: React.FC<ConversationPanelProps> = ({ isMobile, isSideb
           </div>
         </div>
         <div className="flex items-center space-x-2">
+          {isMobile && (
+            <Button variant="ghost" size="icon" onClick={onToggleDetails} aria-label="Ver detalles">
+              <Info className="h-5 w-5" />
+            </Button>
+          )}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button variant="outline" size="sm" className="capitalize" aria-label="Cambiar estado">

--- a/src/components/tickets/DetailsPanel.tsx
+++ b/src/components/tickets/DetailsPanel.tsx
@@ -3,7 +3,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Mail, MapPin, Ticket as TicketIcon, Info, FileDown, User, ExternalLink, MessageCircle, Building, Hash, Copy, ChevronDown, ChevronUp, UserCheck, Bot } from 'lucide-react';
+import { Mail, MapPin, Ticket as TicketIcon, Info, FileDown, User, ExternalLink, MessageCircle, Building, Hash, Copy, ChevronDown, ChevronUp, UserCheck, Bot, ChevronLeft } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { motion } from 'framer-motion';
 import TicketMap, { buildFullAddress } from '../TicketMap';
@@ -11,6 +11,7 @@ import TicketTimeline from './TicketTimeline';
 import TicketStatusBar from './TicketStatusBar';
 import TicketAttachments from './TicketAttachments';
 import { useTickets } from '@/context/TicketContext';
+import { useIsMobile } from '@/hooks/use-mobile';
 import { exportToPdf, exportToXlsx } from '@/services/exportService';
 import { sendTicketHistory, getTicketById, getTicketMessages } from '@/services/ticketService';
 import { Ticket, Message, TicketHistoryEvent } from '@/types/tickets';
@@ -29,8 +30,13 @@ import { fmtAR } from '@/utils/date';
 import { getSpecializedContact, SpecializedContact } from '@/utils/contacts';
 
 
-const DetailsPanel: React.FC = () => {
+interface DetailsPanelProps {
+  onClose?: () => void;
+}
+
+const DetailsPanel: React.FC<DetailsPanelProps> = ({ onClose }) => {
   const { selectedTicket: ticket } = useTickets();
+  const isMobile = useIsMobile();
   const [isSendingEmail, setIsSendingEmail] = React.useState(false);
   const [timelineHistory, setTimelineHistory] = React.useState<TicketHistoryEvent[]>([]);
   const [timelineMessages, setTimelineMessages] = React.useState<Message[]>([]);
@@ -79,7 +85,7 @@ const DetailsPanel: React.FC = () => {
 
   if (!ticket) {
     return (
-       <aside className="w-full border-l border-border flex-col h-screen bg-muted/20 shrink-0 hidden lg:flex items-center justify-center p-6">
+       <aside className="w-full lg:w-[420px] border-l border-border flex-col h-screen bg-muted/20 shrink-0 hidden lg:flex items-center justify-center p-6">
          <div className="text-center text-muted-foreground">
             <Info className="h-12 w-12 mx-auto mb-4" />
             <h3 className="font-semibold">Detalles del Ticket</h3>
@@ -201,10 +207,17 @@ const DetailsPanel: React.FC = () => {
         initial={{ opacity: 0.5 }}
         animate={{ opacity: 1 }}
         transition={{ duration: 0.5 }}
-        className="w-full border-l border-border flex flex-col h-screen bg-muted/20 shrink-0"
+        className="w-full lg:w-[420px] border-l border-border flex flex-col h-screen bg-muted/20 shrink-0"
     >
       <header className="p-4 border-b border-border flex items-center justify-between">
-        <h3 className="font-semibold">Detalles del Ticket</h3>
+        <div className="flex items-center gap-2">
+          {isMobile && onClose && (
+            <Button variant="ghost" size="icon" onClick={onClose} aria-label="Volver">
+              <ChevronLeft className="h-5 w-5" />
+            </Button>
+          )}
+          <h3 className="font-semibold">Detalles del Ticket</h3>
+        </div>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button variant="outline" size="sm">
@@ -237,17 +250,18 @@ const DetailsPanel: React.FC = () => {
                 <p className="text-xs text-muted-foreground">Vecino/a</p>
               </div>
             </CardHeader>
-            <CardContent className="p-4 space-y-3 text-sm border-t">
+            <CardContent className="p-4 space-y-3 text-sm border-t text-justify">
               <h4 className="font-semibold mb-2">Información Personal del Vecino</h4>
               <div className="space-y-2">
                 <div className="flex items-center gap-2">
                   <User className="h-4 w-4 text-muted-foreground flex-shrink-0" />
-                  <span className={cn("flex-1", !isSpecified(personal?.nombre) && "text-muted-foreground")}>{personal?.nombre || 'No especificado'}</span>
+                  <span className={cn("flex-1 break-words", !isSpecified(personal?.nombre) && "text-muted-foreground")}>{personal?.nombre || 'No especificado'}</span>
                   {isSpecified(personal?.nombre) && (
                     <Button
                       variant="ghost"
                       size="icon"
                       onClick={() => copyToClipboard(personal?.nombre || '', 'Nombre')}
+                      title="Copiar Nombre"
                     >
                       <Copy className="h-4 w-4" />
                     </Button>
@@ -255,12 +269,13 @@ const DetailsPanel: React.FC = () => {
                 </div>
                 <div className="flex items-center gap-2">
                   <Info className="h-4 w-4 text-muted-foreground flex-shrink-0" />
-                  <span className={cn("flex-1", !isSpecified(personal?.dni) && "text-muted-foreground")}>DNI: {personal?.dni || 'No especificado'}</span>
+                  <span className={cn("flex-1 break-words", !isSpecified(personal?.dni) && "text-muted-foreground")}>DNI: {personal?.dni || 'No especificado'}</span>
                   {isSpecified(personal?.dni) && (
                     <Button
                       variant="ghost"
                       size="icon"
                       onClick={() => copyToClipboard(personal?.dni || '', 'DNI')}
+                      title="Copiar DNI"
                     >
                       <Copy className="h-4 w-4" />
                     </Button>
@@ -283,6 +298,7 @@ const DetailsPanel: React.FC = () => {
                       variant="ghost"
                       size="icon"
                       onClick={() => copyToClipboard(personal?.email || '', 'Email')}
+                      title="Copiar Email"
                     >
                       <Copy className="h-4 w-4" />
                     </Button>
@@ -307,6 +323,7 @@ const DetailsPanel: React.FC = () => {
                       variant="ghost"
                       size="icon"
                       onClick={() => copyToClipboard(personal?.telefono || '', 'Teléfono')}
+                      title="Copiar Teléfono"
                     >
                       <Copy className="h-4 w-4" />
                     </Button>
@@ -314,12 +331,13 @@ const DetailsPanel: React.FC = () => {
                 </div>
                 <div className="flex items-center gap-2">
                   <MapPin className="h-4 w-4 text-muted-foreground flex-shrink-0" />
-                  <span className={cn("flex-1", !isSpecified(personal?.direccion) && "text-muted-foreground")}>{personal?.direccion || 'No especificado'}</span>
+                  <span className={cn("flex-1 break-words", !isSpecified(personal?.direccion) && "text-muted-foreground")}>{personal?.direccion || 'No especificado'}</span>
                   {isSpecified(personal?.direccion) && (
                     <Button
                       variant="ghost"
                       size="icon"
                       onClick={() => copyToClipboard(personal?.direccion || '', 'Dirección')}
+                      title="Copiar Dirección"
                     >
                       <Copy className="h-4 w-4" />
                     </Button>
@@ -341,7 +359,7 @@ const DetailsPanel: React.FC = () => {
               </CardContent>
             )}
 
-            <CardContent className="p-4 space-y-3 text-sm border-t">
+            <CardContent className="p-4 space-y-3 text-sm border-t text-justify">
                 <h4 className="font-semibold mb-2">Detalles del Ticket</h4>
                 <div className="flex justify-between items-center">
                     <span className="text-muted-foreground">ID:</span>
@@ -385,7 +403,7 @@ const DetailsPanel: React.FC = () => {
             ) : null}
 
             {hasLocation && (
-                <CardContent className="p-4 border-t">
+                <CardContent className="p-4 border-t text-justify">
                     <h4 className="font-semibold mb-2 flex items-center justify-between">
                         Ubicación
                         <Button variant="ghost" size="icon" className="h-7 w-7" onClick={openGoogleMaps}>
@@ -402,7 +420,15 @@ const DetailsPanel: React.FC = () => {
                     {ticket.esquinas_cercanas && (
                         <div className="flex items-center gap-2 text-sm text-muted-foreground">
                             <Hash className="h-4 w-4" />
-                            <span>Esquinas: {ticket.esquinas_cercanas}</span>
+                            <span className="flex-1 break-words">Esquinas: {ticket.esquinas_cercanas}</span>
+                            <Button
+                                variant="ghost"
+                                size="icon"
+                                onClick={() => copyToClipboard(ticket.esquinas_cercanas || '', 'Esquinas')}
+                                title="Copiar Esquinas"
+                            >
+                                <Copy className="h-4 w-4" />
+                            </Button>
                         </div>
                     )}
                     <div className="aspect-video rounded-md overflow-hidden mt-2">

--- a/src/components/tickets/NewTicketsPanel.tsx
+++ b/src/components/tickets/NewTicketsPanel.tsx
@@ -111,13 +111,13 @@ const NewTicketsPanel: React.FC = () => {
                     transition={{ type: 'spring', stiffness: 300, damping: 30 }}
                     className="absolute top-0 left-0 h-full w-full z-30 bg-background"
                 >
-                    <DetailsPanel />
+                    <DetailsPanel onClose={toggleDetails} />
                 </motion.div>
             )}
           </AnimatePresence>
         </div>
       ) : (
-        <div className="grid grid-cols-[320px_1fr_320px] h-full w-full">
+        <div className="grid grid-cols-[320px_1fr_380px] h-full w-full">
           <Sidebar />
           <ConversationPanel
             isMobile={false}

--- a/src/pages/TicketLookup.tsx
+++ b/src/pages/TicketLookup.tsx
@@ -34,6 +34,9 @@ export default function TicketLookup() {
     () => estadoChat || ticket?.estado || statusFlow[statusFlow.length - 1] || '',
     [estadoChat, ticket?.estado, statusFlow],
   );
+  const estimatedArrival =
+    ticket?.tiempo_estimado ||
+    (currentStatus.toLowerCase().replace(/\s+/g, '_') === 'en_proceso' ? '4h' : null);
 
   const performSearch = useCallback(async (searchId?: string, searchPin?: string) => {
     const id = (searchId || '').trim();
@@ -162,49 +165,60 @@ export default function TicketLookup() {
       {error && <p className="text-destructive text-sm text-center">{error}</p>}
       {ticket && (
         <div className="border rounded-xl p-4 sm:p-6 space-y-6 bg-card shadow-lg">
-          <div>
+          <div className="space-y-2 text-justify">
             <p className="text-sm text-muted-foreground">Ticket #{ticket.nro_ticket}</p>
-            <h2 className="text-2xl font-semibold">{ticket.asunto}</h2>
+            <h2 className="text-2xl font-semibold break-words">{ticket.asunto}</h2>
             <p className="pt-1"><span className="font-medium">Estado actual:</span> <span className="text-primary font-semibold">{currentStatus}</span></p>
             <TicketStatusBar status={currentStatus} flow={statusFlow} />
             <TicketMap ticket={ticket} />
-            <p className="text-sm text-muted-foreground">
-              Creado el: {fmtAR(ticket.fecha)}
-            </p>
-            <p className="text-sm text-muted-foreground">
-              Canal: <span className="capitalize">{ticket.channel || 'N/A'}</span>
-            </p>
-            {ticket.tiempo_estimado && (
-              <p className="text-sm text-muted-foreground">
-                Tiempo estimado de llegada: {ticket.tiempo_estimado}
-              </p>
-            )}
-            {ticket.categoria && (
-              <p className="text-sm text-muted-foreground">
-                Categoría: {ticket.categoria}
-              </p>
-            )}
+            <dl className="text-sm text-muted-foreground grid grid-cols-[auto_1fr] gap-x-2 gap-y-1">
+              <dt>Creado el:</dt>
+              <dd>{fmtAR(ticket.fecha)}</dd>
+              <dt>Canal:</dt>
+              <dd className="capitalize">{ticket.channel || 'N/A'}</dd>
+              {estimatedArrival && (
+                <>
+                  <dt>Tiempo estimado:</dt>
+                  <dd>{estimatedArrival}</dd>
+                </>
+              )}
+              {ticket.categoria && (
+                <>
+                  <dt>Categoría:</dt>
+                  <dd>{ticket.categoria}</dd>
+                </>
+              )}
+              {ticket.direccion && (
+                <>
+                  <dt>Dirección:</dt>
+                  <dd>{ticket.direccion}</dd>
+                </>
+              )}
+              {ticket.esquinas_cercanas && (
+                <>
+                  <dt>Esquinas:</dt>
+                  <dd className="break-words">{ticket.esquinas_cercanas}</dd>
+                </>
+              )}
+            </dl>
             {(ticket.description || ticket.detalles) && (
-              <p className="text-sm text-muted-foreground mt-1 whitespace-pre-wrap">
+              <p className="text-sm text-muted-foreground mt-1 whitespace-pre-wrap break-words text-justify">
                 {ticket.description || ticket.detalles}
               </p>
             )}
-            {ticket.direccion && (
-              <p className="text-sm text-muted-foreground mt-1">Dirección: {ticket.direccion}</p>
-            )}
             {(getContactPhone(ticket) || ticket.email || ticket.dni || ticket.informacion_personal_vecino) && (
-              <div className="mt-4 text-sm space-y-1">
+              <div className="mt-4 text-sm space-y-1 text-justify">
                 {(ticket.informacion_personal_vecino?.nombre || ticket.display_name) && (
-                  <p>Nombre: {ticket.informacion_personal_vecino?.nombre || ticket.display_name}</p>
+                  <p className="break-words">Nombre: {ticket.informacion_personal_vecino?.nombre || ticket.display_name}</p>
                 )}
                 {getCitizenDni(ticket) && (
-                  <p>DNI: {getCitizenDni(ticket)}</p>
+                  <p className="break-words">DNI: {getCitizenDni(ticket)}</p>
                 )}
                 {(ticket.informacion_personal_vecino?.email || ticket.email) && (
-                  <p>Email: {ticket.informacion_personal_vecino?.email || ticket.email}</p>
+                  <p className="break-words">Email: {ticket.informacion_personal_vecino?.email || ticket.email}</p>
                 )}
                 {getContactPhone(ticket) && (
-                  <p>Teléfono: {getContactPhone(ticket)}</p>
+                  <p className="break-words">Teléfono: {getContactPhone(ticket)}</p>
                 )}
               </div>
             )}


### PR DESCRIPTION
## Summary
- widen desktop ticket details panel and justify long fields for clearer reading
- add truck marker with 4h demo ETA in ticket map and show fallback arrival time in ticket lookup
- lay out ticket lookup info in a justified grid to keep labels and values aligned

## Testing
- `npm test` *(fails: missing server modules and addressAutocomplete syntax error; agendaParser assertion mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68c598830b488322846d1156c88cea78