### PR TITLE
Preserve ticket message attachments

### DIFF
--- a/src/components/tickets/DetailsPanel.tsx
+++ b/src/components/tickets/DetailsPanel.tsx
@@ -149,7 +149,7 @@ const normalizeAttachment = (raw: any, fallbackIndex: number): Attachment | null
   };
 };
 
-const collectAttachmentsFromTicket = (ticket?: Ticket | null, extraMessages?: Message[]): Attachment[] => {
+export const collectAttachmentsFromTicket = (ticket?: Ticket | null, extraMessages?: Message[]): Attachment[] => {
   if (!ticket && !extraMessages?.length) {
     return [];
   }

--- a/src/services/ticketService.ts
+++ b/src/services/ticketService.ts
@@ -165,22 +165,45 @@ export const getTicketMessages = async (
       return Boolean(val);
     };
 
-    return rawMsgs.map((m: any, idx: number) => ({
-      id: m.id ?? idx,
-      author: parseAdminFlag(m.es_admin ?? m.esAdmin ?? m.is_admin ?? m.isAdmin)
-        ? 'agent'
-        : 'user',
-      agentName: m.nombre_agente || m.agentName,
-      content: m.content || m.texto || m.mensaje || '',
-      timestamp:
-        typeof m.timestamp === 'number'
-          ? new Date(m.timestamp).toISOString()
-          : m.timestamp || m.fecha || new Date().toISOString(),
-      attachments: m.attachments || m.adjuntos,
-      botones: m.botones,
-      structuredContent: m.structuredContent,
-      ubicacion: m.ubicacion,
-    }));
+    return rawMsgs.map((m: any, idx: number) => {
+      const combinedAttachments: any[] = [];
+      for (const value of [
+        m.archivos_adjuntos,
+        m.attachments,
+        m.adjuntos,
+      ]) {
+        if (!value) {
+          continue;
+        }
+        if (Array.isArray(value)) {
+          combinedAttachments.push(...value);
+        } else {
+          combinedAttachments.push(value);
+        }
+      }
+      const normalizedAttachments =
+        combinedAttachments.length > 0 ? combinedAttachments : undefined;
+
+      return {
+        id: m.id ?? idx,
+        author: parseAdminFlag(
+          m.es_admin ?? m.esAdmin ?? m.is_admin ?? m.isAdmin,
+        )
+          ? 'agent'
+          : 'user',
+        agentName: m.nombre_agente || m.agentName,
+        content: m.content || m.texto || m.mensaje || '',
+        timestamp:
+          typeof m.timestamp === 'number'
+            ? new Date(m.timestamp).toISOString()
+            : m.timestamp || m.fecha || new Date().toISOString(),
+        attachments: normalizedAttachments,
+        archivos_adjuntos: normalizedAttachments,
+        botones: m.botones,
+        structuredContent: m.structuredContent,
+        ubicacion: m.ubicacion,
+      };
+    });
   } catch (error) {
     console.error(`Error fetching messages for ticket ${ticketId}:`, error);
     throw error;

--- a/tests/getTicketMessages.test.ts
+++ b/tests/getTicketMessages.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { getTicketMessages } from '../src/services/ticketService';
+import { collectAttachmentsFromTicket } from '../src/components/tickets/DetailsPanel';
+import type { Ticket } from '../src/types/tickets';
 import { apiFetch } from '@/utils/api';
 
 vi.mock('@/utils/api', () => ({
@@ -7,6 +9,10 @@ vi.mock('@/utils/api', () => ({
 }));
 
 describe('getTicketMessages', () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+  });
+
   it('maps admin flag to author field', async () => {
     vi.mocked(apiFetch).mockResolvedValueOnce({
       mensajes: [
@@ -19,5 +25,42 @@ describe('getTicketMessages', () => {
     expect(result).toHaveLength(2);
     expect(result[0]).toMatchObject({ author: 'user', content: 'Hola' });
     expect(result[1]).toMatchObject({ author: 'agent', content: 'Chau' });
+  });
+
+  it('preserves archivos_adjuntos for collectAttachmentsFromTicket', async () => {
+    const attachmentPayload = [
+      { id: 99, filename: 'doc.pdf', url: 'https://example.com/doc.pdf' },
+    ];
+
+    vi.mocked(apiFetch).mockResolvedValueOnce({
+      mensajes: [
+        {
+          id: 10,
+          mensaje: 'Archivo enviado',
+          es_admin: 0,
+          timestamp: '2024-01-03T00:00:00Z',
+          archivos_adjuntos: attachmentPayload,
+        },
+      ],
+    } as any);
+
+    const messages = await getTicketMessages(5, 'municipio');
+    expect(messages).toHaveLength(1);
+    expect(messages[0].attachments).toEqual(attachmentPayload);
+    expect(messages[0].archivos_adjuntos).toBe(messages[0].attachments);
+
+    const ticket: Ticket = {
+      id: 123,
+      tipo: 'municipio',
+      nro_ticket: 'ABC-123',
+      asunto: 'Test',
+      estado: 'abierto',
+      fecha: '2024-01-01T00:00:00Z',
+      messages,
+    };
+
+    const collected = collectAttachmentsFromTicket(ticket);
+    expect(collected).toHaveLength(1);
+    expect(collected[0]).toMatchObject({ url: 'https://example.com/doc.pdf' });
   });
 });


### PR DESCRIPTION
## Summary
- combine `archivos_adjuntos`, `attachments`, and `adjuntos` when normalizing ticket messages so both `attachments` and `archivos_adjuntos` are populated
- export `collectAttachmentsFromTicket` to exercise attachment handling in tests
- add a unit test asserting attachments from the service remain available for collection utilities

## Testing
- npm test -- getTicketMessages

------
https://chatgpt.com/codex/tasks/task_e_68cd81d0a5288322857044a2da021409