### PR TITLE
Ignore stored rubro data when chatting as a municipality

### DIFF
--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -107,14 +107,12 @@ const ChatPanel = ({
     skipAuth,
   });
 
+  const rubrosEnabled = tipoChat === 'pyme';
   const [rubros, setRubros] = useState<Rubro[]>([]);
   const [isLoadingRubros, setIsLoadingRubros] = useState(false);
   const [rubrosError, setRubrosError] = useState<string | null>(null);
   const welcomeShownRef = useRef(false);
-  const [localRubro, setLocalRubro] = useState<string | null>(() => {
-    const stored = safeLocalStorage.getItem("rubroSeleccionado");
-    return selectedRubro ?? stored;
-  });
+  const [localRubro, setLocalRubro] = useState<string | null>(() => selectedRubro ?? null);
 
   const loadRubros = useCallback(() => {
     setIsLoadingRubros(true);
@@ -137,45 +135,84 @@ const ChatPanel = ({
   }, []);
 
   useEffect(() => {
-    if (localRubro) {
+    if (!rubrosEnabled) {
+      safeLocalStorage.removeItem("rubroSeleccionado");
+      welcomeShownRef.current = false;
+      const nextValue = selectedRubro ?? null;
+      if (localRubro !== nextValue) {
+        setLocalRubro(nextValue);
+      }
+      return;
+    }
+
+    if (selectedRubro && selectedRubro !== localRubro) {
+      welcomeShownRef.current = false;
+      setLocalRubro(selectedRubro);
+      return;
+    }
+
+    if (!selectedRubro && !localRubro) {
+      const stored = safeLocalStorage.getItem("rubroSeleccionado");
+      if (stored) {
+        setLocalRubro(stored);
+      }
+    }
+  }, [rubrosEnabled, selectedRubro, localRubro]);
+
+
+  useEffect(() => {
+    if (!rubrosEnabled || localRubro) {
       return;
     }
     if (isLoadingRubros || rubros.length > 0 || rubrosError) {
       return;
     }
     loadRubros();
-  }, [localRubro, isLoadingRubros, rubros.length, rubrosError, loadRubros]);
+  }, [rubrosEnabled, localRubro, isLoadingRubros, rubros.length, rubrosError, loadRubros]);
 
   useEffect(() => {
-    if (selectedRubro && selectedRubro !== localRubro) {
-      welcomeShownRef.current = false;
-      setLocalRubro(selectedRubro);
+    if (!rubrosEnabled) {
+      return;
     }
-  }, [selectedRubro, localRubro]);
-
-  useEffect(() => {
     if (!selectedRubro && localRubro && onRubroSelect) {
       onRubroSelect(localRubro);
     }
-  }, [selectedRubro, localRubro, onRubroSelect]);
+  }, [rubrosEnabled, selectedRubro, localRubro, onRubroSelect]);
 
   useEffect(() => {
+    if (!rubrosEnabled) {
+      return;
+    }
     if (localRubro) {
       safeLocalStorage.setItem("rubroSeleccionado", localRubro);
     } else {
       safeLocalStorage.removeItem("rubroSeleccionado");
       welcomeShownRef.current = false;
     }
-  }, [localRubro]);
+  }, [rubrosEnabled, localRubro]);
 
   useEffect(() => {
+    if (!rubrosEnabled) {
+      return;
+    }
     if (localRubro && messages.length === 0 && !welcomeShownRef.current) {
       addSystemMessage(
         `¡Hola! Soy Chatboc, tu asistente para ${localRubro.toLowerCase()}. ¿En qué puedo ayudarte hoy?`
       );
       welcomeShownRef.current = true;
     }
-  }, [localRubro, messages.length, addSystemMessage]);
+  }, [rubrosEnabled, localRubro, messages.length, addSystemMessage]);
+
+  const [esperandoDireccion, setEsperandoDireccion] = useState(false);
+  const [forzarDireccion, setForzarDireccion] = useState(false);
+  const [direccionGuardada, setDireccionGuardada] = useState<string | null>(null);
+  const [showCierre, setShowCierre] = useState<{ show: boolean; text: string } | null>(null);
+  const [ticketLocation, setTicketLocation] = useState<{
+    direccion?: string | null;
+    latitud?: number | null;
+    longitud?: number | null;
+    municipio_nombre?: string | null;
+  } | null>(null);
 
   const handleRubroSelection = useCallback(
     (rubro: Rubro) => {
@@ -204,7 +241,7 @@ const ChatPanel = ({
     ]
   );
 
-  const showRubroSelector = !localRubro;
+  const showRubroSelector = rubrosEnabled && !localRubro;
 
   const [visitorName, setVisitorNameState] = useState(() => getVisitorName());
 
@@ -226,11 +263,6 @@ const ChatPanel = ({
     });
   };
 
-  const [esperandoDireccion, setEsperandoDireccion] = useState(false);
-  const [forzarDireccion, setForzarDireccion] = useState(false);
-  const [direccionGuardada, setDireccionGuardada] = useState<string | null>(null);
-  const [showCierre, setShowCierre] = useState<{ show: boolean; text: string } | null>(null);
-  const [ticketLocation, setTicketLocation] = useState<{ direccion?: string | null; latitud?: number | null; longitud?: number | null; municipio_nombre?: string | null } | null>(null);
   const esAnonimo = skipAuth || !safeLocalStorage.getItem("authToken");
   const { user } = useUser();
 

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -94,6 +94,35 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
     typeof window !== "undefined" && window.innerWidth < 640
   );
 
