### PR TITLE
Sanitize demo entity tokens before hitting the API

### DIFF
--- a/cdn/widget.js
+++ b/cdn/widget.js
@@ -85,6 +85,7 @@
     const SCRIPT_CONFIG = {
       WIDGET_JS_FILENAME: "widget.js",
       DEFAULT_TOKEN: "demo-anon",
+      PLACEHOLDER_PREFIX: "demo-anon",
       DEFAULT_Z_INDEX: "9999",
       DEFAULT_INITIAL_BOTTOM: "24px",
       DEFAULT_INITIAL_RIGHT: "24px",
@@ -108,9 +109,20 @@
       return;
     }
 
+    const sanitizeEntityToken = (token) => {
+      if (!token) return null;
+      const trimmed = token.trim();
+      if (!trimmed) return null;
+      return trimmed.toLowerCase().startsWith(SCRIPT_CONFIG.PLACEHOLDER_PREFIX)
+        ? null
+        : trimmed;
+    };
+
     const ownerTokenAttr =
       script.getAttribute("data-owner-token") || script.getAttribute("data-entity-token");
-    const ownerToken = ownerTokenAttr || SCRIPT_CONFIG.DEFAULT_TOKEN;
+    const trimmedOwnerTokenAttr = ownerTokenAttr ? ownerTokenAttr.trim() : "";
+    const ownerToken = trimmedOwnerTokenAttr || SCRIPT_CONFIG.DEFAULT_TOKEN;
+    const iframeEntityToken = sanitizeEntityToken(trimmedOwnerTokenAttr);
     const registry = (window.__chatbocWidgets = window.__chatbocWidgets || {});
 
     if (registry[ownerToken]) {
@@ -289,7 +301,9 @@
       // Use explicit .html path so integrations without rewrite rules work
       const iframeSrc = new URL(`${apiBase}/iframe.html`);
       iframeSrc.searchParams.set("token", latestToken);
-      iframeSrc.searchParams.set("entityToken", ownerToken);
+      if (iframeEntityToken) {
+        iframeSrc.searchParams.set("entityToken", iframeEntityToken);
+      }
       iframeSrc.searchParams.set("widgetId", iframeId);
       iframeSrc.searchParams.set("defaultOpen", String(defaultOpen));
       iframeSrc.searchParams.set("tipo_chat", tipoChat);

--- a/public/iframe.html
+++ b/public/iframe.html
@@ -50,9 +50,14 @@
     // Config que llega por query (encapsulada para no contaminar el global)
     (() => {
       const params = new URLSearchParams(location.search);
+      const rawEntityToken = params.get('entityToken');
+      const sanitizedEntityToken = rawEntityToken && rawEntityToken.trim().toLowerCase().startsWith('demo-anon')
+        ? ''
+        : (rawEntityToken ? rawEntityToken.trim() : '');
+
       window.CHATBOC_CONFIG = {
         endpoint: params.get('endpoint') || 'municipio',
-        entityToken: params.get('entityToken') || '',
+        entityToken: sanitizedEntityToken,
         userToken: params.get('userToken') || null,
         defaultOpen: params.get('defaultOpen') === 'true',
         width: params.get('width') || '460px',

--- a/public/widget.js
+++ b/public/widget.js
@@ -23,11 +23,22 @@
 
   const ds = script ? script.dataset : {};
 
+  const PLACEHOLDER_PREFIX = "demo-anon";
+  const sanitizeEntityToken = (token) => {
+    if (!token) return "";
+    const trimmed = token.trim();
+    if (!trimmed) return "";
+    return trimmed.toLowerCase().startsWith(PLACEHOLDER_PREFIX) ? "" : trimmed;
+  };
+
+  const rawEntityToken = ds.token || ds.entityToken || "";
+  const sanitizedEntityToken = sanitizeEntityToken(rawEntityToken);
+
   const cfg = {
     host: chatbocDomain,
     iframePath: ds.iframePath || "/iframe",
     endpoint: ds.endpoint || "municipio",
-    entityToken: ds.token || ds.entityToken || "demo-anon",
+    entityToken: sanitizedEntityToken,
     defaultOpen: ds.defaultOpen === "true",
     width: ds.width || "460px",
     height: ds.height || "680px",
@@ -44,26 +55,27 @@
     welcomeSubtitle: ds.welcomeSubtitle || "",
   };
 
-  const qs = new URLSearchParams({
-    endpoint: cfg.endpoint,
-    entityToken: cfg.entityToken,
-    defaultOpen: String(cfg.defaultOpen),
-    width: cfg.width,
-    height: cfg.height,
-    closedWidth: cfg.closedWidth,
-    closedHeight: cfg.closedHeight,
-    bottom: cfg.bottom,
-    right: cfg.right,
-    widgetId: iframeId,
-    hostDomain: window.location.origin,
-    primaryColor: cfg.primaryColor,
-    accentColor: cfg.accentColor,
-    logoUrl: cfg.logoUrl,
-    headerLogoUrl: cfg.headerLogoUrl,
-    logoAnimation: cfg.logoAnimation,
-    welcomeTitle: cfg.welcomeTitle,
-    welcomeSubtitle: cfg.welcomeSubtitle,
-  });
+  const qs = new URLSearchParams();
+  qs.set("endpoint", cfg.endpoint);
+  if (cfg.entityToken) {
+    qs.set("entityToken", cfg.entityToken);
+  }
+  qs.set("defaultOpen", String(cfg.defaultOpen));
+  qs.set("width", cfg.width);
+  qs.set("height", cfg.height);
+  qs.set("closedWidth", cfg.closedWidth);
+  qs.set("closedHeight", cfg.closedHeight);
+  qs.set("bottom", cfg.bottom);
+  qs.set("right", cfg.right);
+  qs.set("widgetId", iframeId);
+  qs.set("hostDomain", window.location.origin);
+  qs.set("primaryColor", cfg.primaryColor);
+  if (cfg.accentColor) qs.set("accentColor", cfg.accentColor);
+  if (cfg.logoUrl) qs.set("logoUrl", cfg.logoUrl);
+  if (cfg.headerLogoUrl) qs.set("headerLogoUrl", cfg.headerLogoUrl);
+  if (cfg.logoAnimation) qs.set("logoAnimation", cfg.logoAnimation);
+  if (cfg.welcomeTitle) qs.set("welcomeTitle", cfg.welcomeTitle);
+  if (cfg.welcomeSubtitle) qs.set("welcomeSubtitle", cfg.welcomeSubtitle);
 
   const iframeSrc = `${cfg.host}${cfg.iframePath}?${qs.toString()}`;
 

--- a/src/components/chat/ChatUserLoginPanel.tsx
+++ b/src/components/chat/ChatUserLoginPanel.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import GoogleLoginButton from "@/components/auth/GoogleLoginButton";
 import { apiFetch, ApiError } from "@/utils/api";
 import { safeLocalStorage } from "@/utils/safeLocalStorage";
+import { getStoredEntityToken, sanitizeEntityToken, storeEntityToken } from "@/utils/entityToken";
 import { useUser } from "@/hooks/useUser";
 
 interface LoginResponse {
@@ -40,7 +41,8 @@ const ChatUserLoginPanel: React.FC<Props> = ({ onSuccess, onShowRegister }) => {
       const params = new URLSearchParams(window.location.search);
       const tokenFromUrl = params.get('token');
       if (tokenFromUrl) {
-        safeLocalStorage.setItem('entityToken', tokenFromUrl);
+        const sanitized = sanitizeEntityToken(tokenFromUrl);
+        storeEntityToken(sanitized);
       }
     }
   }, []);
@@ -51,8 +53,8 @@ const ChatUserLoginPanel: React.FC<Props> = ({ onSuccess, onShowRegister }) => {
     setLoading(true);
     try {
       const payload: Record<string, any> = { email, password };
-      const empresaToken = safeLocalStorage.getItem("entityToken");
-      payload.empresa_token = empresaToken;
+      const empresaToken = getStoredEntityToken();
+      payload.empresa_token = empresaToken ?? null;
       const anon = safeLocalStorage.getItem("anon_id");
       if (anon) payload.anon_id = anon;
       const data = await apiFetch<LoginResponse>("/chatuserloginpanel", {

--- a/src/components/chat/ChatUserRegisterPanel.tsx
+++ b/src/components/chat/ChatUserRegisterPanel.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import GoogleLoginButton from "@/components/auth/GoogleLoginButton";
 import { apiFetch, ApiError } from "@/utils/api";
 import { safeLocalStorage } from "@/utils/safeLocalStorage";
+import { getStoredEntityToken, sanitizeEntityToken, storeEntityToken } from "@/utils/entityToken";
 import { useUser } from "@/hooks/useUser";
 
 
@@ -55,14 +56,14 @@ const ChatUserRegisterPanel: React.FC<Props> = ({ onSuccess, onShowLogin, entity
       if (phone.trim()) payload.telefono = phone.trim();
 
       // Prioritize entityToken from prop, then localStorage, then URL (handled by useEffect)
-      let currentEntityToken = entityToken || safeLocalStorage.getItem("entityToken");
+      let currentEntityToken = sanitizeEntityToken(entityToken) || getStoredEntityToken();
 
       if (!currentEntityToken) {
         const params = new URLSearchParams(window.location.search);
-        const tokenFromUrl = params.get('token');
+        const tokenFromUrl = sanitizeEntityToken(params.get('token'));
         if (tokenFromUrl) {
           currentEntityToken = tokenFromUrl;
-          safeLocalStorage.setItem('entityToken', tokenFromUrl); // Save it for potential future use in this session
+          storeEntityToken(tokenFromUrl); // Save it for potential future use in this session
         }
       }
 

--- a/src/hooks/useUser.tsx
+++ b/src/hooks/useUser.tsx
@@ -3,6 +3,7 @@ import { apiFetch } from '@/utils/api';
 import { safeLocalStorage } from '@/utils/safeLocalStorage';
 import { enforceTipoChatForRubro, parseRubro } from '@/utils/tipoChat';
 import { getIframeToken } from '@/utils/config';
+import { getStoredEntityToken } from '@/utils/entityToken';
 
 interface UserData {
   id?: number;
@@ -39,7 +40,9 @@ const UserContext = React.createContext<UserContextValue>({
 export const UserProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [user, setUser] = useState<UserData | null>(() => {
     try {
-      const hasEntity = safeLocalStorage.getItem('entityToken') || getIframeToken();
+      const storedEntityToken = getStoredEntityToken();
+      const iframeEntityToken = getIframeToken();
+      const hasEntity = storedEntityToken || iframeEntityToken;
       const chatToken = safeLocalStorage.getItem('chatAuthToken');
       if (hasEntity && !chatToken) return null;
       const stored = safeLocalStorage.getItem('user');
@@ -51,7 +54,9 @@ export const UserProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [loading, setLoading] = useState(false);
 
   const refreshUser = useCallback(async () => {
-    const tokenKey = (safeLocalStorage.getItem('entityToken') || getIframeToken()) ? 'chatAuthToken' : 'authToken';
+    const storedEntityToken = getStoredEntityToken();
+    const iframeEntityToken = getIframeToken();
+    const tokenKey = (storedEntityToken || iframeEntityToken) ? 'chatAuthToken' : 'authToken';
     const token = safeLocalStorage.getItem(tokenKey);
     if (!token) return;
     setLoading(true);
@@ -90,7 +95,9 @@ export const UserProvider: React.FC<{ children: React.ReactNode }> = ({ children
       console.error('Error fetching user profile, logging out.', e);
       // If fetching the user fails, the token is likely invalid or expired.
       // Clear the user data and token to force a re-login.
-      const tokenKey = (safeLocalStorage.getItem('entityToken') || getIframeToken()) ? 'chatAuthToken' : 'authToken';
+      const storedEntityToken = getStoredEntityToken();
+      const iframeEntityToken = getIframeToken();
+      const tokenKey = (storedEntityToken || iframeEntityToken) ? 'chatAuthToken' : 'authToken';
       safeLocalStorage.removeItem('user');
       safeLocalStorage.removeItem(tokenKey);
       setUser(null);
@@ -100,7 +107,9 @@ export const UserProvider: React.FC<{ children: React.ReactNode }> = ({ children
   }, []);
 
   useEffect(() => {
-    const tokenKey = (safeLocalStorage.getItem('entityToken') || getIframeToken()) ? 'chatAuthToken' : 'authToken';
+    const storedEntityToken = getStoredEntityToken();
+    const iframeEntityToken = getIframeToken();
+    const tokenKey = (storedEntityToken || iframeEntityToken) ? 'chatAuthToken' : 'authToken';
     const token = safeLocalStorage.getItem(tokenKey);
     if (token && (!user || !user.rubro)) {
       refreshUser();

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { apiFetch, ApiError } from "@/utils/api";
 import { safeLocalStorage } from "@/utils/safeLocalStorage";
+import { storeEntityToken } from "@/utils/entityToken";
 import { useUser } from "@/hooks/useUser";
 import GoogleLoginButton from "@/components/auth/GoogleLoginButton";
 
@@ -41,7 +42,7 @@ const Login = () => {
 
       safeLocalStorage.setItem("authToken", data.token);
       if (data.entityToken) {
-        safeLocalStorage.setItem("entityToken", data.entityToken);
+        storeEntityToken(data.entityToken);
       }
 
       await refreshUser();

--- a/src/pages/iframe.tsx
+++ b/src/pages/iframe.tsx
@@ -7,7 +7,7 @@ import ErrorBoundary from '../components/ErrorBoundary';
 import { MemoryRouter } from "react-router-dom";
 import { getChatbocConfig } from "@/utils/config";
 import { hexToHsl } from "@/utils/color";
-import { safeLocalStorage } from "@/utils/safeLocalStorage";
+import { sanitizeEntityToken, storeEntityToken } from "@/utils/entityToken";
 
 const DEFAULTS = {
   openWidth: "460px",
@@ -44,13 +44,17 @@ const Iframe = () => {
       document.documentElement.style.setProperty("--accent", hexToHsl(accentColorHex));
     }
 
-    const tokenFromUrl = urlParams.get("entityToken") || cfg.entityToken || '';
-    if (tokenFromUrl) {
-      setEntityToken(tokenFromUrl);
-      safeLocalStorage.setItem("entityToken", tokenFromUrl);
+    const rawTokenFromUrl = urlParams.get("entityToken");
+    const sanitizedFromUrl = sanitizeEntityToken(rawTokenFromUrl);
+    const sanitizedFromConfig = sanitizeEntityToken(cfg.entityToken);
+    const finalEntityToken = sanitizedFromUrl ?? sanitizedFromConfig;
+
+    if (finalEntityToken) {
+      setEntityToken(finalEntityToken);
+      storeEntityToken(finalEntityToken);
     } else {
       setEntityToken(null);
-      safeLocalStorage.removeItem("entityToken");
+      storeEntityToken(null);
     }
 
     const endpointFromUrl = urlParams.get("endpoint") || urlParams.get("tipo_chat");

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -1,6 +1,7 @@
 // --- src/services/apiService.ts (CORREGIDO Y COMPLETO) ---
 import type { Ticket, Comment, TicketStatus } from '@/types'; // CAMBIO: Se agrega TicketStatus a la importación
 import { safeLocalStorage } from '@/utils/safeLocalStorage';
+import { getStoredEntityToken } from '@/utils/entityToken';
 
 // Use the same base URL resolution as api.ts. Default to the Vite dev
 // proxy path when no env variable is provided.
@@ -11,7 +12,7 @@ interface CommentsApiResponse { ok: boolean; comentarios: Comment[]; error?: str
 
 async function apiFetch<T>(endpoint:string, options: RequestInit = {}): Promise<T> {
   const userToken = safeLocalStorage.getItem("authToken");
-  const entityToken = safeLocalStorage.getItem("entityToken");
+  const entityToken = getStoredEntityToken();
 
   const headers: HeadersInit = { // Default headers
     ...options.headers,

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -4,6 +4,7 @@ import { BASE_API_URL } from '@/config';
 import { safeLocalStorage } from "@/utils/safeLocalStorage";
 import getOrCreateChatSessionId from "@/utils/chatSessionId"; // Import the new function
 import { getIframeToken } from "@/utils/config";
+import { getStoredEntityToken, sanitizeEntityToken } from "@/utils/entityToken";
 
 export class ApiError extends Error {
   public readonly status: number;
@@ -38,7 +39,12 @@ export async function apiFetch<T>(
 ): Promise<T> {
   const { method = "GET", body, skipAuth, sendAnonId, entityToken, cache } = options;
 
-  const effectiveEntityToken = entityToken ?? getIframeToken();
+  const sanitizedOptionEntityToken = sanitizeEntityToken(entityToken);
+  const storedEntityToken = getStoredEntityToken();
+  const iframeEntityToken = sanitizeEntityToken(getIframeToken());
+  const effectiveEntityToken =
+    sanitizedOptionEntityToken ?? storedEntityToken ?? iframeEntityToken;
+
   const tokenKey = effectiveEntityToken ? "chatAuthToken" : "authToken";
   const token = safeLocalStorage.getItem(tokenKey);
   const anonId = safeLocalStorage.getItem("anon_id");

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,8 +1,14 @@
+import { sanitizeEntityToken } from "./entityToken";
+
 export function getChatbocConfig() {
   const g = (window as any).CHATBOC_CONFIG || {};
+  const sanitizedEntityToken = sanitizeEntityToken(
+    typeof g.entityToken === 'string' ? g.entityToken : null
+  ) || '';
+
   return {
     endpoint: g.endpoint || 'municipio',
-    entityToken: g.entityToken || '',
+    entityToken: sanitizedEntityToken,
     userToken: g.userToken || null,
     defaultOpen: !!g.defaultOpen,
     width: g.width || '460px',
@@ -22,5 +28,6 @@ export function getChatbocConfig() {
 }
 
 export function getIframeToken(): string {
-  return (window as any).CHATBOC_CONFIG?.entityToken || '';
+  const raw = (window as any).CHATBOC_CONFIG?.entityToken;
+  return sanitizeEntityToken(typeof raw === 'string' ? raw : null) || '';
 }

--- a/src/utils/entityToken.ts
+++ b/src/utils/entityToken.ts
@@ -1,0 +1,44 @@
+import { safeLocalStorage } from "./safeLocalStorage";
+
+export const ENTITY_TOKEN_PLACEHOLDER_PREFIX = "demo-anon";
+
+export function sanitizeEntityToken(token?: string | null): string | null {
+  if (!token) return null;
+  const trimmed = token.trim();
+  if (!trimmed) return null;
+  if (trimmed.toLowerCase().startsWith(ENTITY_TOKEN_PLACEHOLDER_PREFIX)) {
+    return null;
+  }
+  return trimmed;
+}
+
+export function storeEntityToken(token?: string | null): string | null {
+  const sanitized = sanitizeEntityToken(token);
+  try {
+    if (sanitized) {
+      safeLocalStorage.setItem("entityToken", sanitized);
+    } else {
+      safeLocalStorage.removeItem("entityToken");
+    }
+  } catch (error) {
+    console.warn("[entityToken] Failed to persist entity token", error);
+  }
+  return sanitized;
+}
+
+export function getStoredEntityToken(): string | null {
+  try {
+    const raw = safeLocalStorage.getItem("entityToken");
+    const sanitized = sanitizeEntityToken(raw);
+    if (!sanitized && raw) {
+      try {
+        safeLocalStorage.removeItem("entityToken");
+      } catch (cleanupError) {
+        console.warn("[entityToken] Failed to remove placeholder entity token", cleanupError);
+      }
+    }
+    return sanitized;
+  } catch {
+    return null;
+  }
+}

--- a/tests/entityToken.test.ts
+++ b/tests/entityToken.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { sanitizeEntityToken, storeEntityToken, getStoredEntityToken } from '@/utils/entityToken';
+import { safeLocalStorage } from '@/utils/safeLocalStorage';
+
+describe('entityToken utilities', () => {
+  beforeEach(() => {
+    safeLocalStorage.clear();
+  });
+
+  it('removes placeholder tokens and whitespace when sanitizing', () => {
+    expect(sanitizeEntityToken('demo-anon')).toBeNull();
+    expect(sanitizeEntityToken(' demo-anon ')).toBeNull();
+    expect(sanitizeEntityToken('demo-anon-123')).toBeNull();
+    expect(sanitizeEntityToken('')).toBeNull();
+    expect(sanitizeEntityToken('  ')).toBeNull();
+  });
+
+  it('returns trimmed token when valid', () => {
+    expect(sanitizeEntityToken('  valid-token  ')).toBe('valid-token');
+  });
+
+  it('persists sanitized tokens and removes placeholders', () => {
+    expect(storeEntityToken('  abc  ')).toBe('abc');
+    expect(getStoredEntityToken()).toBe('abc');
+
+    expect(storeEntityToken('demo-anon')).toBeNull();
+    expect(getStoredEntityToken()).toBeNull();
+  });
+
+  it('cleans up existing placeholder tokens from storage', () => {
+    safeLocalStorage.setItem('entityToken', 'demo-anon-old');
+    expect(getStoredEntityToken()).toBeNull();
+    expect(safeLocalStorage.getItem('entityToken')).toBeNull();
+  });
+});

--- a/widget.js
+++ b/widget.js
@@ -5,6 +5,7 @@
     const SCRIPT_CONFIG = {
       WIDGET_JS_FILENAME: "widget.js",
       DEFAULT_TOKEN: "demo-anon",
+      PLACEHOLDER_PREFIX: "demo-anon",
       DEFAULT_Z_INDEX: "9999",
       DEFAULT_INITIAL_BOTTOM: "24px",
       DEFAULT_INITIAL_RIGHT: "24px",
@@ -28,9 +29,20 @@
       return;
     }
 
+    const sanitizeEntityToken = (token) => {
+      if (!token) return null;
+      const trimmed = token.trim();
+      if (!trimmed) return null;
+      return trimmed.toLowerCase().startsWith(SCRIPT_CONFIG.PLACEHOLDER_PREFIX)
+        ? null
+        : trimmed;
+    };
+
     const ownerTokenAttr =
       script.getAttribute("data-owner-token") || script.getAttribute("data-entity-token");
-    const ownerToken = ownerTokenAttr || SCRIPT_CONFIG.DEFAULT_TOKEN;
+    const trimmedOwnerTokenAttr = ownerTokenAttr ? ownerTokenAttr.trim() : "";
+    const ownerToken = trimmedOwnerTokenAttr || SCRIPT_CONFIG.DEFAULT_TOKEN;
+    const iframeEntityToken = sanitizeEntityToken(trimmedOwnerTokenAttr);
     const registry = (window.__chatbocWidgets = window.__chatbocWidgets || {});
 
     if (registry[ownerToken]) {
@@ -209,7 +221,9 @@
       // Use explicit .html path so integrations without rewrite rules work
       const iframeSrc = new URL(`${apiBase}/iframe.html`);
       iframeSrc.searchParams.set("token", latestToken);
-      iframeSrc.searchParams.set("entityToken", ownerToken);
+      if (iframeEntityToken) {
+        iframeSrc.searchParams.set("entityToken", iframeEntityToken);
+      }
       iframeSrc.searchParams.set("widgetId", iframeId);
       iframeSrc.searchParams.set("defaultOpen", String(defaultOpen));
       iframeSrc.searchParams.set("tipo_chat", tipoChat);


### PR DESCRIPTION
## Summary
- add entity token helpers that strip `demo-anon` placeholders and keep localStorage tidy
- update the widget loaders, iframe bootstrapper, API utilities, and auth forms to reuse the sanitizer so no request sends the fallback token
- cover the new helper with unit tests to guarantee placeholder tokens are dropped

## Testing
- npm test *(fails: existing suite still looks for server/municipal*.cjs fixtures and agendaParser expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68cc76a79cc88322958a4105a54c4823