### PR TITLE
Fix ChatPanel state initialization order

### DIFF
--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -136,6 +136,7 @@ const ChatPanel = ({
       });
   }, []);
 
+
   useEffect(() => {
     if (localRubro) {
       return;
@@ -176,6 +177,17 @@ const ChatPanel = ({
       welcomeShownRef.current = true;
     }
   }, [localRubro, messages.length, addSystemMessage]);
+
+  const [esperandoDireccion, setEsperandoDireccion] = useState(false);
+  const [forzarDireccion, setForzarDireccion] = useState(false);
+  const [direccionGuardada, setDireccionGuardada] = useState<string | null>(null);
+  const [showCierre, setShowCierre] = useState<{ show: boolean; text: string } | null>(null);
+  const [ticketLocation, setTicketLocation] = useState<{
+    direccion?: string | null;
+    latitud?: number | null;
+    longitud?: number | null;
+    municipio_nombre?: string | null;
+  } | null>(null);
 
   const handleRubroSelection = useCallback(
     (rubro: Rubro) => {
@@ -226,11 +238,6 @@ const ChatPanel = ({
     });
   };
 
-  const [esperandoDireccion, setEsperandoDireccion] = useState(false);
-  const [forzarDireccion, setForzarDireccion] = useState(false);
-  const [direccionGuardada, setDireccionGuardada] = useState<string | null>(null);
-  const [showCierre, setShowCierre] = useState<{ show: boolean; text: string } | null>(null);
-  const [ticketLocation, setTicketLocation] = useState<{ direccion?: string | null; latitud?: number | null; longitud?: number | null; municipio_nombre?: string | null } | null>(null);
   const esAnonimo = skipAuth || !safeLocalStorage.getItem("authToken");
   const { user } = useUser();
 

--- a/src/pages/iframe.tsx
+++ b/src/pages/iframe.tsx
@@ -9,41 +9,6 @@ import { getChatbocConfig } from "@/utils/config";
 import { hexToHsl } from "@/utils/color";
 import { safeLocalStorage } from "@/utils/safeLocalStorage";
 
-function hexToHsl(hex: string): string {
-  let r = 0, g = 0, b = 0;
-  const normalized = hex.replace('#', '');
-  if (normalized.length === 3) {
-    r = parseInt(normalized[0] + normalized[0], 16);
-    g = parseInt(normalized[1] + normalized[1], 16);
-    b = parseInt(normalized[2] + normalized[2], 16);
-  } else if (normalized.length === 6) {
-    r = parseInt(normalized.substring(0, 2), 16);
-    g = parseInt(normalized.substring(2, 4), 16);
-    b = parseInt(normalized.substring(4, 6), 16);
-  }
-  r /= 255; g /= 255; b /= 255;
-  const max = Math.max(r, g, b), min = Math.min(r, g, b);
-  let h = 0, s = 0;
-  const l = (max + min) / 2;
-  if (max !== min) {
-    const d = max - min;
-    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
-    switch (max) {
-      case r:
-        h = (g - b) / d + (g < b ? 6 : 0);
-        break;
-      case g:
-        h = (b - r) / d + 2;
-        break;
-      case b:
-        h = (r - g) / d + 4;
-        break;
-    }
-    h /= 6;
-  }
-  return `${Math.round(h * 360)} ${Math.round(s * 100)}% ${Math.round(l * 100)}%`;
-}
-
 const DEFAULTS = {
   openWidth: "460px",
   openHeight: "680px",


### PR DESCRIPTION
## Summary
- declare the ChatPanel state hooks before the rubro selection callback so their setters are initialized prior to use in the dependency array
- keep the rubro reset callback clearing all dependent state without hitting the runtime "Cannot access before initialization" error

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc36c19b208322afccac51d1107c80