### PR TITLE
feat: Implement theme-based logos

### DIFF
--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import { useDarkMode } from "@/hooks/useDarkMode";
 import ChatbocLogoAnimated from "./ChatbocLogoAnimated";
 import { getCurrentTipoChat } from "@/utils/tipoChat";
 import { cn } from "@/lib/utils";
@@ -70,6 +71,7 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
 }) => {
   const proactiveMessageTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const hideProactiveBubbleTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const isDarkMode = useDarkMode();
 
   const [isOpen, setIsOpen] = useState(() => {
     if (mode !== 'standalone' && typeof defaultOpen === 'string') {
@@ -495,7 +497,7 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
                   muted={muted}
                   onToggleSound={toggleMuted}
                   onCart={openCart}
-                  logoUrl={headerLogoUrl || customLauncherLogoUrl || entityInfo?.logo_url}
+                  logoUrl={headerLogoUrl || customLauncherLogoUrl || entityInfo?.logo_url || (isDarkMode ? '/chatbocar.png' : '/chatbocar2.png')}
                   title={welcomeTitle}
                   subtitle={welcomeSubtitle}
                   logoAnimation={logoAnimation}
@@ -523,7 +525,7 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
                     onCart={openCart}
                     selectedRubro={entityInfo?.rubro || selectedRubro}
                     onRubroSelect={setSelectedRubro}
-                    headerLogoUrl={headerLogoUrl || customLauncherLogoUrl || entityInfo?.logo_url}
+                    headerLogoUrl={headerLogoUrl || customLauncherLogoUrl || entityInfo?.logo_url || (isDarkMode ? '/chatbocar.png' : '/chatbocar2.png')}
                     welcomeTitle={welcomeTitle}
                     welcomeSubtitle={welcomeSubtitle}
                     logoAnimation={logoAnimation}
@@ -540,7 +542,7 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
                 message={proactiveMessage || ""}
                 onClick={toggleChat}
                 visible={showProactiveBubble && !showCta}
-                logoUrl={headerLogoUrl || customLauncherLogoUrl || entityInfo?.logo_url}
+                logoUrl={headerLogoUrl || customLauncherLogoUrl || entityInfo?.logo_url || (isDarkMode ? '/chatbocar.png' : '/chatbocar2.png')}
                 logoAnimation={logoAnimation}
               />
               {showCta && ctaMessage && !showProactiveBubble && (
@@ -578,25 +580,14 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
                   animate={isOpen ? "open" : "closed"}
                   transition={openSpring}
                 >
-                  {entityInfo?.logo_url || customLauncherLogoUrl ? (
-                    <img
-                      src={entityInfo?.logo_url || customLauncherLogoUrl}
-                      alt="Logo"
-                      style={{
-                        width: calculatedLogoSize,
-                        height: calculatedLogoSize,
-                        borderRadius: "50%",
-                        animation: logoAnimation || undefined,
-                      }}
-                    />
-                  ) : (
-                    <ChatbocLogoAnimated
-                      size={calculatedLogoSize}
-                      blinking={!isOpen}
-                      floating={!isOpen}
-                      pulsing={!isOpen}
-                    />
-                  )}
+                  <ChatbocLogoAnimated
+                    src={entityInfo?.logo_url || customLauncherLogoUrl || (isDarkMode ? '/chatbocar.png' : '/chatbocar2.png')}
+                    size={calculatedLogoSize}
+                    blinking={!isOpen}
+                    floating={!isOpen}
+                    pulsing={!isOpen}
+                    animation={logoAnimation}
+                  />
                 </motion.div>
               </motion.button>
             </motion.div>

--- a/src/components/chat/ChatbocLogoAnimated.tsx
+++ b/src/components/chat/ChatbocLogoAnimated.tsx
@@ -11,8 +11,26 @@ const ChatbocLogoAnimated = ({
   floating = false,
   pulsing = false,
   style = {},
+  src,
+  animation,
 }) => {
   const actualSize = Math.max(size, 1); // Asegurar que el tamaño no sea 0 o negativo
+
+  if (src) {
+    return (
+      <img
+        src={src}
+        alt="Logo"
+        style={{
+          width: actualSize,
+          height: actualSize,
+          borderRadius: "50%",
+          animation: animation || undefined,
+          ...style,
+        }}
+      />
+    );
+  }
 
   const eyeBaseY = 24;
   const leftEyeX = movingEyes ? 19 : 18;

--- a/src/components/ui/DarkModeToggle.tsx
+++ b/src/components/ui/DarkModeToggle.tsx
@@ -17,8 +17,9 @@ const DarkModeToggle = () => {
 
   const toggleTheme = () => {
     const html = document.documentElement;
+    const isCurrentlyDark = html.classList.contains("dark");
 
-    if (html.classList.contains("dark")) {
+    if (isCurrentlyDark) {
       html.classList.remove("dark");
       safeLocalStorage.setItem("theme", "light");
       setIsDark(false);
@@ -27,6 +28,7 @@ const DarkModeToggle = () => {
       safeLocalStorage.setItem("theme", "dark");
       setIsDark(true);
     }
+    window.dispatchEvent(new CustomEvent('themechange'));
   };
 
   return (

--- a/src/hooks/useDarkMode.ts
+++ b/src/hooks/useDarkMode.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+import { safeLocalStorage } from "@/utils/safeLocalStorage";
+
+export function useDarkMode() {
+  const [isDark, setIsDark] = useState(() => {
+    if (typeof window === "undefined") return false;
+    const stored = safeLocalStorage.getItem("theme");
+    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    return stored === "dark" || (!stored && prefersDark);
+  });
+
+  useEffect(() => {
+    const handleThemeChange = () => {
+      const isDarkMode = document.documentElement.classList.contains("dark");
+      setIsDark(isDarkMode);
+    };
+
+    window.addEventListener("themechange", handleThemeChange);
+
+    // Initial check
+    handleThemeChange();
+
+    return () => {
+      window.removeEventListener("themechange", handleThemeChange);
+    };
+  }, []);
+
+  return isDark;
+}

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -9,6 +9,7 @@ import { apiFetch, getErrorMessage } from "@/utils/api";
 import { getAskEndpoint, esRubroPublico, parseRubro } from "@/utils/chatEndpoints";
 import { safeLocalStorage } from "@/utils/safeLocalStorage";
 import { useUser } from "@/hooks/useUser";
+import { useDarkMode } from "@/hooks/useDarkMode";
 import AddressAutocomplete from "@/components/ui/AddressAutocomplete";
 import TicketMap from "@/components/TicketMap";
 import TicketTimeline from "@/components/tickets/TicketTimeline";
@@ -67,6 +68,7 @@ const ChatPage = () => {
   const pollingIntervalRef = useRef<NodeJS.Timeout | null>(null);
 
   const { user, refreshUser, loading } = useUser();
+  const isDarkMode = useDarkMode();
   const authToken = safeLocalStorage.getItem("authToken");
   const isAnonimo = !authToken;
   const anonId = getOrCreateAnonId();
@@ -416,7 +418,7 @@ const ChatPage = () => {
           <header className="p-3 sm:p-4 border-b border-border bg-card/95 backdrop-blur-sm flex items-center justify-between">
             <div className="flex items-center gap-3">
               <img
-                src={tipoChat === "municipio" ? "/favicon/favicon-96x96.png" : "/chatboc_widget_64x64.webp"}
+                src={isDarkMode ? "/chatbocar.png" : "/chatbocar2.png"}
                 alt="Chat Icon"
                 className="w-8 h-8 sm:w-9 sm:h-9 rounded-full bg-primary/10 p-1"
               />


### PR DESCRIPTION
This commit introduces theme-based logos for the chat widget and standalone chat page.

- A `useDarkMode` hook has been created to detect the current theme.
- The `DarkModeToggle` component now dispatches a `themechange` event.
- The `ChatbocLogoAnimated` component has been updated to accept an `src` prop to render custom images.
- The `ChatWidget` and `ChatPage` components now use the `useDarkMode` hook to display the correct logo based on the theme (`chatbocar.png` for dark mode and `chatbocar2.png` for light mode).