### PR TITLE
Fix iframe preview token handling

### DIFF
--- a/src/pages/Integracion.tsx
+++ b/src/pages/Integracion.tsx
@@ -151,7 +151,7 @@ ${customAttrs ? customAttrs + "\n" : ""}></script>`;
 
   const iframeSrcUrl = useMemo(() => {
     const url = new URL(`${apiBase}/iframe`);
-    url.searchParams.set("ownerToken", ownerToken);
+    url.searchParams.set("entityToken", ownerToken);
     url.searchParams.set("tipo_chat", endpoint);
     if (primaryColor) url.searchParams.set("primaryColor", primaryColor);
     if (accentColor) url.searchParams.set("accentColor", accentColor);
@@ -165,7 +165,7 @@ ${customAttrs ? customAttrs + "\n" : ""}></script>`;
 
   const previewIframeUrl = useMemo(() => {
     const url = new URL(`${iframeBase}/iframe`);
-    url.searchParams.set("ownerToken", ownerToken);
+    url.searchParams.set("entityToken", ownerToken);
     url.searchParams.set("tipo_chat", endpoint);
     if (primaryColor) url.searchParams.set("primaryColor", primaryColor);
     if (accentColor) url.searchParams.set("accentColor", accentColor);

--- a/src/pages/iframe.tsx
+++ b/src/pages/iframe.tsx
@@ -44,7 +44,11 @@ const Iframe = () => {
       document.documentElement.style.setProperty("--accent", hexToHsl(accentColorHex));
     }
 
-    const tokenFromUrl = urlParams.get("entityToken") || cfg.entityToken || '';
+    const tokenFromUrl =
+      urlParams.get("entityToken") ||
+      urlParams.get("ownerToken") ||
+      cfg.entityToken ||
+      '';
     if (tokenFromUrl) {
       setEntityToken(tokenFromUrl);
       safeLocalStorage.setItem("entityToken", tokenFromUrl);


### PR DESCRIPTION
## Summary
- ensure the integration page generates iframe URLs with the entity token parameter expected by the widget runtime
- allow the iframe runtime to fall back to an ownerToken query parameter for backward compatibility when loading

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd4f30b4508322be0c7e57d12c2c8b