### PR TITLE
Ensure iframe widget propagates entity token

### DIFF
--- a/public/iframe.html
+++ b/public/iframe.html
@@ -50,25 +50,57 @@
     // Config que llega por query (encapsulada para no contaminar el global)
     (() => {
       const params = new URLSearchParams(location.search);
+      const endpoint =
+        params.get('endpoint') ||
+        params.get('tipo_chat') ||
+        'municipio';
+      const entityToken =
+        params.get('entityToken') ||
+        params.get('ownerToken') ||
+        '';
+      const openWidth = params.get('openWidth') || params.get('width') || '460px';
+      const openHeight = params.get('openHeight') || params.get('height') || '680px';
+      const closedWidth = params.get('closedWidth') || '72px';
+      const closedHeight = params.get('closedHeight') || '72px';
+      const bottom = params.get('bottom') || '20px';
+      const right = params.get('right') || '20px';
+      const primaryColor = params.get('primaryColor') || '#007aff';
+      const accentColor = params.get('accentColor') || '';
+      const logoUrl = params.get('logoUrl') || '';
+      const headerLogoUrl = params.get('headerLogoUrl') || logoUrl;
+      const logoAnimation = params.get('logoAnimation') || '';
+      const welcomeTitle = params.get('welcomeTitle') || '';
+      const welcomeSubtitle = params.get('welcomeSubtitle') || '';
+
       window.CHATBOC_CONFIG = {
-        endpoint: params.get('endpoint') || 'municipio',
-        entityToken: params.get('entityToken') || '',
+        endpoint,
+        entityToken,
         userToken: params.get('userToken') || null,
         defaultOpen: params.get('defaultOpen') === 'true',
-        width: params.get('width') || '460px',
-        height: params.get('height') || '680px',
-        closedWidth: params.get('closedWidth') || '72px',
-        closedHeight: params.get('closedHeight') || '72px',
-        bottom: params.get('bottom') || '20px',
-        right: params.get('right') || '20px',
-        primaryColor: params.get('primaryColor') || '#007aff',
-        accentColor: params.get('accentColor') || '',
-        logoUrl: params.get('logoUrl') || '',
-        headerLogoUrl: params.get('headerLogoUrl') || params.get('logoUrl') || '',
-        logoAnimation: params.get('logoAnimation') || '',
-        welcomeTitle: params.get('welcomeTitle') || '',
-        welcomeSubtitle: params.get('welcomeSubtitle') || ''
+        width: openWidth,
+        height: openHeight,
+        closedWidth,
+        closedHeight,
+        bottom,
+        right,
+        primaryColor,
+        accentColor,
+        logoUrl,
+        headerLogoUrl,
+        logoAnimation,
+        welcomeTitle,
+        welcomeSubtitle
       };
+
+      try {
+        if (entityToken) {
+          localStorage.setItem('entityToken', entityToken);
+        } else {
+          localStorage.removeItem('entityToken');
+        }
+      } catch (err) {
+        console.warn('No se pudo persistir el entityToken en localStorage.', err);
+      }
     })();
   </script>
 