+  const isEmbedded = mode !== "standalone";
+
+  const derivedEntityTitle =
+    (typeof entityInfo?.nombre_empresa === "string" && entityInfo.nombre_empresa.trim()) ||
+    (typeof entityInfo?.nombre === "string" && entityInfo.nombre.trim()) ||
+    (typeof entityInfo?.nombre_publico === "string" && entityInfo.nombre_publico.trim()) ||
+    (typeof entityInfo?.nombre_fantasia === "string" && entityInfo.nombre_fantasia.trim()) ||
+    (typeof entityInfo?.nombreFantasia === "string" && entityInfo.nombreFantasia.trim()) ||
+    (typeof entityInfo?.nombre_asistente === "string" && entityInfo.nombre_asistente.trim()) ||
+    (typeof entityInfo?.nombreAsistente === "string" && entityInfo.nombreAsistente.trim()) ||
+    (typeof entityInfo?.bot_nombre === "string" && entityInfo.bot_nombre.trim()) ||
+    (typeof entityInfo?.botNombre === "string" && entityInfo.botNombre.trim()) ||
+    (typeof entityInfo?.display_name === "string" && entityInfo.display_name.trim()) ||
+    (typeof entityInfo?.municipio_nombre === "string" && entityInfo.municipio_nombre.trim()) ||
+    (typeof entityInfo?.municipio === "string" && entityInfo.municipio.trim()) ||
+    "";
+
+  const derivedEntitySubtitle =
+    (typeof entityInfo?.rubro === "string" && entityInfo.rubro.trim()) ||
+    (typeof entityInfo?.descripcion === "string" && entityInfo.descripcion.trim()) ||
+    (typeof entityInfo?.descripcion_corta === "string" && entityInfo.descripcion_corta.trim()) ||
+    (typeof entityInfo?.tagline === "string" && entityInfo.tagline.trim()) ||
+    (typeof entityInfo?.eslogan === "string" && entityInfo.eslogan.trim()) ||
+    (typeof entityInfo?.slogan === "string" && entityInfo.slogan.trim()) ||
+    "";
+
+  const headerTitle = isEmbedded ? derivedEntityTitle : welcomeTitle;
+  const headerSubtitle = isEmbedded ? derivedEntitySubtitle : welcomeSubtitle;
+
   useEffect(() => {
     const checkMobile = () => {
       if (typeof window !== "undefined") {
@@ -498,8 +527,8 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
                   onToggleSound={toggleMuted}
                   onCart={openCart}
                   logoUrl={headerLogoUrl || customLauncherLogoUrl || entityInfo?.logo_url || (isDarkMode ? '/chatbocar.png' : '/chatbocar2.png')}
-                  title={welcomeTitle}
-                  subtitle={welcomeSubtitle}
+                  title={headerTitle}
+                  subtitle={headerSubtitle}
                   logoAnimation={logoAnimation}
                   onA11yChange={setA11yPrefs}
                 />
@@ -526,8 +555,8 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
                     selectedRubro={entityInfo?.rubro || selectedRubro}
                     onRubroSelect={setSelectedRubro}
                     headerLogoUrl={headerLogoUrl || customLauncherLogoUrl || entityInfo?.logo_url || (isDarkMode ? '/chatbocar.png' : '/chatbocar2.png')}
-                    welcomeTitle={welcomeTitle}
-                    welcomeSubtitle={welcomeSubtitle}
+                    welcomeTitle={headerTitle}
+                    welcomeSubtitle={headerSubtitle}
                     logoAnimation={logoAnimation}
                     onA11yChange={setA11yPrefs}
                     a11yPrefs={a11yPrefs}

--- a/src/hooks/useChatLogic.ts
+++ b/src/hooks/useChatLogic.ts
@@ -731,8 +731,14 @@ export function useChatLogic({ tipoChat, entityToken: propToken, tokenKey = 'aut
 
     try {
       const storedUser = JSON.parse(safeLocalStorage.getItem('user') || 'null');
-      const rubro = storedUser?.rubro?.clave || storedUser?.rubro?.nombre || safeLocalStorage.getItem("rubroSeleccionado") || null;
-      const tipoChatFinal = enforceTipoChatForRubro(tipoChat, rubro);
+      const storedRubro =
+        storedUser?.rubro?.clave ||
+        storedUser?.rubro?.nombre ||
+        safeLocalStorage.getItem("rubroSeleccionado") ||
+        null;
+
+      const tipoChatFinal = enforceTipoChatForRubro(tipoChat, storedRubro);
+      const rubro = tipoChatFinal === 'pyme' ? storedRubro : null;
 
       const updatedContext = updateMunicipioContext(contexto, { userInput: userMessageText, action: resolvedAction });
       setContexto(updatedContext);

--- a/src/pages/iframe.tsx
+++ b/src/pages/iframe.tsx
@@ -9,41 +9,6 @@ import { getChatbocConfig } from "@/utils/config";
 import { hexToHsl } from "@/utils/color";
 import { safeLocalStorage } from "@/utils/safeLocalStorage";
 
-function hexToHsl(hex: string): string {
-  let r = 0, g = 0, b = 0;
-  const normalized = hex.replace('#', '');
-  if (normalized.length === 3) {
-    r = parseInt(normalized[0] + normalized[0], 16);
-    g = parseInt(normalized[1] + normalized[1], 16);
-    b = parseInt(normalized[2] + normalized[2], 16);
-  } else if (normalized.length === 6) {
-    r = parseInt(normalized.substring(0, 2), 16);
-    g = parseInt(normalized.substring(2, 4), 16);
-    b = parseInt(normalized.substring(4, 6), 16);
-  }
-  r /= 255; g /= 255; b /= 255;
-  const max = Math.max(r, g, b), min = Math.min(r, g, b);
-  let h = 0, s = 0;
-  const l = (max + min) / 2;
-  if (max !== min) {
-    const d = max - min;
-    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
-    switch (max) {
-      case r:
-        h = (g - b) / d + (g < b ? 6 : 0);
-        break;
-      case g:
-        h = (b - r) / d + 2;
-        break;
-      case b:
-        h = (r - g) / d + 4;
-        break;
-    }
-    h /= 6;
-  }
-  return `${Math.round(h * 360)} ${Math.round(s * 100)}% ${Math.round(l * 100)}%`;
-}
-
 const DEFAULTS = {
   openWidth: "460px",
   openHeight: "680px",


### PR DESCRIPTION
## Summary
- stop reusing locally stored pyme rubros when building municipality chat requests so the enforced tipoChat stays municipal
- ensure the backend payload and endpoint only receive a rubro when the final chat type is pyme
- derive embedded widget header copy from entity profile data so municipality/company embeds rely on backend greetings instead of static welcome text

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc36c19b208322afccac51d1107c80