### PR TITLE
Fix user refresh auth token selection

### DIFF
--- a/src/hooks/useUser.tsx
+++ b/src/hooks/useUser.tsx
@@ -51,48 +51,55 @@ export const UserProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [loading, setLoading] = useState(false);
 
   const refreshUser = useCallback(async () => {
-    const tokenKey = (safeLocalStorage.getItem('entityToken') || getIframeToken()) ? 'chatAuthToken' : 'authToken';
-    const token = safeLocalStorage.getItem(tokenKey);
-    if (!token) return;
+    const panelToken = safeLocalStorage.getItem('authToken');
+    const chatToken = safeLocalStorage.getItem('chatAuthToken');
+    const activeToken = panelToken ?? chatToken;
+    const tokenKey: 'authToken' | 'chatAuthToken' | null = panelToken
+      ? 'authToken'
+      : chatToken
+        ? 'chatAuthToken'
+        : null;
+    if (!activeToken) return;
     setLoading(true);
     try {
-    const data = await apiFetch<any>('/me');
-    const rubroNorm = parseRubro(data.rubro) || '';
-    if (!data.tipo_chat) {
-      console.warn('tipo_chat faltante en respuesta de /me');
-    }
-    if (!data.rol) {
-      console.warn('rol faltante en respuesta de /me');
-    }
-    const finalTipo = data.tipo_chat
-      ? enforceTipoChatForRubro(data.tipo_chat as 'pyme' | 'municipio', rubroNorm)
-      : undefined;
-    const updated: UserData = {
-      id: data.id,
-      name: data.name,
-      email: data.email,
-      plan: data.plan || 'free',
-      rubro: rubroNorm,
-      nombre_empresa: data.nombre_empresa,
-      logo_url: data.logo_url,
-      picture: data.picture,
-      tipo_chat: finalTipo,
-      rol: data.rol,
-      token,
-      widget_icon_url: data.widget_icon_url,
-      widget_animation: data.widget_animation,
-      latitud: typeof data.latitud === 'number' ? data.latitud : Number(data.latitud),
-      longitud: typeof data.longitud === 'number' ? data.longitud : Number(data.longitud),
-    };
-    safeLocalStorage.setItem('user', JSON.stringify(updated));
-    setUser(updated);
+      const data = await apiFetch<any>('/me');
+      const rubroNorm = parseRubro(data.rubro) || '';
+      if (!data.tipo_chat) {
+        console.warn('tipo_chat faltante en respuesta de /me');
+      }
+      if (!data.rol) {
+        console.warn('rol faltante en respuesta de /me');
+      }
+      const finalTipo = data.tipo_chat
+        ? enforceTipoChatForRubro(data.tipo_chat as 'pyme' | 'municipio', rubroNorm)
+        : undefined;
+      const updated: UserData = {
+        id: data.id,
+        name: data.name,
+        email: data.email,
+        plan: data.plan || 'free',
+        rubro: rubroNorm,
+        nombre_empresa: data.nombre_empresa,
+        logo_url: data.logo_url,
+        picture: data.picture,
+        tipo_chat: finalTipo,
+        rol: data.rol,
+        token: activeToken,
+        widget_icon_url: data.widget_icon_url,
+        widget_animation: data.widget_animation,
+        latitud: typeof data.latitud === 'number' ? data.latitud : Number(data.latitud),
+        longitud: typeof data.longitud === 'number' ? data.longitud : Number(data.longitud),
+      };
+      safeLocalStorage.setItem('user', JSON.stringify(updated));
+      setUser(updated);
     } catch (e) {
       console.error('Error fetching user profile, logging out.', e);
       // If fetching the user fails, the token is likely invalid or expired.
       // Clear the user data and token to force a re-login.
-      const tokenKey = (safeLocalStorage.getItem('entityToken') || getIframeToken()) ? 'chatAuthToken' : 'authToken';
       safeLocalStorage.removeItem('user');
-      safeLocalStorage.removeItem(tokenKey);
+      if (tokenKey) {
+        safeLocalStorage.removeItem(tokenKey);
+      }
       setUser(null);
     } finally {
       setLoading(false);
@@ -100,8 +107,9 @@ export const UserProvider: React.FC<{ children: React.ReactNode }> = ({ children
   }, []);
 
   useEffect(() => {
-    const tokenKey = (safeLocalStorage.getItem('entityToken') || getIframeToken()) ? 'chatAuthToken' : 'authToken';
-    const token = safeLocalStorage.getItem(tokenKey);
+    const token =
+      safeLocalStorage.getItem('authToken') ||
+      safeLocalStorage.getItem('chatAuthToken');
     if (token && (!user || !user.rubro)) {
       refreshUser();
     }


### PR DESCRIPTION
## Summary
- ensure `apiFetch` prefers the panel auth token when both panel and widget tokens are present
- update the user context refresh logic to reuse the active token and clear only the invalid key on errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd9ce012908322b0119fadf6c66072