--- a/src/pages/Integracion.tsx
+++ b/src/pages/Integracion.tsx
@@ -151,7 +151,7 @@ ${customAttrs ? customAttrs + "\n" : ""}></script>`;
 
   const iframeSrcUrl = useMemo(() => {
     const url = new URL(`${apiBase}/iframe`);
-    url.searchParams.set("ownerToken", ownerToken);
+    url.searchParams.set("entityToken", ownerToken);
     url.searchParams.set("tipo_chat", endpoint);
     if (primaryColor) url.searchParams.set("primaryColor", primaryColor);
     if (accentColor) url.searchParams.set("accentColor", accentColor);
@@ -165,7 +165,7 @@ ${customAttrs ? customAttrs + "\n" : ""}></script>`;
 
   const previewIframeUrl = useMemo(() => {
     const url = new URL(`${iframeBase}/iframe`);
-    url.searchParams.set("ownerToken", ownerToken);
+    url.searchParams.set("entityToken", ownerToken);
     url.searchParams.set("tipo_chat", endpoint);
     if (primaryColor) url.searchParams.set("primaryColor", primaryColor);
     if (accentColor) url.searchParams.set("accentColor", accentColor);

--- a/src/pages/iframe.tsx
+++ b/src/pages/iframe.tsx
@@ -44,47 +44,99 @@ const Iframe = () => {
       document.documentElement.style.setProperty("--accent", hexToHsl(accentColorHex));
     }
 
-    const tokenFromUrl = urlParams.get("entityToken") || cfg.entityToken || '';
-    if (tokenFromUrl) {
-      setEntityToken(tokenFromUrl);
-      safeLocalStorage.setItem("entityToken", tokenFromUrl);
+    const rawEntityToken =
+      urlParams.get("entityToken") ||
+      urlParams.get("ownerToken") ||
+      cfg.entityToken ||
+      '';
+    if (rawEntityToken) {
+      setEntityToken(rawEntityToken);
+      safeLocalStorage.setItem("entityToken", rawEntityToken);
     } else {
       setEntityToken(null);
       safeLocalStorage.removeItem("entityToken");
     }
 
     const endpointFromUrl = urlParams.get("endpoint") || urlParams.get("tipo_chat");
-    const endpointParam =
+    const configEndpoint =
       cfg.endpoint === 'pyme' || cfg.endpoint === 'municipio'
         ? (cfg.endpoint as 'pyme' | 'municipio')
-        : endpointFromUrl === 'pyme' || endpointFromUrl === 'municipio'
-          ? (endpointFromUrl as 'pyme' | 'municipio')
-          : null;
-    if (endpointParam) {
-      setTipoChat(endpointParam);
+        : null;
+    const endpointParam =
+      endpointFromUrl === 'pyme' || endpointFromUrl === 'municipio'
+        ? (endpointFromUrl as 'pyme' | 'municipio')
+        : null;
+    const resolvedEndpoint = endpointParam || configEndpoint || null;
+    if (resolvedEndpoint) {
+      setTipoChat(resolvedEndpoint);
     }
 
+    const widgetId = urlParams.get("widgetId") || "chatboc-iframe-unknown";
+    const view = urlParams.get("view") || 'chat';
+    const defaultOpenParam = urlParams.get("defaultOpen");
+    const defaultOpen =
+      typeof defaultOpenParam === 'string'
+        ? defaultOpenParam === 'true'
+        : cfg.defaultOpen;
+    const openWidth = urlParams.get("openWidth") || cfg.width || DEFAULTS.openWidth;
+    const openHeight = urlParams.get("openHeight") || cfg.height || DEFAULTS.openHeight;
+    const closedWidth = urlParams.get("closedWidth") || cfg.closedWidth || DEFAULTS.closedWidth;
+    const closedHeight = urlParams.get("closedHeight") || cfg.closedHeight || DEFAULTS.closedHeight;
+    const bottomParam = urlParams.get("bottom") || cfg.bottom || String(DEFAULTS.bottom);
+    const rightParam = urlParams.get("right") || cfg.right || String(DEFAULTS.right);
+    const bottomValue = Number.parseInt(bottomParam, 10);
+    const rightValue = Number.parseInt(rightParam, 10);
+    const logoUrl = urlParams.get("logoUrl") || cfg.logoUrl || '';
+    const headerLogoUrl = urlParams.get("headerLogoUrl") || cfg.headerLogoUrl || '';
+    const logoAnimation = urlParams.get("logoAnimation") || cfg.logoAnimation || '';
+    const welcomeTitle = urlParams.get("welcomeTitle") || cfg.welcomeTitle || '';
+    const welcomeSubtitle = urlParams.get("welcomeSubtitle") || cfg.welcomeSubtitle || '';
+
     setWidgetParams({
-      defaultOpen: cfg.defaultOpen,
-      widgetId: urlParams.get("widgetId") || "chatboc-iframe-unknown",
-      view: urlParams.get("view") || 'chat',
-      openWidth: urlParams.get("openWidth") || cfg.width || DEFAULTS.openWidth,
-      openHeight: urlParams.get("openHeight") || cfg.height || DEFAULTS.openHeight,
-      closedWidth: urlParams.get("closedWidth") || cfg.closedWidth || DEFAULTS.closedWidth,
-      closedHeight: urlParams.get("closedHeight") || cfg.closedHeight || DEFAULTS.closedHeight,
+      defaultOpen,
+      widgetId,
+      view,
+      openWidth,
+      openHeight,
+      closedWidth,
+      closedHeight,
       ctaMessage: urlParams.get("ctaMessage") || undefined,
       rubro: urlParams.get("rubro") || undefined,
-      endpoint: endpointParam || undefined,
-      bottom: parseInt(urlParams.get("bottom") || cfg.bottom || String(DEFAULTS.bottom), 10),
-      right: parseInt(urlParams.get("right") || cfg.right || String(DEFAULTS.right), 10),
+      endpoint: resolvedEndpoint || undefined,
+      bottom: Number.isFinite(bottomValue) ? bottomValue : DEFAULTS.bottom,
+      right: Number.isFinite(rightValue) ? rightValue : DEFAULTS.right,
       primaryColor: primaryColorHex,
       accentColor: accentColorHex,
-      logoUrl: urlParams.get("logoUrl") || cfg.logoUrl || '',
-      headerLogoUrl: urlParams.get("headerLogoUrl") || cfg.headerLogoUrl || '',
-      logoAnimation: urlParams.get("logoAnimation") || cfg.logoAnimation || '',
-      welcomeTitle: urlParams.get("welcomeTitle") || cfg.welcomeTitle || '',
-      welcomeSubtitle: urlParams.get("welcomeSubtitle") || cfg.welcomeSubtitle || '',
+      logoUrl,
+      headerLogoUrl,
+      logoAnimation,
+      welcomeTitle,
+      welcomeSubtitle,
     });
+
+    const mergedConfig = {
+      ...cfg,
+      endpoint: resolvedEndpoint || cfg.endpoint || 'pyme',
+      entityToken: rawEntityToken || '',
+      defaultOpen,
+      width: openWidth,
+      height: openHeight,
+      closedWidth,
+      closedHeight,
+      bottom: bottomParam,
+      right: rightParam,
+      primaryColor: primaryColorHex,
+      accentColor: accentColorHex,
+      logoUrl,
+      headerLogoUrl,
+      logoAnimation,
+      welcomeTitle,
+      welcomeSubtitle,
+    };
+
+    if (typeof window !== 'undefined') {
+      (window as any).CHATBOC_CONFIG = mergedConfig;
+    }
 
     setIsLoading(false);
   }, []);
@@ -140,10 +192,10 @@ const Iframe = () => {
   if (!GOOGLE_CLIENT_ID) {
     return (
       <MemoryRouter>
-      <ChatWidgetComponent />
-    </MemoryRouter>
-  );
-}
+        <ChatWidgetComponent />
+      </MemoryRouter>
+    );
+  }
 
   return (
     <GoogleOAuthProvider clientId={GOOGLE_CLIENT_ID}>

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,8 +1,15 @@
+import { safeLocalStorage } from '@/utils/safeLocalStorage';
+
 export function getChatbocConfig() {
   const g = (window as any).CHATBOC_CONFIG || {};
+  const storedToken = safeLocalStorage.getItem('entityToken') || '';
+  const effectiveEntityToken =
+    typeof g.entityToken === 'string' && g.entityToken.trim()
+      ? g.entityToken
+      : storedToken;
   return {
     endpoint: g.endpoint || 'municipio',
-    entityToken: g.entityToken || '',
+    entityToken: effectiveEntityToken,
     userToken: g.userToken || null,
     defaultOpen: !!g.defaultOpen,
     width: g.width || '460px',
@@ -22,5 +29,14 @@ export function getChatbocConfig() {
 }
 
 export function getIframeToken(): string {
-  return (window as any).CHATBOC_CONFIG?.entityToken || '';
+  const globalToken = (window as any).CHATBOC_CONFIG?.entityToken;
+  if (typeof globalToken === 'string' && globalToken.trim()) {
+    return globalToken;
+  }
+
+  try {
+    return safeLocalStorage.getItem('entityToken') || '';
+  } catch {
+    return '';
+  }
 }


### PR DESCRIPTION
## Summary
- normalize the iframe runtime so it persists entity tokens from query params, updates the global config, and reuses values for preview widgets
- let `getChatbocConfig`/`getIframeToken` fall back to the token saved in safeLocalStorage so API calls always send `X-Entity-Token`
- teach the static iframe bootstrap page to accept legacy ownerToken params and store the token for subsequent requests

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd4f30b4508322be0c7e57d12c2c8b