### PR TITLE
feat: Implement theme-based logos and redesign proactive bubble

### DIFF
--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -41,10 +41,10 @@ interface ChatWidgetProps {
 }
 
 const PROACTIVE_MESSAGES = [
-  "¿Necesitas ayuda para encontrar algo?",
-  "¡Hola! Estoy aquí para asistirte.",
-  "¿Tienes alguna consulta? ¡Pregúntame!",
-  "Explora nuestros servicios, ¡te ayudo!",
+  "¿Necesitas ayuda?",
+  "¿Querés hacer una sugerencia?",
+  "¿Tenés un reclamo?",
+  "¿Tenés consultas? ¡Preguntame!",
 ];
 
 const LS_KEY = "chatboc_accessibility";

--- a/src/components/chat/ProactiveBubble.tsx
+++ b/src/components/chat/ProactiveBubble.tsx
@@ -1,76 +1,55 @@
 import React from "react";
 import { motion } from "framer-motion";
-// import { MessageSquareHeart, Sparkles } from "lucide-react"; // Iconos alternativos si se prefiere
-import ChatbocLogoAnimated from "./ChatbocLogoAnimated"; // Usar el logo del bot
 
 interface ProactiveBubbleProps {
   message: string;
   onClick: () => void;
   visible: boolean;
-  logoUrl?: string;
-  logoAnimation?: string;
 }
 
 const ProactiveBubble: React.FC<ProactiveBubbleProps> = ({
   message,
   onClick,
   visible,
-  logoUrl,
-  logoAnimation,
 }) => {
   if (!visible) return null;
 
   return (
     <motion.div
       key="proactive-bubble"
-      className="absolute bottom-full right-0 mb-3 flex items-end gap-2 cursor-pointer group" // Añadido group para hover effects
-      initial={{ opacity: 0, y: 30, scale: 0.8 }}
+      className="absolute bottom-0 right-[calc(100%+1rem)] mb-4 cursor-pointer group"
+      initial={{ opacity: 0, x: 20 }}
       animate={{
         opacity: 1,
-        y: 0,
-        scale: 1,
-        transition: { type: "spring", stiffness: 280, damping: 20, delay: 0.2 }
+        x: 0,
+        transition: { type: "spring", stiffness: 280, damping: 25, delay: 0.2 }
       }}
-      exit={{ opacity: 0, y: 20, scale: 0.9, transition: { duration: 0.2, ease: "easeOut" } }}
-      whileHover={{ y: -3, transition: { type: "spring", stiffness: 300, damping: 15 } }} // Ligero lift al hacer hover
+      exit={{ opacity: 0, x: 20, transition: { duration: 0.2, ease: "easeOut" } }}
+      whileHover={{ scale: 1.05 }}
       onClick={onClick}
       role="alert"
       aria-live="polite"
+      style={{
+        animation: 'float 3s ease-in-out infinite',
+      }}
     >
-      {/* Contenedor del mensaje y el rabito */}
-      <div className="relative">
+      <div
+        className="relative bg-primary text-primary-foreground px-4 py-3 rounded-lg shadow-lg font-semibold"
+        style={{
+            boxShadow: 'var(--shadow)',
+            animation: 'pulse-shadow 3s ease-in-out infinite',
+        }}
+      >
+        <span className="block">{message}</span>
         <div
-          className="bg-background dark:bg-slate-800 text-foreground dark:text-slate-100 px-4 py-2.5 rounded-xl shadow-xl border border-border dark:border-slate-700 max-w-xs text-sm font-medium leading-normal"
-          style={{ borderRadius: "12px" }} // Mantener el estilo explícito si se prefiere, o quitar si px-4 py-2.5 es suficiente. rounded-xl ya está en clases.
-        >
-          {message}
-        </div>
-        {/* Rabito de la burbuja - más integrado y estilizado */}
-        <div
-          className="absolute right-[18px] -bottom-[7px] w-4 h-4 bg-background dark:bg-slate-800 border-r border-b border-border dark:border-r-slate-700 dark:border-b-slate-700 transform rotate-45 shadow-sm"
+          className="absolute left-full top-1/2 -translate-y-1/2 w-0 h-0"
           style={{
-            clipPath: "polygon(0 0, 100% 0, 100% 100%)" // Solo muestra la parte inferior derecha del cuadrado rotado
+            borderTop: '10px solid transparent',
+            borderBottom: '10px solid transparent',
+            borderLeft: '16px solid hsl(var(--primary))',
           }}
         />
       </div>
-
-      {/* Icono/Avatar del Bot al lado de la burbuja */}
-      <motion.div
-        className="flex-shrink-0 w-10 h-10 bg-primary rounded-full flex items-center justify-center shadow-lg border-2 border-background dark:border-slate-800"
-        initial={{ scale: 0, opacity: 0, x: 10 }}
-        animate={{ scale: 1, opacity: 1, x: 0, transition: { type: "spring", stiffness: 260, damping: 18, delay: 0.4 } }}
-      >
-        {logoUrl ? (
-          <img
-            src={logoUrl}
-            alt="Bot"
-            className="w-6 h-6 rounded-full"
-            style={{ animation: logoAnimation || undefined }}
-          />
-        ) : (
-          <ChatbocLogoAnimated size={26} blinking />
-        )}
-      </motion.div>
     </motion.div>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -242,3 +242,13 @@ body,
   text-decoration: underline;
   text-underline-offset: 2px;
 }
+
+@keyframes float {
+  0%,100% { transform: translateY(0); }
+  50% { transform: translateY(-6px); }
+}
+
+@keyframes pulse-shadow {
+  0%,100% { box-shadow: var(--shadow); }
+  50% { box-shadow: 0 0 20px rgba(0,108,63,.4); }
+}


### PR DESCRIPTION
This commit introduces two major UI enhancements based on user feedback:

1.  **Theme-Based Logos:**
    *   A `useDarkMode` hook has been created to detect the current theme.
    *   Components like `ChatWidget` and `ChatPage` now use this hook to display different logos for light (`/chatbocar2.png`) and dark (`/chatbocar.png`) modes.
    *   The `ChatbocLogoAnimated` component was updated to support custom image `src` props, allowing it to display the new logos while preserving its animation capabilities for the default case.

2.  **Redesigned Proactive Bubble:**
    *   The `ProactiveBubble` component has been completely restyled to match a design provided by the user.
    *   It now appears as a speech bubble with a pointer, and features new `float` and `pulse-shadow` animations for a more dynamic and engaging look.
    *   The list of proactive messages has been updated to use the phrases requested by the user.