### PR TITLE
Handle MapLibre dynamic import fallback

### DIFF
--- a/src/components/MapLibreMap.tsx
+++ b/src/components/MapLibreMap.tsx
@@ -59,7 +59,17 @@ export default function MapLibreMap({
 
     const initMap = async () => {
       try {
-        const maplibre = (await import("maplibre-gl")).default;
+        const maplibreModule = await import("maplibre-gl");
+        const maplibre = (
+          maplibreModule as typeof import("maplibre-gl") & {
+            default?: typeof import("maplibre-gl");
+          }
+        ).default ?? maplibreModule;
+
+        if (!maplibre?.Map) {
+          throw new Error("MapLibre library failed to load");
+        }
+
         libRef.current = maplibre;
 
         if (!isMounted || !mapContainerRef.current) return;


### PR DESCRIPTION
## Summary
- ensure the MapLibre dynamic import falls back to the module itself when no default export is present
- surface a clear error if MapLibre fails to load before attempting to construct the map instance

## Testing
- `npm test` *(fails: several existing suites require ../server/*.cjs fixtures that are absent in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd7d3493a88322922c73723d6b0cf1