### PR TITLE
fix: prevent overflow in ticket details panel

### DIFF
--- a/src/components/tickets/DetailsPanel.tsx
+++ b/src/components/tickets/DetailsPanel.tsx
@@ -239,8 +239,8 @@ const DetailsPanel: React.FC<DetailsPanelProps> = ({ onClose }) => {
           </DropdownMenuContent>
         </DropdownMenu>
       </header>
-      <ScrollArea className="flex-1">
-        <div className="p-4 pr-6 space-y-4">
+      <ScrollArea className="flex-1 overflow-x-auto">
+        <div className="p-4 lg:pr-6 space-y-4">
           <Card>
             <CardHeader className="flex flex-row items-center gap-4 p-4">
               <Avatar className="h-14 w-14">


### PR DESCRIPTION
## Summary
- allow horizontal scrolling in DetailsPanel ScrollArea to avoid clipping
- reduce right padding on narrow screens

## Testing
- `npm test` *(fails: parseAgendaText > parses event details)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e81e54288322ba1bbfef1d5c7f5f