### PR TITLE
fix: import label and radio group components

### DIFF
--- a/src/pages/IncidentsMap.tsx
+++ b/src/pages/IncidentsMap.tsx
@@ -14,6 +14,8 @@ import {
   TicketStatsResponse,
 } from '@/services/statsService';
 import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 
 export default function IncidentsMap() {
   useRequireRole(['admin', 'super_admin'] as Role[]);


### PR DESCRIPTION
## Summary
- add Label and RadioGroup imports to IncidentsMap

## Testing
- `npm test` *(fails: addressAutocomplete expected '>' got 'onSelect'; Failed to resolve import '../server/cart.cjs'; Failed to resolve import '../server/catalog.cjs'; Failed to resolve import '../server/db.cjs'; Failed to resolve import '../server/municipalStats.cjs'; Failed to resolve import '../server/preferences.cjs'; Failed to resolve import '../server/widgetAttention.cjs'; parseAgendaText parses event details assertion)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c5dae7a23483228178d03ac16c0ea4