### PR TITLE
Show ticket media preview on status page

### DIFF
--- a/src/components/TicketMap.tsx
+++ b/src/components/TicketMap.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { cn } from '@/lib/utils';
 
 export interface TicketLocation {
   latitud?: number | null;
@@ -37,7 +38,23 @@ export const buildFullAddress = (ticket: TicketLocation) => {
   return parts.join(', ');
 };
 
-const TicketMap: React.FC<{ ticket: TicketLocation }> = ({ ticket }) => {
+interface TicketMapProps {
+  ticket: TicketLocation;
+  className?: string;
+  hideTitle?: boolean;
+  title?: React.ReactNode;
+  heightClassName?: string;
+  showAddressHint?: boolean;
+}
+
+const TicketMap: React.FC<TicketMapProps> = ({
+  ticket,
+  className,
+  hideTitle = false,
+  title = 'Ubicación aproximada',
+  heightClassName,
+  showAddressHint = true,
+}) => {
   const direccionCompleta = buildFullAddress(ticket);
   const destLat =
     typeof ticket.lat_destino === 'number'
@@ -97,10 +114,14 @@ const TicketMap: React.FC<{ ticket: TicketLocation }> = ({ ticket }) => {
 
   if (!src) return null;
 
+  const heightClasses = heightClassName ?? 'h-[150px] sm:h-[180px]';
+
   return (
-    <div className="mb-6">
-      <h4 className="font-semibold mb-2">Ubicación aproximada</h4>
-      <div className="w-full rounded overflow-hidden h-[150px] sm:h-[180px]">
+    <div className={cn('mb-6', className)}>
+      {!hideTitle && title && (
+        <h4 className="font-semibold mb-2">{title}</h4>
+      )}
+      <div className={cn('w-full rounded overflow-hidden', heightClasses)}>
         <iframe
           width="100%"
           height="100%"
@@ -115,7 +136,7 @@ const TicketMap: React.FC<{ ticket: TicketLocation }> = ({ ticket }) => {
           }}
         />
       </div>
-      {direccionCompleta && (
+      {direccionCompleta && showAddressHint && (
         <div className="text-xs mt-1 text-muted-foreground truncate">
           {direccionCompleta}
         </div>

--- a/src/pages/TicketLookup.tsx
+++ b/src/pages/TicketLookup.tsx
@@ -12,6 +12,8 @@ import { getErrorMessage, ApiError } from '@/utils/api';
 import { getContactPhone, getCitizenDni } from '@/utils/ticket';
 import { getSpecializedContact, SpecializedContact } from '@/utils/contacts';
 import TicketStatusBar from '@/components/tickets/TicketStatusBar';
+import { collectAttachmentsFromTicket, getPrimaryImageUrl } from '@/components/tickets/DetailsPanel';
+import { Maximize2, X, ExternalLink, Building, Hash } from 'lucide-react';
 export default function TicketLookup() {
   const { ticketId } = useParams<{ ticketId: string }>();
   const navigate = useNavigate();
@@ -26,6 +28,16 @@ export default function TicketLookup() {
   const [estadoChat, setEstadoChat] = useState('');
   const [specialContact, setSpecialContact] = useState<SpecializedContact | null>(null);
   const [completionSent, setCompletionSent] = useState(false);
+  const attachments = React.useMemo(
+    () => collectAttachmentsFromTicket(ticket, timelineMessages),
+    [ticket, timelineMessages],
+  );
+  const primaryImageUrl = React.useMemo(
+    () => getPrimaryImageUrl(ticket, attachments),
+    [attachments, ticket],
+  );
+  const [imageError, setImageError] = useState(false);
+  const [isImageModalOpen, setIsImageModalOpen] = useState(false);
   const statusFlow = React.useMemo(
     () => timelineHistory.map((h) => h.status).filter(Boolean),
     [timelineHistory],
@@ -34,6 +46,13 @@ export default function TicketLookup() {
     () => estadoChat || ticket?.estado || statusFlow[statusFlow.length - 1] || '',
     [estadoChat, ticket?.estado, statusFlow],
   );
+  const hasLocation = React.useMemo(() => {
+    if (!ticket) return false;
+    const hasCoords =
+      (typeof ticket.latitud === 'number' && typeof ticket.longitud === 'number') ||
+      (typeof ticket.lat_destino === 'number' && typeof ticket.lon_destino === 'number');
+    return Boolean(ticket.direccion || hasCoords);
+  }, [ticket]);
   const estimatedArrival =
     ticket?.tiempo_estimado ||
     (currentStatus.toLowerCase().replace(/\s+/g, '_') === 'en_proceso' ? '4h' : null);
@@ -105,6 +124,11 @@ export default function TicketLookup() {
     return () => clearInterval(interval);
   }, [ticket, pin, performSearch]);
 
+  useEffect(() => {
+    setImageError(false);
+    setIsImageModalOpen(false);
+  }, [primaryImageUrl]);
+
   const handleFormSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     const trimmed = ticketNumber.trim();
@@ -117,6 +141,33 @@ export default function TicketLookup() {
       navigate(`/ticket/${encodeURIComponent(trimmed)}?pin=${encodeURIComponent(trimmedPin)}`);
     }
   };
+
+  const openGoogleMaps = useCallback(() => {
+    if (typeof window === 'undefined' || !ticket) return;
+    if (typeof ticket.latitud === 'number' && typeof ticket.longitud === 'number') {
+      window.open(
+        `https://www.google.com/maps/search/?api=1&query=${ticket.latitud},${ticket.longitud}`,
+        '_blank',
+        'noopener',
+      );
+      return;
+    }
+    if (typeof ticket.lat_destino === 'number' && typeof ticket.lon_destino === 'number') {
+      window.open(
+        `https://www.google.com/maps/search/?api=1&query=${ticket.lat_destino},${ticket.lon_destino}`,
+        '_blank',
+        'noopener',
+      );
+      return;
+    }
+    if (ticket.direccion) {
+      window.open(
+        `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(ticket.direccion)}`,
+        '_blank',
+        'noopener',
+      );
+    }
+  }, [ticket]);
 
   useEffect(() => {
     const normalizeStatus = (s?: string | null) =>
@@ -164,74 +215,181 @@ export default function TicketLookup() {
       </form>
       {error && <p className="text-destructive text-sm text-center">{error}</p>}
       {ticket && (
-        <div className="border rounded-xl p-4 sm:p-6 space-y-6 bg-card shadow-lg">
-          <div className="space-y-2 text-justify">
-            <p className="text-sm text-muted-foreground">Ticket #{ticket.nro_ticket}</p>
-            <h2 className="text-2xl font-semibold break-words">{ticket.asunto}</h2>
-            <p className="pt-1"><span className="font-medium">Estado actual:</span> <span className="text-primary font-semibold">{currentStatus}</span></p>
-            <TicketStatusBar status={currentStatus} flow={statusFlow} />
-            <TicketMap ticket={ticket} />
-            <dl className="text-sm text-muted-foreground grid grid-cols-[auto_1fr] gap-x-2 gap-y-1">
-              <dt>Creado el:</dt>
-              <dd>{fmtAR(ticket.fecha)}</dd>
-              <dt>Canal:</dt>
-              <dd className="capitalize">{ticket.channel || 'N/A'}</dd>
-              {estimatedArrival && (
-                <>
-                  <dt>Tiempo estimado:</dt>
-                  <dd>{estimatedArrival}</dd>
-                </>
-              )}
-              {ticket.categoria && (
-                <>
-                  <dt>Categoría:</dt>
-                  <dd>{ticket.categoria}</dd>
-                </>
-              )}
-              {ticket.direccion && (
-                <>
-                  <dt>Dirección:</dt>
-                  <dd>{ticket.direccion}</dd>
-                </>
-              )}
-              {ticket.esquinas_cercanas && (
-                <>
-                  <dt>Esquinas:</dt>
-                  <dd className="break-words">{ticket.esquinas_cercanas}</dd>
-                </>
-              )}
-            </dl>
-            {(ticket.description || ticket.detalles) && (
-              <p className="text-sm text-muted-foreground mt-1 whitespace-pre-wrap break-words text-justify">
-                {ticket.description || ticket.detalles}
+        <>
+          <div className="border rounded-xl p-4 sm:p-6 space-y-6 bg-card shadow-lg">
+            <div className="space-y-2 text-justify">
+              <p className="text-sm text-muted-foreground">Ticket #{ticket.nro_ticket}</p>
+              <h2 className="text-2xl font-semibold break-words">{ticket.asunto}</h2>
+              <p className="pt-1">
+                <span className="font-medium">Estado actual:</span>{' '}
+                <span className="text-primary font-semibold">{currentStatus}</span>
               </p>
-            )}
-            {(getContactPhone(ticket) || ticket.email || ticket.dni || ticket.informacion_personal_vecino) && (
-              <div className="mt-4 text-sm space-y-1 text-justify">
-                {(ticket.informacion_personal_vecino?.nombre || ticket.display_name) && (
-                  <p className="break-words">Nombre: {ticket.informacion_personal_vecino?.nombre || ticket.display_name}</p>
+              <TicketStatusBar status={currentStatus} flow={statusFlow} />
+              {(primaryImageUrl || hasLocation) && (
+                <div className="grid gap-4 pt-4 sm:grid-cols-2">
+                  {primaryImageUrl && (
+                    <div className="space-y-2 rounded-lg border border-border bg-muted/30 p-3">
+                      <h4 className="text-base font-semibold">Imagen del reclamo</h4>
+                      {imageError ? (
+                        <p className="text-sm text-muted-foreground">
+                          No se pudo cargar la imagen proporcionada.
+                        </p>
+                      ) : (
+                        <button
+                          type="button"
+                          onClick={() => setIsImageModalOpen(true)}
+                          className="group relative aspect-video w-full overflow-hidden rounded-md border bg-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                          aria-label="Ampliar imagen del reclamo"
+                        >
+                          <img
+                            src={primaryImageUrl}
+                            alt="Foto enviada en el reclamo"
+                            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+                            loading="lazy"
+                            onError={() => {
+                              setImageError(true);
+                              setIsImageModalOpen(false);
+                            }}
+                          />
+                          <div className="absolute inset-0 flex items-center justify-center bg-black/0 transition-colors group-hover:bg-black/20">
+                            <Maximize2 className="h-6 w-6 text-white opacity-0 transition-opacity group-hover:opacity-100" />
+                          </div>
+                        </button>
+                      )}
+                    </div>
+                  )}
+                  {hasLocation && (
+                    <div className="space-y-2 rounded-lg border border-border bg-muted/30 p-3">
+                      <div className="flex items-center justify-between">
+                        <h4 className="text-base font-semibold">Ubicación</h4>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          className="h-8 w-8"
+                          onClick={openGoogleMaps}
+                          aria-label="Abrir ubicación en Google Maps"
+                        >
+                          <ExternalLink className="h-4 w-4" />
+                        </Button>
+                      </div>
+                      {ticket.direccion && (
+                        <p className="text-sm font-medium text-primary break-words">{ticket.direccion}</p>
+                      )}
+                      {ticket.distrito && (
+                        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                          <Building className="h-4 w-4" />
+                          <span className="break-words">Distrito: {ticket.distrito}</span>
+                        </div>
+                      )}
+                      {ticket.esquinas_cercanas && (
+                        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                          <Hash className="h-4 w-4" />
+                          <span className="break-words">Esquinas: {ticket.esquinas_cercanas}</span>
+                        </div>
+                      )}
+                      <div className="aspect-video overflow-hidden rounded-md border border-border bg-muted/40">
+                        <TicketMap
+                          ticket={ticket}
+                          hideTitle
+                          className="mb-0"
+                          heightClassName="h-full"
+                          showAddressHint={false}
+                        />
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+              <dl className="text-sm text-muted-foreground grid grid-cols-[auto_1fr] gap-x-2 gap-y-1">
+                <dt>Creado el:</dt>
+                <dd>{fmtAR(ticket.fecha)}</dd>
+                <dt>Canal:</dt>
+                <dd className="capitalize">{ticket.channel || 'N/A'}</dd>
+                {estimatedArrival && (
+                  <>
+                    <dt>Tiempo estimado:</dt>
+                    <dd>{estimatedArrival}</dd>
+                  </>
                 )}
-                {getCitizenDni(ticket) && (
-                  <p className="break-words">DNI: {getCitizenDni(ticket)}</p>
+                {ticket.categoria && (
+                  <>
+                    <dt>Categoría:</dt>
+                    <dd>{ticket.categoria}</dd>
+                  </>
                 )}
-                {(ticket.informacion_personal_vecino?.email || ticket.email) && (
-                  <p className="break-words">Email: {ticket.informacion_personal_vecino?.email || ticket.email}</p>
+                {ticket.direccion && (
+                  <>
+                    <dt>Dirección:</dt>
+                    <dd>{ticket.direccion}</dd>
+                  </>
                 )}
-                {getContactPhone(ticket) && (
-                  <p className="break-words">Teléfono: {getContactPhone(ticket)}</p>
+                {ticket.esquinas_cercanas && (
+                  <>
+                    <dt>Esquinas:</dt>
+                    <dd className="break-words">{ticket.esquinas_cercanas}</dd>
+                  </>
                 )}
+              </dl>
+              {(ticket.description || ticket.detalles) && (
+                <p className="text-sm text-muted-foreground mt-1 whitespace-pre-wrap break-words text-justify">
+                  {ticket.description || ticket.detalles}
+                </p>
+              )}
+              {(getContactPhone(ticket) || ticket.email || ticket.dni || ticket.informacion_personal_vecino) && (
+                <div className="mt-4 text-sm space-y-1 text-justify">
+                  {(ticket.informacion_personal_vecino?.nombre || ticket.display_name) && (
+                    <p className="break-words">
+                      Nombre: {ticket.informacion_personal_vecino?.nombre || ticket.display_name}
+                    </p>
+                  )}
+                  {getCitizenDni(ticket) && (
+                    <p className="break-words">DNI: {getCitizenDni(ticket)}</p>
+                  )}
+                  {(ticket.informacion_personal_vecino?.email || ticket.email) && (
+                    <p className="break-words">
+                      Email: {ticket.informacion_personal_vecino?.email || ticket.email}
+                    </p>
+                  )}
+                  {getContactPhone(ticket) && (
+                    <p className="break-words">Teléfono: {getContactPhone(ticket)}</p>
+                  )}
+                </div>
+              )}
+            </div>
+
+            <Separator />
+
+            <div>
+              <h3 className="text-xl font-semibold mb-4">Historial del Reclamo</h3>
+              <TicketTimeline history={timelineHistory} messages={timelineMessages} ticket={ticket} />
+            </div>
+          </div>
+          {isImageModalOpen && primaryImageUrl && !imageError && (
+            <div
+              className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+              role="dialog"
+              aria-modal="true"
+              onClick={() => setIsImageModalOpen(false)}
+            >
+              <div className="relative" onClick={(event) => event.stopPropagation()}>
+                <img
+                  src={primaryImageUrl}
+                  alt="Foto ampliada del reclamo"
+                  className="max-h-[90vh] max-w-[90vw] rounded-lg shadow-2xl"
+                />
+                <button
+                  type="button"
+                  onClick={() => setIsImageModalOpen(false)}
+                  className="absolute top-2 right-2 rounded-full bg-black/60 p-1 text-white transition hover:bg-black/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                  aria-label="Cerrar imagen ampliada"
+                >
+                  <X className="h-4 w-4" />
+                </button>
               </div>
-            )}
-          </div>
-
-          <Separator />
-
-          <div>
-            <h3 className="text-xl font-semibold mb-4">Historial del Reclamo</h3>
-            <TicketTimeline history={timelineHistory} messages={timelineMessages} ticket={ticket} />
-          </div>
-
-        </div>
+            </div>
+          )}
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- show the ticket evidence thumbnail with an expandable modal and contact details on the public status page
- add a compact location card that mirrors the admin panel layout, including a shortcut to Google Maps
- expose reusable helpers and TicketMap configuration to support the new preview while keeping existing behavior

## Testing
- npm run test *(fails: several suites require server/*.cjs fixtures and vite swc support that are not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd92eb694083228de8229588196572