### PR TITLE
Improve tickets panel layout and responsiveness

### DIFF
--- a/src/components/tickets/ConversationPanel.tsx
+++ b/src/components/tickets/ConversationPanel.tsx
@@ -223,7 +223,7 @@ const ConversationPanel: React.FC<ConversationPanelProps> = ({ isMobile, isSideb
 
   if (!selectedTicket) {
     return (
-      <div className="flex flex-col h-screen bg-background items-center justify-center text-center p-4">
+      <div className="flex h-full flex-col items-center justify-center bg-background p-4 text-center">
         <MessageSquare className="w-16 h-16 text-muted-foreground mb-4" />
         <h2 className="text-xl font-semibold">Selecciona un ticket</h2>
         <p className="text-muted-foreground">Elige un ticket de la lista para ver la conversación.</p>
@@ -253,7 +253,7 @@ const ConversationPanel: React.FC<ConversationPanelProps> = ({ isMobile, isSideb
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ duration: 0.5 }}
-        className="flex flex-col h-screen bg-background"
+        className="flex h-full min-w-0 flex-col bg-background"
     >
       <header className="p-3 border-b border-border flex items-center justify-between shrink-0 h-16">
         <div className="flex items-center space-x-3">
@@ -309,6 +309,35 @@ const ConversationPanel: React.FC<ConversationPanelProps> = ({ isMobile, isSideb
           </DropdownMenu>
         </div>
       </header>
+
+      {isMobile && (
+        <div className="px-3 pb-2">
+          <div className="grid grid-cols-2 gap-2">
+            <Button
+              type="button"
+              variant={isDetailsVisible ? 'outline' : 'secondary'}
+              onClick={() => {
+                if (isDetailsVisible) {
+                  onToggleDetails();
+                }
+              }}
+            >
+              Conversación
+            </Button>
+            <Button
+              type="button"
+              variant={isDetailsVisible ? 'secondary' : 'outline'}
+              onClick={() => {
+                if (!isDetailsVisible) {
+                  onToggleDetails();
+                }
+              }}
+            >
+              Información
+            </Button>
+          </div>
+        </div>
+      )}
 
       <div className="flex-1 relative bg-gray-50/50 dark:bg-gray-900/50">
         <ScrollArea className="h-full p-4" ref={scrollAreaRef} onScroll={handleScroll}>

--- a/src/components/tickets/DetailsPanel.tsx
+++ b/src/components/tickets/DetailsPanel.tsx
@@ -287,9 +287,10 @@ export const getPrimaryImageUrl = (ticket: Ticket | null, attachments: Attachmen
 
 interface DetailsPanelProps {
   onClose?: () => void;
+  className?: string;
 }
 
-const DetailsPanel: React.FC<DetailsPanelProps> = ({ onClose }) => {
+const DetailsPanel: React.FC<DetailsPanelProps> = ({ onClose, className }) => {
   const { selectedTicket: ticket, updateTicket } = useTickets();
   const [isSendingEmail, setIsSendingEmail] = React.useState(false);
 
@@ -383,7 +384,7 @@ const DetailsPanel: React.FC<DetailsPanelProps> = ({ onClose }) => {
 
   if (!ticket) {
     return (
-       <aside className="w-full border-l border-border flex-col h-screen bg-muted/20 shrink-0 hidden lg:flex items-center justify-center p-6">
+       <aside className="hidden h-full w-full flex-col items-center justify-center border-l border-border bg-muted/20 p-6 lg:flex">
          <div className="text-center text-muted-foreground">
             <Info className="h-12 w-12 mx-auto mb-4" />
             <h3 className="font-semibold">Detalles del Ticket</h3>
@@ -507,10 +508,9 @@ const DetailsPanel: React.FC<DetailsPanelProps> = ({ onClose }) => {
         animate={{ opacity: 1 }}
         transition={{ duration: 0.5 }}
         className={cn(
-          "flex flex-col bg-muted/20 shrink-0 border-border",
-          onClose
-            ? "h-full md:h-screen w-full md:w-[360px] lg:w-[380px] border-l md:border-l"
-            : "h-screen w-full border-l"
+          'flex h-full shrink-0 flex-col border-border bg-muted/20',
+          onClose ? 'w-full border-0 md:border-l' : 'w-full border-l',
+          className,
         )}
     >
       <header className="sticky top-0 z-10 flex items-center justify-between gap-2 border-b border-border p-4 bg-muted/80 backdrop-blur supports-[backdrop-filter]:bg-muted/60">

--- a/src/components/tickets/NewTicketsPanel.tsx
+++ b/src/components/tickets/NewTicketsPanel.tsx
@@ -8,6 +8,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { useTickets } from '@/context/TicketContext';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Card } from '@/components/ui/card';
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
 
 const NewTicketsPanel: React.FC = () => {
   const isMobile = useIsMobile();
@@ -71,9 +72,9 @@ const NewTicketsPanel: React.FC = () => {
   }
 
   return (
-    <Card className="h-screen w-full bg-card shadow-xl rounded-xl border border-border backdrop-blur-sm overflow-hidden">
+    <Card className="flex w-full min-h-[calc(100vh-6rem)] flex-col overflow-hidden rounded-2xl border border-border bg-card shadow-xl backdrop-blur-sm">
       {isMobile ? (
-        <div className="relative h-full w-full overflow-hidden">
+        <div className="relative flex-1 overflow-hidden">
           <AnimatePresence>
             {isSidebarVisible && (
               <motion.div
@@ -82,9 +83,9 @@ const NewTicketsPanel: React.FC = () => {
                 animate={{ x: 0 }}
                 exit={{ x: '-100%' }}
                 transition={{ type: 'spring', stiffness: 300, damping: 30 }}
-                className="absolute top-0 left-0 h-full w-full z-20"
+                className="absolute top-0 left-0 z-20 h-full w-full"
               >
-                <Sidebar />
+                <Sidebar className="min-w-full" />
               </motion.div>
             )}
           </AnimatePresence>
@@ -110,7 +111,7 @@ const NewTicketsPanel: React.FC = () => {
                     animate={{ x: 0 }}
                     exit={{ x: '100%' }}
                     transition={{ type: 'spring', stiffness: 300, damping: 30 }}
-                    className="absolute top-0 left-0 h-full w-full z-30 bg-background"
+                    className="absolute top-0 left-0 z-30 h-full w-full overflow-y-auto bg-background"
                 >
                     <DetailsPanel onClose={toggleDetails} />
                 </motion.div>
@@ -118,17 +119,25 @@ const NewTicketsPanel: React.FC = () => {
           </AnimatePresence>
         </div>
       ) : (
-        <div className="grid grid-cols-[320px_1fr_380px] h-full w-full">
-          <Sidebar />
-          <ConversationPanel
-            isMobile={false}
-            isSidebarVisible={isSidebarVisible}
-            isDetailsVisible={true}
-            onToggleSidebar={toggleSidebar}
-            onToggleDetails={toggleDetails}
-          />
-          <DetailsPanel />
-        </div>
+        <ResizablePanelGroup direction="horizontal" className="flex-1">
+          <ResizablePanel defaultSize={26} minSize={20} maxSize={35} className="min-w-[280px]">
+            <Sidebar className="h-full" />
+          </ResizablePanel>
+          <ResizableHandle withHandle />
+          <ResizablePanel defaultSize={48} minSize={38} className="min-w-[420px]">
+            <ConversationPanel
+              isMobile={false}
+              isSidebarVisible={isSidebarVisible}
+              isDetailsVisible={true}
+              onToggleSidebar={toggleSidebar}
+              onToggleDetails={toggleDetails}
+            />
+          </ResizablePanel>
+          <ResizableHandle withHandle />
+          <ResizablePanel defaultSize={26} minSize={22} maxSize={40} className="min-w-[340px]">
+            <DetailsPanel className="h-full" />
+          </ResizablePanel>
+        </ResizablePanelGroup>
       )}
       <Toaster richColors />
     </Card>

--- a/src/components/tickets/Sidebar.tsx
+++ b/src/components/tickets/Sidebar.tsx
@@ -14,8 +14,13 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
+import { cn } from '@/lib/utils';
 
-const Sidebar: React.FC = () => {
+interface SidebarProps {
+  className?: string;
+}
+
+const Sidebar: React.FC<SidebarProps> = ({ className }) => {
   const { tickets, ticketsByCategory, selectedTicket, selectTicket } = useTickets();
   const [searchTerm, setSearchTerm] = React.useState('');
   const debouncedSearchTerm = useDebounce(searchTerm, 300);
@@ -55,7 +60,10 @@ const Sidebar: React.FC = () => {
   }, [ticketsByCategory, debouncedSearchTerm]);
 
   return (
-    <aside className="w-80 border-r border-border flex flex-col h-screen bg-muted/20 shrink-0">
+    <aside className={cn(
+      'flex h-full min-w-[260px] flex-col border-r border-border bg-muted/20',
+      className,
+    )}>
       <div className="p-4 space-y-4">
         <div className="flex justify-between items-center">
           <h1 className="text-2xl font-bold">Tickets</h1>

--- a/src/pages/TicketsPanel.tsx
+++ b/src/pages/TicketsPanel.tsx
@@ -5,10 +5,10 @@ import NewTicketsPanel from '@/components/tickets/NewTicketsPanel';
 import { TicketProvider } from '@/context/TicketContext';
 
 const TicketsPanelPage = () => {
-useRequireRole(['admin', 'empleado', 'super_admin'] as Role[]);
+  useRequireRole(['admin', 'empleado', 'super_admin'] as Role[]);
   return (
-    <div className="flex flex-col min-h-screen bg-background dark:bg-gradient-to-tr dark:from-slate-950 dark:to-slate-900 text-foreground py-8 px-2 sm:px-4 md:px-6 lg:px-8">
-      <div className="w-full max-w-7xl mx-auto mb-6 relative px-2">
+    <div className="flex flex-col min-h-screen bg-background dark:bg-gradient-to-tr dark:from-slate-950 dark:to-slate-900 text-foreground py-8 px-2 sm:px-4 md:px-6 xl:px-10">
+      <div className="relative mx-auto mb-6 w-full max-w-[95vw]">
         <TicketProvider>
           <NewTicketsPanel />
         </TicketProvider>


### PR DESCRIPTION
## Summary
- expand the tickets panel page container and wrapper card to use a wider portion of the viewport
- replace the static desktop grid with resizable columns and refresh the mobile slide panels and toggle buttons
- update the sidebar and details panel components to support full-height layouts and smoother mobile overlays

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf2572d3bc8322bee5eb2a33515003