### PR TITLE
Preserve stored entity tokens and avoid chat JWT fallback

### DIFF
--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -19,6 +19,7 @@ import EntityInfoPanel from "./EntityInfoPanel";
 import ChatPanel from "./ChatPanel";
 import ReadingRuler from "./ReadingRuler";
 import type { Prefs } from "./AccessibilityToggle";
+import { activateWidgetMode, deactivateWidgetMode } from "@/utils/widgetMode";
 
 interface ChatWidgetProps {
   mode?: "standalone" | "iframe" | "script";
@@ -96,6 +97,14 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
   );
 
   const isEmbedded = mode !== "standalone";
+
+  useEffect(() => {
+    if (!isEmbedded) return;
+    activateWidgetMode();
+    return () => {
+      deactivateWidgetMode();
+    };
+  }, [isEmbedded]);
 
   const derivedEntityTitle =
     (typeof entityInfo?.nombre_empresa === "string" && entityInfo.nombre_empresa.trim()) ||

--- a/src/hooks/useUser.tsx
+++ b/src/hooks/useUser.tsx
@@ -3,12 +3,18 @@ import { apiFetch } from '@/utils/api';
 import { safeLocalStorage } from '@/utils/safeLocalStorage';
 import { enforceTipoChatForRubro, parseRubro } from '@/utils/tipoChat';
 import { getIframeToken } from '@/utils/config';
