### PR TITLE
Fix map rendering for string ticket coordinates

### DIFF
--- a/src/components/TicketMap.tsx
+++ b/src/components/TicketMap.tsx
@@ -1,15 +1,15 @@
 import MapLibreMap from "@/components/MapLibreMap";
 
 export interface TicketLocation {
-  latitud?: number | null;
-  longitud?: number | null;
-  lat_destino?: number | null;
-  lon_destino?: number | null;
+  latitud?: number | string | null;
+  longitud?: number | string | null;
+  lat_destino?: number | string | null;
+  lon_destino?: number | string | null;
   direccion?: string | null;
   esquinas_cercanas?: string | null;
   distrito?: string | null;
-  municipio_latitud?: number | null;
-  municipio_longitud?: number | null;
+  municipio_latitud?: number | string | null;
+  municipio_longitud?: number | string | null;
 }
 
 export const buildFullAddress = (ticket: TicketLocation) => {
@@ -21,28 +21,29 @@ export const buildFullAddress = (ticket: TicketLocation) => {
 };
 
 const TicketMap: React.FC<{ ticket: TicketLocation }> = ({ ticket }) => {
-  const destLat =
-    typeof ticket.lat_destino === 'number'
-      ? ticket.lat_destino
-      : typeof ticket.latitud === 'number'
-        ? ticket.latitud
-        : undefined;
-  const destLon =
-    typeof ticket.lon_destino === 'number'
-      ? ticket.lon_destino
-      : typeof ticket.longitud === 'number'
-        ? ticket.longitud
-        : undefined;
+  const parse = (v?: number | string | null): number | undefined => {
+    if (typeof v === 'number') return v;
+    if (typeof v === 'string') {
+      const parsed = parseFloat(v);
+      return Number.isFinite(parsed) ? parsed : undefined;
+    }
+    return undefined;
+  };
+
+  const destLat = parse(ticket.lat_destino) ?? parse(ticket.latitud);
+  const destLon = parse(ticket.lon_destino) ?? parse(ticket.longitud);
   const hasCoords =
     typeof destLat === 'number' &&
     typeof destLon === 'number' &&
     (destLat !== 0 || destLon !== 0);
 
+  const muniLon = parse(ticket.municipio_longitud);
+  const muniLat = parse(ticket.municipio_latitud);
+
   const center: [number, number] | undefined = hasCoords
     ? [destLon as number, destLat as number]
-    : typeof ticket.municipio_longitud === 'number' &&
-      typeof ticket.municipio_latitud === 'number'
-      ? [ticket.municipio_longitud, ticket.municipio_latitud]
+    : typeof muniLon === 'number' && typeof muniLat === 'number'
+      ? [muniLon, muniLat]
       : undefined;
 
   if (!center) return null;

--- a/src/components/tickets/DetailsPanel.tsx
+++ b/src/components/tickets/DetailsPanel.tsx
@@ -96,11 +96,20 @@ const DetailsPanel: React.FC<DetailsPanelProps> = ({ onClose }) => {
   }
 
 
+  const parse = (v: unknown) => {
+    if (typeof v === 'number') return v;
+    if (typeof v === 'string') {
+      const n = parseFloat(v);
+      return Number.isFinite(n) ? n : undefined;
+    }
+    return undefined;
+  };
+
   const hasLocation =
     !!ticket.direccion ||
-    (typeof ticket.latitud === 'number' && typeof ticket.longitud === 'number') ||
-    (typeof ticket.municipio_latitud === 'number' &&
-      typeof ticket.municipio_longitud === 'number');
+    (parse(ticket.latitud) !== undefined && parse(ticket.longitud) !== undefined) ||
+    (parse(ticket.municipio_latitud) !== undefined &&
+      parse(ticket.municipio_longitud) !== undefined);
 
   const handleExportPdf = () => {
     exportToPdf(ticket, ticket.messages || []);


### PR DESCRIPTION
## Summary
- parse numeric string coordinates and fallback to municipal location in `TicketMap`
- handle numeric strings when deciding to show location in `DetailsPanel`

## Testing
- `npm test` *(fails: Expected '>', got 'onSelect', Failed to resolve import "../server/cart.cjs"...)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c5e698cd588322a71c84e672cf8820