### PR TITLE
Fix rubro initialization flow for widget and demo

### DIFF
--- a/src/hooks/useChatLogic.ts
+++ b/src/hooks/useChatLogic.ts
@@ -10,7 +10,7 @@ import {
 import { io, Socket } from "socket.io-client";
 import { getSocketUrl } from "@/config";
 import { apiFetch, getErrorMessage } from "@/utils/api";
-import { getAskEndpoint } from "@/utils/chatEndpoints";
+import { getAskEndpoint, parseRubro } from "@/utils/chatEndpoints";
 import { enforceTipoChatForRubro } from "@/utils/tipoChat";
 import { safeLocalStorage } from "@/utils/safeLocalStorage";
 import getOrCreateChatSessionId from "@/utils/chatSessionId";
@@ -27,9 +27,16 @@ interface UseChatLogicOptions {
   entityToken?: string;
   tokenKey?: string;
   skipAuth?: boolean;
+  selectedRubro?: string | null;
 }
 
-export function useChatLogic({ tipoChat, entityToken: propToken, tokenKey = 'authToken', skipAuth = false }: UseChatLogicOptions) {
+export function useChatLogic({
+  tipoChat,
+  entityToken: propToken,
+  tokenKey = 'authToken',
+  skipAuth = false,
+  selectedRubro = null,
+}: UseChatLogicOptions) {
   const entityToken = propToken || getIframeToken();
   const { user } = useUser();
   const [messages, setMessages] = useState<Message[]>([]);
@@ -37,6 +44,116 @@ export function useChatLogic({ tipoChat, entityToken: propToken, tokenKey = 'aut
   const [contexto, setContexto] = useState<MunicipioContext>(() => getInitialMunicipioContext());
   const [activeTicketId, setActiveTicketId] = useState<number | null>(null);
   const [currentClaimIdempotencyKey, setCurrentClaimIdempotencyKey] = useState<string | null>(null);
+  const messagesRef = useRef<Message[]>([]);
+
+  useEffect(() => {
+    messagesRef.current = messages;
+  }, [messages]);
+
+  const sanitizeRubroValue = (value: string | null | undefined) => {
+    if (!value) return null;
+    const trimmed = value.toString().trim();
+    return trimmed.length ? trimmed : null;
+  };
+
+  const initializeConversation = useCallback(
+    async (options?: {
+      rubroOverride?: string | null;
+      resetContext?: boolean;
+      resetMessages?: boolean;
+      force?: boolean;
+    }) => {
+      if (!options?.force && messagesRef.current.length > 0) {
+        return;
+      }
+
+      let rawRubro = sanitizeRubroValue(options?.rubroOverride);
+      if (!rawRubro) {
+        rawRubro = sanitizeRubroValue(selectedRubro);
+      }
+
+      if (!rawRubro) {
+        try {
+          const storedUser = JSON.parse(safeLocalStorage.getItem('user') || 'null');
+          rawRubro =
+            sanitizeRubroValue(storedUser?.rubro?.clave) ||
+            sanitizeRubroValue(storedUser?.rubro?.nombre) ||
+            null;
+        } catch {
+          rawRubro = null;
+        }
+      }
+
+      if (!rawRubro) {
+        rawRubro = sanitizeRubroValue(safeLocalStorage.getItem('rubroSeleccionado'));
+      }
+
+      const normalizedRubro = rawRubro ? parseRubro(rawRubro) : null;
+      const tipoChatFinal = enforceTipoChatForRubro(tipoChat, normalizedRubro || undefined);
+      const rubroForPayload = tipoChatFinal === 'pyme' ? rawRubro : null;
+
+      if (tipoChatFinal === 'pyme' && !rubroForPayload) {
+        console.log('useChatLogic: Rubro no seleccionado para chat pyme, se omite el saludo inicial.');
+        setIsTyping(false);
+        return;
+      }
+
+      if (options?.resetMessages) {
+        setMessages([]);
+        setActiveTicketId(null);
+      }
+
+      const shouldResetContext = options?.resetContext ?? messagesRef.current.length === 0;
+      const contextToSend = shouldResetContext ? getInitialMunicipioContext() : contexto;
+      if (shouldResetContext) {
+        setContexto(contextToSend);
+      }
+
+      const visitorName = getVisitorName();
+      const endpoint = getAskEndpoint({
+        tipoChat: tipoChatFinal,
+        rubro: normalizedRubro || null,
+      });
+
+      console.log('useChatLogic: Enviando saludo inicial', {
+        endpoint,
+        tipoChatFinal,
+        rubroForPayload,
+      });
+
+      setIsTyping(true);
+
+      try {
+        await apiFetch<any>(endpoint, {
+          method: 'POST',
+          skipAuth,
+          body: {
+            pregunta: '',
+            action: 'initial_greeting',
+            contexto_previo: contextToSend,
+            tipo_chat: tipoChatFinal,
+            ...(rubroForPayload && { rubro_clave: rubroForPayload }),
+            ...(visitorName && { nombre_usuario: visitorName }),
+          },
+        });
+      } catch (error) {
+        console.error('Error sending initial greeting:', getErrorMessage(error));
+        const errorMsg = getErrorMessage(error, '⚠️ No se pudo cargar el menú inicial.');
+        setMessages(prev => [
+          ...prev,
+          {
+            id: generateClientMessageId(),
+            text: errorMsg,
+            isBot: true,
+            timestamp: new Date(),
+            isError: true,
+          },
+        ]);
+        setIsTyping(false);
+      }
+    },
+    [contexto, selectedRubro, skipAuth, tipoChat]
+  );
 
   const token = skipAuth ? null : safeLocalStorage.getItem(tokenKey);
   const isAnonimo = skipAuth || !token;
@@ -281,31 +398,7 @@ export function useChatLogic({ tipoChat, entityToken: propToken, tokenKey = 'aut
       console.log('Socket.IO connected, joining room with web channel...');
       socket.emit('join', { room: sessionId, channel: 'web' });
 
-      // Automatically send a silent greeting to fetch the main menu on connect.
-      const endpoint = getAskEndpoint({ tipoChat, rubro: null });
-      const initialContext = getInitialMunicipioContext();
-
-      console.log("useChatLogic: Sending initial greeting to fetch menu.");
-      setIsTyping(true);
-
-      const initialName = getVisitorName();
-      apiFetch<any>(endpoint, {
-        method: 'POST',
-        skipAuth,
-        body: {
-          pregunta: '',
-          action: 'initial_greeting',
-          contexto_previo: initialContext,
-          tipo_chat: tipoChat,
-          ...(initialName && { nombre_usuario: initialName }),
-        },
-      })
-        .catch(error => {
-          console.error("Error sending initial greeting:", getErrorMessage(error));
-          const errorMsg = getErrorMessage(error, '⚠️ No se pudo cargar el menú inicial.');
-          setMessages(prev => [...prev, { id: generateClientMessageId(), text: errorMsg, isBot: true, timestamp: new Date(), isError: true }]);
-          setIsTyping(false);
-        });
+      initializeConversation({ resetContext: true });
     };
 
     const handleConnectError = (err: any) => {
@@ -594,7 +687,7 @@ export function useChatLogic({ tipoChat, entityToken: propToken, tokenKey = 'aut
       socket.off?.('disconnect', handleDisconnect);
       socket.disconnect();
     };
-}, [entityToken, tipoChat]);
+}, [entityToken, initializeConversation, tipoChat]);
 
   useEffect(() => {
     if (contexto.estado_conversacion === 'confirmando_reclamo' && !activeTicketId) {
@@ -809,5 +902,16 @@ export function useChatLogic({ tipoChat, entityToken: propToken, tokenKey = 'aut
     }
   }, [contexto, activeTicketId, isTyping, isAnonimo, currentClaimIdempotencyKey, tipoChat]);
 
-  return { messages, isTyping, handleSend, activeTicketId, setMessages, setContexto, setActiveTicketId, contexto, addSystemMessage };
+  return {
+    messages,
+    isTyping,
+    handleSend,
+    activeTicketId,
+    setMessages,
+    setContexto,
+    setActiveTicketId,
+    contexto,
+    addSystemMessage,
+    initializeConversation,
+  };
 }


### PR DESCRIPTION
## Summary
- add a rubro-aware `initializeConversation` helper to `useChatLogic` so greetings are only sent once a valid selection exists
- reset and bootstrap widget chat sessions through the new initializer when a rubro is chosen or supplied by the host
- replace the demo page’s hardcoded welcome with an API-driven greeting that mirrors the production flow

## Testing
- npm test *(fails: relies on missing server `.cjs` fixtures and an existing agenda parser expectation mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68cc842a754c8322937d93d513870d6c