### PR TITLE
Align widget owner token and polish link rendering

### DIFF
--- a/src/components/chat/ChatMessageBase.tsx
+++ b/src/components/chat/ChatMessageBase.tsx
@@ -1,6 +1,6 @@
 // src/components/chat/ChatMessageBase.tsx
 import React, { useState, useMemo } from "react";
-import { Message, SendPayload, StructuredContentItem } from "@/types/chat";
+import { Boton, Message, SendPayload, StructuredContentItem } from "@/types/chat";
 import ChatButtons from "./ChatButtons";
 import CategorizedButtons from "./CategorizedButtons";
 import AudioPlayer from "./AudioPlayer";
@@ -58,6 +58,107 @@ function normalizeAttachment(msg: any): RawAttachment | null {
   }
   return null;
 }
+
+const LINK_LABEL_MAX_LENGTH = 48;
+const FALLBACK_URL_BASE = "https://chatboc.local";
+
+const createDomParser = () => {
+  if (typeof window !== "undefined" && typeof window.DOMParser !== "undefined") {
+    return new window.DOMParser();
+  }
+  if (typeof DOMParser !== "undefined") {
+    return new DOMParser();
+  }
+  return null;
+};
+
+const normaliseUrlForKey = (url: string) => {
+  try {
+    const parsed = new URL(url, url.startsWith("http") ? undefined : FALLBACK_URL_BASE);
+    return parsed.href.replace(/\/+$/, "").toLowerCase();
+  } catch {
+    return url.trim().toLowerCase();
+  }
+};
+
+const buttonKey = (button: Boton): string => {
+  if (button.action) return `action:${button.action.trim().toLowerCase()}`;
+  if (button.accion_interna) return `internal:${button.accion_interna.trim().toLowerCase()}`;
+  if (button.url) return `url:${normaliseUrlForKey(button.url)}`;
+  if (button.texto) return `text:${button.texto.trim().toLowerCase()}`;
+  return Math.random().toString(36);
+};
+
+const formatLinkLabel = (rawText: string | null | undefined, href: string): string => {
+  const normalizedHref = href?.trim?.() ?? "";
+  const cleanedText = rawText?.replace(/\s+/g, " ")?.trim() ?? "";
+
+  const textLooksLikeUrl = cleanedText.length > 0 &&
+    cleanedText.replace(/\/?$/, "").toLowerCase() === normalizedHref.replace(/\/?$/, "").toLowerCase();
+
+  let candidate = cleanedText || normalizedHref;
+
+  if (!cleanedText || cleanedText.length > LINK_LABEL_MAX_LENGTH || textLooksLikeUrl) {
+    try {
+      const url = new URL(normalizedHref, normalizedHref.startsWith("http") ? undefined : FALLBACK_URL_BASE);
+      const hostname = url.hostname.replace(/^www\./i, "");
+      const firstSegment = url.pathname.split("/").filter(Boolean)[0];
+      candidate = firstSegment ? `${hostname} / ${firstSegment}` : hostname || normalizedHref;
+    } catch {
+      candidate = cleanedText || normalizedHref;
+    }
+  }
+
+  if (candidate.length > LINK_LABEL_MAX_LENGTH) {
+    return `${candidate.slice(0, LINK_LABEL_MAX_LENGTH - 3)}…`;
+  }
+
+  return candidate;
+};
+
+const extractLinkButtons = (
+  html: string
+): { cleanedHtml: string; linkButtons: Boton[] } => {
+  if (!html) {
+    return { cleanedHtml: "", linkButtons: [] };
+  }
+
+  const parser = createDomParser();
+  if (!parser) {
+    return { cleanedHtml: html, linkButtons: [] };
+  }
+
+  try {
+    const doc = parser.parseFromString(`<div>${html}</div>`, "text/html");
+    const container = doc.body.firstElementChild as HTMLElement | null;
+    if (!container) {
+      return { cleanedHtml: html, linkButtons: [] };
+    }
+
+    const anchors = Array.from(container.querySelectorAll("a"));
+    const derivedButtons: Boton[] = [];
+
+    anchors.forEach((anchor) => {
+      const href = anchor.getAttribute("href");
+      if (!href) {
+        return;
+      }
+      const label = formatLinkLabel(anchor.textContent, href);
+      derivedButtons.push({ texto: label, url: href });
+      const replacement = doc.createElement("span");
+      replacement.textContent = label;
+      replacement.className = "chat-link-placeholder";
+      anchor.replaceWith(replacement);
+    });
+
+    return {
+      cleanedHtml: container.innerHTML,
+      linkButtons: derivedButtons,
+    };
+  } catch {
+    return { cleanedHtml: html, linkButtons: [] };
+  }
+};
 
 // --- Avatares (reutilizados de ChatMessagePyme/Municipio) ---
 const AvatarBot: React.FC<{ isTyping: boolean; logoUrl?: string; logoAnimation?: string }> = ({
@@ -206,6 +307,43 @@ const ChatMessageBase = React.forwardRef<HTMLDivElement, ChatMessageBaseProps>( 
 
   const safeText = typeof message.text === "string" && message.text !== "NaN" ? message.text : "";
   const sanitizedHtml = sanitizeMessageHtml(safeText);
+  const { cleanedHtml, linkButtons } = useMemo(() => {
+    if (!isBot) {
+      return { cleanedHtml: sanitizedHtml, linkButtons: [] as Boton[] };
+    }
+    return extractLinkButtons(sanitizedHtml);
+  }, [isBot, sanitizedHtml]);
+
+  const { combinedButtons, derivedLinkButtons } = useMemo(() => {
+    const existing = Array.isArray(message.botones) ? message.botones : [];
+    if (!linkButtons.length) {
+      return {
+        combinedButtons: existing,
+        derivedLinkButtons: [] as Boton[],
+      };
+    }
+
+    const seen = new Set<string>();
+    const combined: Boton[] = [];
+    const derivedOnly: Boton[] = [];
+
+    const register = (button: Boton, isDerived: boolean) => {
+      if (!button) return;
+      const key = buttonKey(button);
+      if (seen.has(key)) return;
+      seen.add(key);
+      combined.push(button);
+      if (isDerived) {
+        derivedOnly.push(button);
+      }
+    };
+
+    existing.forEach((btn) => register(btn, false));
+    linkButtons.forEach((btn) => register(btn, true));
+
+    return { combinedButtons: combined, derivedLinkButtons: derivedOnly };
+  }, [message.botones, linkButtons]);
+
   const plainText = useMemo(() => safeText.replace(/<[^>]+>/g, ""), [safeText]);
   const simplified = useMemo(() => simplify(plainText), [plainText]);
   const [simple, setSimple] = useState<boolean>(() => {
@@ -222,11 +360,11 @@ const ChatMessageBase = React.forwardRef<HTMLDivElement, ChatMessageBaseProps>( 
   ) : (
     <div
       className="whitespace-pre-wrap text-justify max-w-none text-sm [&_p]:my-0 mb-2 chat-message"
-      dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
+      dangerouslySetInnerHTML={{ __html: cleanedHtml }}
     />
   );
 
-  const textBlock = sanitizedHtml
+  const textBlock = cleanedHtml
     ? isBot
       ? (
           <>
@@ -256,9 +394,9 @@ const ChatMessageBase = React.forwardRef<HTMLDivElement, ChatMessageBaseProps>( 
   ) : null;
 
   const textAndListBlock =
-    (sanitizedHtml || listBlock) ? (
+    (cleanedHtml || listBlock) ? (
       <>
-        {sanitizedHtml && textBlock}
+        {cleanedHtml && textBlock}
         {listBlock}
       </>
     ) : null;
@@ -358,7 +496,7 @@ const ChatMessageBase = React.forwardRef<HTMLDivElement, ChatMessageBaseProps>( 
                 message={message} // Pasamos el mensaje completo para que AttachmentPreview decida
                 attachmentInfo={processedAttachmentInfo}
                 // Si hay adjunto pero también texto, el texto puede ser un caption o fallback
-                fallbackText={sanitizedHtml && !showStructuredContent && !audioSrc ? sanitizedHtml : undefined}
+                fallbackText={cleanedHtml && !showStructuredContent && !audioSrc ? cleanedHtml : undefined}
               />
           )}
 
@@ -393,14 +531,23 @@ const ChatMessageBase = React.forwardRef<HTMLDivElement, ChatMessageBaseProps>( 
 
           {/* Botones (categorized or flat) */}
           {isBot && message.categorias && message.categorias.length > 0 ? (
-            <CategorizedButtons
-              categorias={message.categorias}
-              onButtonClick={onButtonClick}
-              onInternalAction={onInternalAction}
-            />
-          ) : isBot && message.botones && message.botones.length > 0 ? (
+            <>
+              <CategorizedButtons
+                categorias={message.categorias}
+                onButtonClick={onButtonClick}
+                onInternalAction={onInternalAction}
+              />
+              {derivedLinkButtons.length > 0 && (
+                <ChatButtons
+                  botones={derivedLinkButtons}
+                  onButtonClick={onButtonClick}
+                  onInternalAction={onInternalAction}
+                />
+              )}
+            </>
+          ) : isBot && combinedButtons.length > 0 ? (
             <ChatButtons
-              botones={message.botones}
+              botones={combinedButtons}
               onButtonClick={onButtonClick}
               onInternalAction={onInternalAction}
             />

--- a/src/index.css
+++ b/src/index.css
@@ -243,6 +243,51 @@ body,
   text-underline-offset: 2px;
 }
 
+.chat-message a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 9999px;
+  background: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+  text-decoration: none;
+  font-weight: 600;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.14);
+  margin-top: 0.5rem;
+  margin-right: 0.5rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+  max-width: min(100%, 280px);
+  white-space: normal;
+  word-break: break-word;
+  text-align: center;
+}
+
+.chat-message a:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.18);
+}
+
+.chat-message a:active {
+  transform: translateY(0);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.2);
+}
+
+.chat-message a svg {
+  width: 0.9rem;
+  height: 0.9rem;
+}
+
+.chat-message a + a {
+  margin-left: 0.35rem;
+}
+
+.chat-message .chat-link-placeholder {
+  font-weight: 600;
+  color: hsl(var(--foreground));
+}
+
 @keyframes float {
   0%,100% { transform: translateY(0); }
   50% { transform: translateY(-6px); }

--- a/src/pages/iframe.tsx
+++ b/src/pages/iframe.tsx
@@ -116,7 +116,7 @@ const Iframe = () => {
   const ChatWidgetComponent = () => (
     <ChatWidget
       mode="iframe"
-      entityToken={entityToken}
+      ownerToken={entityToken || undefined}
       defaultOpen={widgetParams.defaultOpen}
       widgetId={widgetParams.widgetId}
       tipoChat={tipoChat || undefined}


### PR DESCRIPTION
## Summary
- ensure the iframe-hosted widget forwards the entity token as the ChatWidget owner token so backend profiles and rubros load inside the embed
- normalize bot message rendering by extracting inline anchors into dedicated buttons while merging with backend-provided actions
- refresh chat transcript link styling so anchors render as compact UX-friendly pills instead of raw URLs

## Testing
- npm test *(fails: existing suite requires server-side fixtures and agenda parser expectation updates)*

------
https://chatgpt.com/codex/tasks/task_e_68cd3acaa72c8322b007d154021bda6d