### PR TITLE
Display ticket photo inside follow-up contact section

### DIFF
--- a/src/components/tickets/TicketAttachments.tsx
+++ b/src/components/tickets/TicketAttachments.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useState } from 'react';
 import { CardContent } from '@/components/ui/card';
 import type { Attachment } from '@/types/tickets';
 import { deriveAttachmentInfo, isAllowedAttachmentType } from '@/utils/attachment';
@@ -14,7 +14,7 @@ const TicketAttachments: React.FC<Props> = ({ attachments }) => {
     info: deriveAttachmentInfo(
       att.url,
       att.filename || att.url.split('/').pop() || 'archivo_adj',
-      att.mime_type,
+      att.mime_type || att.mimeType,
       att.size,
       att.thumbUrl || att.thumb_url || att.thumbnail_url || att.thumbnailUrl
     ),
@@ -25,9 +25,6 @@ const TicketAttachments: React.FC<Props> = ({ attachments }) => {
   const images = allowed.filter((p) => p.info.type === 'image');
   const others = allowed.filter((p) => p.info.type !== 'image');
   const [openUrl, setOpenUrl] = useState<string | null>(null);
-  const [openIndex, setOpenIndex] = useState<number | null>(null);
-  const thumbsRef = useRef<(HTMLButtonElement | null)[]>([]);
-  const closeBtnRef = useRef<HTMLButtonElement>(null);
 
   if (!images.length && !others.length && !disallowed.length) return null;
 
@@ -36,13 +33,11 @@ const TicketAttachments: React.FC<Props> = ({ attachments }) => {
       <h4 className="font-semibold mb-2">Adjuntos</h4>
       {images.length > 0 && (
         <div className="grid grid-cols-3 gap-2 mb-2">
-          {images.map(({ data, info }, index) => (
+          {images.map(({ data, info }) => (
             <button
-              key={data.id}
-              ref={(el) => (thumbsRef.current[index] = el)}
+              key={`${data.id}-${info.url}`}
               onClick={() => {
                 setOpenUrl(data.url);
-                setOpenIndex(index);
               }}
               className="relative group aspect-video overflow-hidden rounded-lg border"
               aria-label="Abrir imagen adjunta"
@@ -66,8 +61,8 @@ const TicketAttachments: React.FC<Props> = ({ attachments }) => {
       )}
       {others.length > 0 && (
         <ul className="space-y-1">
-          {others.map(({ data, info }) => (
-            <li key={data.id}>
+          {others.map(({ data, info }, index) => (
+            <li key={`${data.id}-${info.url}-${index}`}>
               <a
                 href={data.url}
                 target="_blank"
@@ -100,7 +95,6 @@ const TicketAttachments: React.FC<Props> = ({ attachments }) => {
               className="max-h-[90vh] max-w-[90vw] rounded-lg shadow-2xl"
             />
             <button
-              ref={closeBtnRef}
               onClick={() => setOpenUrl(null)}
               className="absolute top-2 right-2 rounded-full bg-black/60 text-white p-1 hover:bg-black/80 focus:outline-none"
               aria-label="Cerrar"

--- a/src/types/tickets.ts
+++ b/src/types/tickets.ts
@@ -19,16 +19,32 @@ export interface User {
   horario?: Horario;
 }
 
+export interface AttachmentAnalysisData {
+  url?: string;
+  thumbnail_url?: string;
+  [key: string]: unknown;
+}
+
+export interface AttachmentAnalysis {
+  datos_estructurados?: AttachmentAnalysisData;
+  structured_data?: AttachmentAnalysisData;
+  [key: string]: unknown;
+}
+
 export interface Attachment {
   id: number;
   filename: string;
   url: string;
-  size: number;
+  size?: number;
   mime_type?: string;
+  mimeType?: string;
   thumbUrl?: string;
   thumb_url?: string;
   thumbnail_url?: string;
   thumbnailUrl?: string;
+  analisis?: AttachmentAnalysis;
+  analysis?: AttachmentAnalysis;
+  datos_estructurados?: AttachmentAnalysisData;
 }
 
 export interface Message {
@@ -41,6 +57,7 @@ export interface Message {
 
   // Fields to align with ChatMessageData
   attachments?: Attachment[];
+  archivos_adjuntos?: Attachment[];
   botones?: Boton[];
   structuredContent?: StructuredContentItem[];
 
@@ -124,6 +141,7 @@ export interface Ticket {
   // Fields that might come from a detailed view, but good to have
   messages?: Message[];
   attachments?: Attachment[];
+  archivos_adjuntos?: Attachment[];
   activityLog?: any[];
   hasUnreadMessages?: boolean;
 
@@ -136,4 +154,5 @@ export interface Ticket {
   channel?: 'whatsapp' | 'web' | 'email' | 'phone' | 'other';
   assignedAgent?: User;
   whatsapp_conversation_id?: string;
+  foto_url_directa?: string;
 }


### PR DESCRIPTION
## Summary
- sanitize attachment URLs so photo links resolve consistently when deriving the primary image
- keep the vecino header avatar independent from ticket evidence and rely on sanitized avatar data
- embed the ticket photo in the follow-up contact block with a larger preview and error handling

## Testing
- npm run test *(fails: local environment lacks server/*.cjs stubs and agendaParser expectation mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68cb201e94f08322b59bbc7d2945ccf0