### PR TITLE
Reset chat session when changing rubro

### DIFF
--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -29,6 +29,7 @@ import { safeOn, assertEventSource } from "@/utils/safeOn";
 import { getVisitorName, setVisitorName } from "@/utils/visitorName";
 import { Loader2 } from "lucide-react";
 import { getInitialMunicipioContext } from "@/utils/contexto_municipio";
+import { resetChatSessionId } from "@/utils/chatSessionId";
 
 const PENDING_TICKET_KEY = 'pending_ticket_id';
 const PENDING_GPS_KEY = 'pending_gps';
@@ -221,6 +222,7 @@ const ChatPanel = ({
       welcomeShownRef.current = false;
       safeLocalStorage.setItem("rubroSeleccionado", nombre);
       setLocalRubro(nombre);
+      resetChatSessionId();
       setMessages([]);
       setActiveTicketId(null);
       setContexto(getInitialMunicipioContext());

--- a/src/pages/Demo.tsx
+++ b/src/pages/Demo.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import { safeLocalStorage } from "@/utils/safeLocalStorage";
+import { resetChatSessionId } from "@/utils/chatSessionId";
 import getOrCreateAnonId from "@/utils/anonId";
 import ChatInput from "@/components/chat/ChatInput";
 import TypingIndicator from "@/components/chat/TypingIndicator";
@@ -36,6 +37,7 @@ const Demo = () => {
 
   const handleChangeRubro = () => {
     safeLocalStorage.removeItem("rubroSeleccionado");
+    resetChatSessionId();
     setRubroSeleccionado(null);
     setEsperandoRubro(true);
     setMessages([]);

--- a/src/utils/chatSessionId.ts
+++ b/src/utils/chatSessionId.ts
@@ -30,4 +30,26 @@ export function getOrCreateChatSessionId(): string {
   }
 }
 
+/**
+ * Resets the current chat session ID by removing the stored value and creating a new one.
+ * Useful when starting a new conversation flow that should not reuse the previous context.
+ */
+export function resetChatSessionId(): string {
+  const newSessionId = uuidv4();
+
+  if (typeof window === 'undefined') {
+    console.warn('resetChatSessionId called in a non-browser environment. Returning a new UUID without persisting it.');
+    return newSessionId;
+  }
+
+  try {
+    safeLocalStorage.removeItem(CHAT_SESSION_ID_KEY);
+    safeLocalStorage.setItem(CHAT_SESSION_ID_KEY, newSessionId);
+  } catch (error) {
+    console.error('Error resetting chat session ID in localStorage:', error);
+  }
+
+  return newSessionId;
+}
+
 export default getOrCreateChatSessionId;


### PR DESCRIPTION
## Summary
- add a resetChatSessionId utility that wipes the persisted chat session ID and stores a freshly generated UUID
- call resetChatSessionId when switching rubros from the demo page and main chat panel so every new rubro conversation starts cleanly

## Testing
- npm run lint *(fails: script not defined in package.json)*
- npm run test *(fails: pre-existing Vitest suite errors resolving server/*.cjs imports and agendaParser expectation)*

------
https://chatgpt.com/codex/tasks/task_e_68cc7cd433648322ad06a4a130635d3d