### PR TITLE
Fix widget token reuse in CDN widget

### DIFF
--- a/cdn/widget.js
+++ b/cdn/widget.js
@@ -725,7 +725,7 @@ if (typeof window !== "undefined") {
 
       unsubscribeAuth = authManager.subscribe((token) => {
         latestToken = token;
-        postToIframe({ type: "AUTH", token });
+        postToIframe({ type: "AUTH", token: latestToken });
       });
 
       function dragStart(event) {

--- a/widget.js
+++ b/widget.js
@@ -338,7 +338,6 @@
     const tipoChat =
       endpointAttr === "municipio" || endpointAttr === "pyme" ? endpointAttr : "pyme";
 
-    let latestToken = null;
     function buildWidget(finalCta) {
       const zIndexBase = parseInt(script.getAttribute("data-z") || SCRIPT_CONFIG.DEFAULT_Z_INDEX, 10);
       const iframeId = `chatboc-dynamic-iframe-${Math.random().toString(36).substring(2, 9)}`;
@@ -644,7 +643,7 @@
 
       unsubscribeAuth = authManager.subscribe((token) => {
         latestToken = token;
-        postToIframe({ type: "AUTH", token });
+        postToIframe({ type: "AUTH", token: latestToken });
       });
 
       // Global API


### PR DESCRIPTION
## Summary
- stop reinitializing the widget iframe token so the minted JWT is reused for the initial src
- ensure the CDN bundle posts refreshed tokens using the shared latestToken reference

## Testing
- manual verification of iframe token parameter and /perfil response using local mock API

------
https://chatgpt.com/codex/tasks/task_e_68cd752649ec8322b1cdd3e039651d70