+import {
+  extractEntityToken,
+  getStoredEntityToken,
+  persistEntityToken,
+} from '@/utils/entityToken';
 
 interface UserData {
   id?: number;
   name?: string;
   email?: string;
   token?: string;
+  entityToken?: string;
   plan?: string;
   rubro?: string;
   nombre_empresa?: string;
@@ -43,7 +49,21 @@ export const UserProvider: React.FC<{ children: React.ReactNode }> = ({ children
       const chatToken = safeLocalStorage.getItem('chatAuthToken');
       if (hasEntity && !chatToken) return null;
       const stored = safeLocalStorage.getItem('user');
-      return stored ? JSON.parse(stored) : null;
+      if (!stored) return null;
+      const parsed = JSON.parse(stored);
+      const storedEntityToken = getStoredEntityToken();
+      if (storedEntityToken && (!parsed || typeof parsed !== 'object')) {
+        return { entityToken: storedEntityToken };
+      }
+      if (parsed && typeof parsed === 'object') {
+        return {
+          ...parsed,
+          ...(storedEntityToken && !parsed.entityToken
+            ? { entityToken: storedEntityToken }
+            : {}),
+        } as UserData;
+      }
+      return null;
     } catch {
       return null;
     }
@@ -70,6 +90,12 @@ export const UserProvider: React.FC<{ children: React.ReactNode }> = ({ children
       if (!data.rol) {
         console.warn('rol faltante en respuesta de /me');
       }
+      const entityToken =
+        extractEntityToken(data) ??
+        getStoredEntityToken();
+      if (entityToken) {
+        persistEntityToken(entityToken);
+      }
       const finalTipo = data.tipo_chat
         ? enforceTipoChatForRubro(data.tipo_chat as 'pyme' | 'municipio', rubroNorm)
         : undefined;
@@ -85,6 +111,7 @@ export const UserProvider: React.FC<{ children: React.ReactNode }> = ({ children
         tipo_chat: finalTipo,
         rol: data.rol,
         token: activeToken,
+        ...(entityToken ? { entityToken } : {}),
         widget_icon_url: data.widget_icon_url,
         widget_animation: data.widget_animation,
         latitud: typeof data.latitud === 'number' ? data.latitud : Number(data.latitud),

--- a/src/pages/Integracion.tsx
+++ b/src/pages/Integracion.tsx
@@ -1,10 +1,17 @@
 // src/pages/Integracion.tsx
 
-import React, { useEffect, useState, useMemo } from "react";
+import React, { useEffect, useState, useMemo, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 import { safeLocalStorage } from "@/utils/safeLocalStorage";
+import { apiFetch } from "@/utils/api";
+import {
+  extractEntityToken,
+  getStoredEntityToken,
+  persistEntityToken,
+  normalizeEntityToken,
+} from "@/utils/entityToken";
 import {
   Card,
   CardContent,
@@ -31,6 +38,7 @@ interface User {
   name: string;
   email: string;
   token: string;
+  entityToken?: string;
   plan?: string;
   tipo_chat?: "pyme" | "municipio";
   widget_icon_url?: string;
@@ -49,6 +57,87 @@ const Integracion = () => {
   const [headerLogoUrl, setHeaderLogoUrl] = useState("");
   const [welcomeTitle, setWelcomeTitle] = useState("");
   const [welcomeSubtitle, setWelcomeSubtitle] = useState("");
+  const [ownerToken, setOwnerToken] = useState<string | null>(null);
+  const [ownerTokenLoading, setOwnerTokenLoading] = useState(false);
+  const [ownerTokenError, setOwnerTokenError] = useState<string | null>(null);
+
+  const applyOwnerToken = useCallback(
+    (candidate: string | null | undefined) => {
+      const normalized = normalizeEntityToken(candidate ?? null);
+      if (!normalized) {
+        return null;
+      }
+      const persisted = persistEntityToken(normalized) ?? normalized;
+      setOwnerToken(persisted);
+      setOwnerTokenError(null);
+      setUser((prev) => (prev ? { ...prev, entityToken: persisted } : prev));
+      return persisted;
+    },
+    [setUser],
+  );
+
+  const fetchOwnerTokenFromApi = useCallback(async () => {
+    const authToken = safeLocalStorage.getItem("authToken");
+    if (!authToken) {
+      return null;
+    }
+
+    setOwnerTokenLoading(true);
+    setOwnerTokenError(null);
+
+    const previousToken = getStoredEntityToken();
+    let lastError: unknown = null;
+
+    const resolveFromPayload = (payload: any) => {
+      const direct = extractEntityToken(payload);
+      return applyOwnerToken(direct);
+    };
+
+    const attempt = async (fn: () => Promise<any>) => {
+      try {
+        const payload = await fn();
+        return resolveFromPayload(payload);
+      } catch (err) {
+        lastError = lastError ?? err;
+        return null;
+      }
+    };
+
+    try {
+      let resolved = await attempt(() => apiFetch<any>("/me", { cache: "no-store" }));
+      if (!resolved) {
+        resolved = await attempt(() =>
+          apiFetch<any>("/perfil", { cache: "no-store", entityToken: "" }),
+        );
+      }
+
+      if (resolved) {
+        return resolved;
+      }
+
+      if (previousToken) {
+        applyOwnerToken(previousToken);
+        setOwnerTokenError(
+          "No pudimos refrescar el token de integración. Se mantiene el último token disponible.",
+        );
+        return previousToken;
+      }
+
+      if (lastError) {
+        console.error("Integracion: no se pudo obtener el token de integración", lastError);
+      }
+      persistEntityToken(null);
+      setOwnerToken(null);
+      setOwnerTokenError(
+        lastError
+          ? "No pudimos obtener el token de integración. Reintentá más tarde o contactá soporte."
+          : "Tu cuenta no tiene un token de integración activo. Escribinos para activarlo.",
+      );
+      return null;
+    } finally {
+      setOwnerTokenLoading(false);
+    }
+  }, [applyOwnerToken]);
 
   const validarAcceso = (currentUser: User | null) => {
     if (!currentUser) {
@@ -83,6 +172,10 @@ const Integracion = () => {
       return;
     }
 
+    const storedEntityToken = extractEntityToken(parsedUser) ?? getStoredEntityToken();
+    const normalizedEntityToken =
+      storedEntityToken ? persistEntityToken(storedEntityToken) ?? storedEntityToken : null;
+
     const fullUser: User = {
       ...parsedUser,
       token: authToken,
@@ -90,17 +183,41 @@ const Integracion = () => {
       tipo_chat: parsedUser.tipo_chat || undefined,
       widget_icon_url: parsedUser.widget_icon_url,
       widget_animation: parsedUser.widget_animation,
+      ...(normalizedEntityToken ? { entityToken: normalizedEntityToken } : {}),
     };
     setUser(fullUser);
-    setIsLoading(false);
 
     if (!validarAcceso(fullUser)) {
+      setIsLoading(false);
       return;
+    }
+
+    if (normalizedEntityToken) {
+      setOwnerToken(normalizedEntityToken);
+      setOwnerTokenError(null);
+    } else {
+      setOwnerToken(null);
+      fetchOwnerTokenFromApi();
     }
 
     setLogoUrl(fullUser.widget_icon_url || "");
     setLogoAnimation(fullUser.widget_animation || "");
-  }, [navigate]);
+    setIsLoading(false);
+  }, [navigate, fetchOwnerTokenFromApi]);
+
+  useEffect(() => {
+    if (!user) {
+      return;
+    }
+    const normalized = normalizeEntityToken(user.entityToken ?? null);
+    if (normalized && normalized !== ownerToken) {
+      setOwnerToken(normalized);
+      setOwnerTokenError(null);
+    } else if (!normalized && ownerToken) {
+      persistEntityToken(null);
+      setOwnerToken(null);
+    }
+  }, [user, ownerToken]);
 
 
   const endpoint = useMemo(() => {
@@ -108,7 +225,10 @@ const Integracion = () => {
     return user.tipo_chat === "municipio" ? "municipio" : "pyme";
   }, [user?.tipo_chat]);
 
-  const ownerToken = useMemo(() => user?.token || "OWNER_TOKEN_DEL_WIDGET", [user?.token]);
+  const hasOwnerToken = typeof ownerToken === "string" && ownerToken.length > 0;
+  const maskedOwnerToken = hasOwnerToken && ownerToken
+    ? `${ownerToken.substring(0, 8)}...`
+    : "No disponible";
   const isFullPlan = (user?.plan || "").toLowerCase() === "full";
 
   const WIDGET_STD_WIDTH = "460px";
@@ -123,6 +243,10 @@ const Integracion = () => {
   const iframeBase = window.location.origin;
   
   const codeScript = useMemo(() => {
+    if (!ownerToken) {
+      return "<!-- Token del widget no disponible. Reintentá regenerarlo desde el panel de integración. -->";
+    }
+
     const customAttrs = [
       primaryColor && `  data-primary-color="${primaryColor}"`,
       accentColor && `  data-accent-color="${accentColor}"`,
@@ -150,6 +274,10 @@ ${customAttrs ? customAttrs + "\n" : ""}></script>`;
   }, [apiBase, widgetScriptUrl, ownerToken, endpoint, primaryColor, accentColor, logoUrl, headerLogoUrl, logoAnimation, welcomeTitle, welcomeSubtitle]);
 
   const iframeSrcUrl = useMemo(() => {
+    if (!ownerToken) {
+      return "";
+    }
+
     const url = new URL(`${apiBase}/iframe`);
     url.searchParams.set("entityToken", ownerToken);
     url.searchParams.set("tipo_chat", endpoint);
@@ -164,6 +292,10 @@ ${customAttrs ? customAttrs + "\n" : ""}></script>`;
   }, [apiBase, ownerToken, endpoint, primaryColor, accentColor, logoUrl, headerLogoUrl, logoAnimation, welcomeTitle, welcomeSubtitle]);
 
   const previewIframeUrl = useMemo(() => {
+    if (!ownerToken) {
+      return "";
+    }
+
     const url = new URL(`${iframeBase}/iframe`);
     url.searchParams.set("entityToken", ownerToken);
     url.searchParams.set("tipo_chat", endpoint);
@@ -177,7 +309,12 @@ ${customAttrs ? customAttrs + "\n" : ""}></script>`;
     return url.toString();
   }, [iframeBase, ownerToken, endpoint, primaryColor, accentColor, logoUrl, headerLogoUrl, logoAnimation, welcomeTitle, welcomeSubtitle]);
   
-  const codeIframe = useMemo(() => `<iframe
+  const codeIframe = useMemo(() => {
+    if (!ownerToken || !iframeSrcUrl) {
+      return "<!-- Token del widget no disponible. Reintentá regenerarlo desde el panel de integración. -->";
+    }
+
+    return `<iframe
   id="chatboc-iframe"
   src="${iframeSrcUrl}"
   style="position:fixed; bottom:${WIDGET_STD_BOTTOM}; right:${WIDGET_STD_RIGHT}; border:none; border-radius:50%; z-index:9999; box-shadow:0 4px 32px rgba(0,0,0,0.2); background:transparent; overflow:hidden; width:${WIDGET_STD_CLOSED_WIDTH}; height:${WIDGET_STD_CLOSED_HEIGHT}; display:block; transition: width 0.3s ease, height 0.3s ease, border-radius 0.3s ease;"
@@ -211,7 +348,8 @@ document.addEventListener('DOMContentLoaded', function () {
   //   chatIframe.contentWindow.postMessage({ type: 'chatboc-init', settings: { exampleSetting: true } }, '${apiBase}');
   // };
 });
-</script>`, [iframeSrcUrl, apiBase, endpoint]);
+</script>`;
+  }, [iframeSrcUrl, apiBase, endpoint, ownerToken]);
 
   useEffect(() => {
     if (!ownerToken) return;
@@ -264,7 +402,30 @@ document.addEventListener('DOMContentLoaded', function () {
   }, [apiBase, widgetScriptUrl, defaultWidgetScriptUrl, ownerToken, endpoint, primaryColor, accentColor, logoUrl, headerLogoUrl, logoAnimation, welcomeTitle, welcomeSubtitle]);
 
 
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key !== "entityToken") return;
+      const normalized = normalizeEntityToken(event.newValue);
+      setOwnerToken(normalized);
+      setOwnerTokenError(null);
+      setUser((prev) => (prev ? { ...prev, entityToken: normalized ?? undefined } : prev));
+    };
+
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, [setUser]);
+
+
   const copiarCodigo = async (tipo: "iframe" | "script") => {
+    if (!ownerToken) {
+      toast.error("No hay un token de integración disponible. Reintentá obtenerlo desde esta página.", {
+        icon: <AlertTriangle className="text-destructive" />,
+      });
+      return;
+    }
+
     const textoACopiar = tipo === "iframe" ? codeIframe : codeScript;
     try {
       await navigator.clipboard.writeText(textoACopiar);
@@ -336,13 +497,14 @@ document.addEventListener('DOMContentLoaded', function () {
                   variant="ghost"
                   size="icon"
                   onClick={() => copiarCodigo(type)}
+                  disabled={!hasOwnerToken}
                   aria-label={`Copiar código ${type}`}
                 >
                   {copiado === type ? <Check size={18} className="text-green-500" /> : <Copy size={18} />}
                 </Button>
               </TooltipTrigger>
               <TooltipContent>
-                <p>Copiar código {type}</p>
+                <p>{hasOwnerToken ? `Copiar código ${type}` : "Token no disponible"}</p>
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>
@@ -356,10 +518,11 @@ document.addEventListener('DOMContentLoaded', function () {
         </pre>
       </CardContent>
       <CardFooter className="p-4 bg-muted/20 dark:bg-muted/10">
-         <Button
+        <Button
             className="w-full"
             onClick={() => copiarCodigo(type)}
             variant="secondary"
+            disabled={!hasOwnerToken}
           >
             {copiado === type ? <Check size={18} className="mr-2 text-green-500" /> : <Copy size={18} className="mr-2" />}
             {copiado === type ? `¡Código ${type} Copiado!` : `Copiar Código ${type}`}
@@ -397,16 +560,48 @@ document.addEventListener('DOMContentLoaded', function () {
             Ambos métodos de integración (Script y Iframe) están diseñados para ser seguros y eficientes. El método de Script es generalmente más flexible y recomendado.
           </p>
           <p>
-            <strong>Token del Widget:</strong> Tu token de integración es <code>{ownerToken.substring(0,8)}...</code>. Ya está incluido en los códigos de abajo.
+            <strong>Token del Widget:</strong>{" "}
+            {ownerTokenLoading ? (
+              "Generando token seguro..."
+            ) : hasOwnerToken ? (
+              <>Tu token de integración es <code>{maskedOwnerToken}</code>. Ya está incluido en los códigos de abajo.</>
+            ) : (
+              "Todavía no encontramos un token activo. Usá el botón de reintentar o contactá a soporte."
+            )}
           </p>
+      </CardContent>
+    </Card>
+
+    {!hasOwnerToken && !ownerTokenLoading && (
+      <Card className="mb-8 border-yellow-300 bg-yellow-50 dark:bg-yellow-900/30 dark:border-yellow-700">
+        <CardHeader>
+          <CardTitle className="flex items-center text-yellow-800 dark:text-yellow-200">
+            <AlertTriangle size={20} className="mr-2" />
+            Necesitamos tu token de integración
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm space-y-3 text-yellow-800 dark:text-yellow-100">
+          <p>
+            {ownerTokenError ||
+              "Generamos un token seguro por cada cuenta para que tus integraciones sigan funcionando después de los deploys."}
+          </p>
+          <Button
+            variant="outline"
+            onClick={fetchOwnerTokenFromApi}
+            disabled={ownerTokenLoading}
+            className="w-full sm:w-auto"
+          >
+            {ownerTokenLoading ? "Generando..." : "Reintentar"}
+          </Button>
         </CardContent>
       </Card>
+    )}
 
-      {isFullPlan && (
-        <Card className="mb-8">
-          <CardHeader>
-            <CardTitle className="text-lg">Personalización del Widget</CardTitle>
-            <CardDescription>
+    {isFullPlan && (
+      <Card className="mb-8">
+        <CardHeader>
+          <CardTitle className="text-lg">Personalización del Widget</CardTitle>
+          <CardDescription>
               Ajusta el color y el icono del lanzador para adaptarlo a tu sitio.
             </CardDescription>
           </CardHeader>
@@ -546,7 +741,19 @@ document.addEventListener('DOMContentLoaded', function () {
                   justifyContent: "center",
                 }}
               >
-                {user && user.token && user.tipo_chat ? (
+                {ownerTokenLoading ? (
+                  <div className="p-4 text-center text-muted-foreground">
+                    <svg className="mx-auto mb-2 h-8 w-8 animate-spin text-primary" viewBox="0 0 24 24">
+                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                      <path
+                        className="opacity-75"
+                        fill="currentColor"
+                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                      ></path>
+                    </svg>
+                    Preparando la vista previa segura...
+                  </div>
+                ) : hasOwnerToken && previewIframeUrl ? (
                   <iframe
                     src={previewIframeUrl}
                     width={WIDGET_STD_WIDTH}
@@ -566,7 +773,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 ) : (
                   <div className="p-4 text-center text-muted-foreground">
                     <AlertTriangle size={32} className="mx-auto mb-2" />
-                    La vista previa no está disponible. Verifica la configuración del usuario.
+                    La vista previa se habilita cuando haya un token de integración válido. Generalo desde esta misma página.
                   </div>
                 )}
               </div>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -8,6 +8,7 @@ import { apiFetch, ApiError } from "@/utils/api";
 import { safeLocalStorage } from "@/utils/safeLocalStorage";
 import { useUser } from "@/hooks/useUser";
 import GoogleLoginButton from "@/components/auth/GoogleLoginButton";
+import { extractEntityToken, persistEntityToken } from "@/utils/entityToken";
 
 // Asegúrate de que esta interfaz refleje EXACTAMENTE lo que tu backend devuelve en /login
 interface LoginResponse {
@@ -40,8 +41,9 @@ const Login = () => {
       });
 
       safeLocalStorage.setItem("authToken", data.token);
-      if (data.entityToken) {
-        safeLocalStorage.setItem("entityToken", data.entityToken);
+      const loginEntityToken = extractEntityToken(data);
+      if (loginEntityToken) {
+        persistEntityToken(loginEntityToken);
       }
 
       await refreshUser();

--- a/src/pages/iframe.tsx
+++ b/src/pages/iframe.tsx
@@ -8,6 +8,7 @@ import { MemoryRouter } from "react-router-dom";
 import { getChatbocConfig } from "@/utils/config";
 import { hexToHsl } from "@/utils/color";
 import { safeLocalStorage } from "@/utils/safeLocalStorage";
+import { activateWidgetMode, deactivateWidgetMode } from "@/utils/widgetMode";
 
 const DEFAULTS = {
   openWidth: "460px",
@@ -32,6 +33,13 @@ const Iframe = () => {
   const [entityToken, setEntityToken] = useState<string | null>(null);
   const [tipoChat, setTipoChat] = useState<'pyme' | 'municipio' | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    activateWidgetMode();
+    return () => {
+      deactivateWidgetMode();
+    };
+  }, []);
 
   useEffect(() => {
     const cfg = getChatbocConfig();

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -4,6 +4,11 @@ import { BASE_API_URL } from '@/config';
 import { safeLocalStorage } from "@/utils/safeLocalStorage";
 import getOrCreateChatSessionId from "@/utils/chatSessionId"; // Import the new function
 import { getIframeToken } from "@/utils/config";
+import { isWidgetModeActive } from "@/utils/widgetMode";
+import {
+  normalizeEntityToken,
+  persistEntityToken,
+} from "@/utils/entityToken";
 
 export class ApiError extends Error {
   public readonly status: number;
@@ -25,6 +30,8 @@ interface ApiFetchOptions {
   sendAnonId?: boolean;
   entityToken?: string | null;
   cache?: RequestCache;
+  omitCredentials?: boolean;
+  preferChatAuthToken?: boolean;
 }
 
 /**
@@ -36,12 +43,25 @@ export async function apiFetch<T>(
   path: string,
   options: ApiFetchOptions = {}
 ): Promise<T> {
-  const { method = "GET", body, skipAuth, sendAnonId, entityToken, cache } = options;
+  const {
+    method = "GET",
+    body,
+    skipAuth,
+    sendAnonId,
+    entityToken,
+    cache,
+    omitCredentials,
+    preferChatAuthToken,
+  } = options;
 
   const effectiveEntityToken = entityToken ?? getIframeToken();
-  const panelToken = safeLocalStorage.getItem("authToken");
-  const chatToken = safeLocalStorage.getItem("chatAuthToken");
-  const token = panelToken || chatToken;
+  const widgetMode = isWidgetModeActive();
+  const preferChatToken = preferChatAuthToken ?? widgetMode;
+  const rawPanelToken = safeLocalStorage.getItem("authToken");
+  const rawChatToken = safeLocalStorage.getItem("chatAuthToken");
+  const panelToken = preferChatToken ? null : rawPanelToken;
+  const chatToken = preferChatToken ? rawChatToken : null;
+  const token = panelToken ?? chatToken ?? null;
   const tokenSource: "authToken" | "chatAuthToken" | null = panelToken
     ? "authToken"
     : chatToken
@@ -78,19 +98,20 @@ export async function apiFetch<T>(
     method,
     url,
     hasBody: !!body,
-    authToken: mask(panelToken),
-    chatAuthToken: mask(chatToken),
+    authToken: mask(rawPanelToken),
+    chatAuthToken: mask(rawChatToken),
     anonId: mask(anonId),
     entityToken: mask(effectiveEntityToken || null),
     sendAnonId,
     headers,
+    widgetMode,
   });
 
   const requestInit: RequestInit = {
     method,
     headers,
     body: isForm ? body : body ? JSON.stringify(body) : undefined,
-    credentials: 'include', // ensure cookies like session are sent
+    credentials: (omitCredentials ?? widgetMode) ? 'omit' : 'include',
     cache,
   };
 
@@ -123,6 +144,18 @@ export async function apiFetch<T>(
           "[apiFetch] Unable to persist anon_id header",
           storageError,
         );
+      }
+    }
+
+    const responseEntityToken =
+      response.headers.get("X-Entity-Token") ||
+      response.headers.get("X-Owner-Token") ||
+      response.headers.get("X-Widget-Token") ||
+      response.headers.get("X-Integration-Token");
+    if (responseEntityToken) {
+      const normalizedEntityHeader = normalizeEntityToken(responseEntityToken);
+      if (normalizedEntityHeader) {
+        persistEntityToken(normalizedEntityHeader);
       }
     }
 

--- a/src/utils/entityToken.ts
+++ b/src/utils/entityToken.ts
@@ -1,0 +1,254 @@
+import { safeLocalStorage } from "@/utils/safeLocalStorage";
+
+const ENTITY_TOKEN_KEYS = [
+  "entityToken",
+  "entity_token",
+  "widgetToken",
+  "widget_token",
+  "ownerToken",
+  "owner_token",
+  "token_widget",
+  "widgetOwnerToken",
+  "widget_owner_token",
+  "empresa_token",
+  "empresaToken",
+  "municipio_token",
+  "municipioToken",
+  "organizationToken",
+  "organization_token",
+  "botToken",
+  "bot_token",
+  "tokenIntegracion",
+  "token_integracion",
+];
+
+const ENTITY_TOKEN_KEY_SET = new Set(
+  ENTITY_TOKEN_KEYS.map((key) => key.toLowerCase()),
+);
+
+const GENERIC_TOKEN_KEYS = [
+  "token",
+  "value",
+  "jwt",
+  "jwt_token",
+  "access_token",
+  "accesstoken",
+  "auth_token",
+  "authtoken",
+  "api_token",
+  "apitoken",
+  "authorization",
+];
+
+const NESTED_TOKEN_SOURCES = [
+  "entity",
+  "entidad",
+  "empresa",
+  "municipio",
+  "organization",
+  "organizacion",
+  "config",
+  "widget",
+  "tokens",
+  "credentials",
+  "integration",
+  "integracion",
+  "owner",
+  "owners",
+  "ownerinfo",
+  "owner_info",
+  "ownerdata",
+  "owner_data",
+  "propietario",
+  "dueno",
+  "dueño",
+  "perfil",
+  "profile",
+  "account",
+  "cuenta",
+];
+
+const NESTED_TOKEN_SOURCE_SET = new Set(
+  NESTED_TOKEN_SOURCES.map((key) => key.toLowerCase()),
+);
+
+const TOKEN_CONTEXT_HINTS = [
+  "entity",
+  "entidad",
+  "empresa",
+  "municipio",
+  "organization",
+  "organizacion",
+  "config",
+  "widget",
+  "tokens",
+  "credentials",
+  "integration",
+  "integracion",
+  "owner",
+  "owners",
+  "propietario",
+  "dueno",
+  "dueño",
+  "perfil",
+  "profile",
+  "account",
+  "cuenta",
+  "bot",
+  "assistant",
+];
+
+const PLACEHOLDER_TOKENS = new Set([
+  "",
+  "demo-anon",
+  "null",
+  "undefined",
+  "none",
+]);
+
+export function normalizeEntityToken(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const withoutBearer = trimmed.startsWith("Bearer ")
+    ? trimmed.slice(7).trim()
+    : trimmed;
+  if (!withoutBearer) return null;
+  const candidate = withoutBearer.replace(/^"|"$/g, "").trim();
+  if (!candidate) return null;
+  if (PLACEHOLDER_TOKENS.has(candidate.toLowerCase())) {
+    return null;
+  }
+  return candidate;
+}
+
+function shouldCaptureFromContext(key: string, path: string[]): boolean {
+  if (!path.length) {
+    return TOKEN_CONTEXT_HINTS.some((hint) => key.toLowerCase().includes(hint));
+  }
+  const normalizedPath = path.map((segment) => segment.toLowerCase());
+  if (normalizedPath.some((segment) => TOKEN_CONTEXT_HINTS.some((hint) => segment.includes(hint)))) {
+    return true;
+  }
+  return TOKEN_CONTEXT_HINTS.some((hint) => key.toLowerCase().includes(hint));
+}
+
+function shouldRecurseInto(key: string, depth: number): boolean {
+  const normalizedKey = key.toLowerCase();
+  if (NESTED_TOKEN_SOURCE_SET.has(normalizedKey)) return true;
+  if (
+    normalizedKey.includes("token") ||
+    normalizedKey.includes("owner") ||
+    normalizedKey.includes("widget") ||
+    normalizedKey.includes("entity") ||
+    normalizedKey.includes("empresa") ||
+    normalizedKey.includes("municipio") ||
+    normalizedKey.includes("organizacion") ||
+    normalizedKey.includes("organization") ||
+    normalizedKey.includes("perfil") ||
+    normalizedKey.includes("profile") ||
+    normalizedKey.includes("account") ||
+    normalizedKey.includes("cuenta") ||
+    normalizedKey.includes("credencial") ||
+    normalizedKey.includes("credential") ||
+    normalizedKey.includes("integration") ||
+    normalizedKey.includes("integracion")
+  ) {
+    return true;
+  }
+  return depth < 1;
+}
+
+export function extractEntityToken(source: any, depth = 0, path: string[] = []): string | null {
+  if (!source) return null;
+
+  if (Array.isArray(source)) {
+    if (depth >= 6) return null;
+    for (const item of source) {
+      const candidate = extractEntityToken(item, depth + 1, path);
+      if (candidate) return candidate;
+    }
+    return null;
+  }
+
+  if (typeof source !== "object") {
+    return null;
+  }
+
+  const record = source as Record<string, unknown>;
+
+  for (const [rawKey, rawValue] of Object.entries(record)) {
+    const normalizedKey = rawKey.toLowerCase();
+    if (ENTITY_TOKEN_KEY_SET.has(normalizedKey)) {
+      const candidate = normalizeEntityToken(rawValue);
+      if (candidate) {
+        return candidate;
+      }
+    }
+
+    if (typeof rawValue === "string") {
+      const genericKey = GENERIC_TOKEN_KEYS.includes(normalizedKey) || normalizedKey.includes("token");
+      if (genericKey && shouldCaptureFromContext(rawKey, path)) {
+        const candidate = normalizeEntityToken(rawValue);
+        if (candidate) {
+          return candidate;
+        }
+      }
+    }
+  }
+
+  if (depth >= 6) {
+    return null;
+  }
+
+  for (const [rawKey, rawValue] of Object.entries(record)) {
+    if (!rawValue || typeof rawValue === "string") continue;
+
+    const nextPath = [...path, rawKey];
+
+    if (Array.isArray(rawValue)) {
+      const candidate = extractEntityToken(rawValue, depth + 1, nextPath);
+      if (candidate) return candidate;
+      continue;
+    }
+
+    if (typeof rawValue === "object" && shouldRecurseInto(rawKey, depth)) {
+      const candidate = extractEntityToken(rawValue, depth + 1, nextPath);
+      if (candidate) return candidate;
+    }
+  }
+
+  return null;
+}
+
+export function getStoredEntityToken(): string | null {
+  try {
+    return normalizeEntityToken(safeLocalStorage.getItem("entityToken"));
+  } catch (err) {
+    console.warn("entityToken: unable to read from storage", err);
+    return null;
+  }
+}
+
+export function persistEntityToken(token: string | null | undefined): string | null {
+  const normalized = normalizeEntityToken(token);
+  try {
+    if (normalized) {
+      safeLocalStorage.setItem("entityToken", normalized);
+      return normalized;
+    }
+    safeLocalStorage.removeItem("entityToken");
+    return null;
+  } catch (err) {
+    console.warn("entityToken: unable to persist token", err);
+    return normalized ?? null;
+  }
+}
+
+export function clearStoredEntityToken() {
+  try {
+    safeLocalStorage.removeItem("entityToken");
+  } catch (err) {
+    console.warn("entityToken: unable to clear storage", err);
+  }
+}

--- a/src/utils/widgetMode.ts
+++ b/src/utils/widgetMode.ts
@@ -1,0 +1,33 @@
+const WIDGET_MODE_FLAG = "__CHATBOC_WIDGET_MODE__";
+const WIDGET_MODE_COUNT = "__CHATBOC_WIDGET_MODE_COUNT__";
+
+function getWindow(): any | null {
+  if (typeof window === "undefined") return null;
+  return window as any;
+}
+
+export function isWidgetModeActive(): boolean {
+  const w = getWindow();
+  return !!(w && w[WIDGET_MODE_FLAG]);
+}
+
+export function activateWidgetMode() {
+  const w = getWindow();
+  if (!w) return;
+  const current = Number(w[WIDGET_MODE_COUNT] || 0) + 1;
+  w[WIDGET_MODE_COUNT] = current;
+  w[WIDGET_MODE_FLAG] = true;
+}
+
+export function deactivateWidgetMode() {
+  const w = getWindow();
+  if (!w) return;
+  const current = Number(w[WIDGET_MODE_COUNT] || 0);
+  const next = current - 1;
+  if (next <= 0) {
+    delete w[WIDGET_MODE_FLAG];
+    delete w[WIDGET_MODE_COUNT];
+  } else {
+    w[WIDGET_MODE_COUNT] = next;
+  }
+}


### PR DESCRIPTION
## Summary
- stop apiFetch from reusing chat widget JWTs when the panel auth token is missing so admin requests no longer inherit short-lived chat tokens
- keep the stored entity token intact when /me fails and reuse the previous value on the Integración page when the backend cannot refresh it
- surface a warning on Integración when the previous token is reused instead of clearing it, keeping embeds running across deploys

## Testing
- `npm test` *(fails: Vitest suites require ../server/*.cjs fixtures and JSX transform support for tests/addressAutocomplete.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68ceb365d93083228b0ee170fa371a85