### PR TITLE
Improve desktop ticket panel ergonomics

### DIFF
--- a/src/components/tickets/ConversationPanel.tsx
+++ b/src/components/tickets/ConversationPanel.tsx
@@ -51,9 +51,19 @@ interface ConversationPanelProps {
   isDetailsVisible: boolean;
   onToggleSidebar: () => void;
   onToggleDetails: () => void;
+  canToggleSidebar?: boolean;
+  showDetailsToggle?: boolean;
 }
 
-const ConversationPanel: React.FC<ConversationPanelProps> = ({ isMobile, isSidebarVisible, isDetailsVisible, onToggleSidebar, onToggleDetails }) => {
+const ConversationPanel: React.FC<ConversationPanelProps> = ({
+  isMobile,
+  isSidebarVisible,
+  isDetailsVisible,
+  onToggleSidebar,
+  onToggleDetails,
+  canToggleSidebar = false,
+  showDetailsToggle = false,
+}) => {
   const { selectedTicket, updateTicket } = useTickets();
   const [message, setMessage] = useState('');
   const [messages, setMessages] = useState<ChatMessageData[]>([]);
@@ -223,7 +233,7 @@ const ConversationPanel: React.FC<ConversationPanelProps> = ({ isMobile, isSideb
 
   if (!selectedTicket) {
     return (
-      <div className="flex flex-col h-screen bg-background items-center justify-center text-center p-4">
+      <div className="flex h-full flex-col items-center justify-center bg-background p-4 text-center">
         <MessageSquare className="w-16 h-16 text-muted-foreground mb-4" />
         <h2 className="text-xl font-semibold">Selecciona un ticket</h2>
         <p className="text-muted-foreground">Elige un ticket de la lista para ver la conversación.</p>
@@ -253,12 +263,17 @@ const ConversationPanel: React.FC<ConversationPanelProps> = ({ isMobile, isSideb
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ duration: 0.5 }}
-        className="flex flex-col h-screen bg-background"
+        className="flex h-full min-w-0 flex-col bg-background"
     >
       <header className="p-3 border-b border-border flex items-center justify-between shrink-0 h-16">
         <div className="flex items-center space-x-3">
-          {(isMobile || !isSidebarVisible) && (
-            <Button variant="ghost" size="icon" onClick={onToggleSidebar} aria-label="Toggle Sidebar">
+          {canToggleSidebar && (
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onToggleSidebar}
+              aria-label={isSidebarVisible ? 'Ocultar lista de tickets' : 'Mostrar lista de tickets'}
+            >
               {isSidebarVisible ? <PanelLeftClose className="h-5 w-5" /> : <PanelLeft className="h-5 w-5" />}
             </Button>
           )}
@@ -275,7 +290,7 @@ const ConversationPanel: React.FC<ConversationPanelProps> = ({ isMobile, isSideb
           </div>
         </div>
         <div className="flex items-center space-x-2">
-          {isMobile && (
+          {showDetailsToggle && (
             <Button
               variant={isDetailsVisible ? 'secondary' : 'outline'}
               size="sm"
@@ -309,6 +324,35 @@ const ConversationPanel: React.FC<ConversationPanelProps> = ({ isMobile, isSideb
           </DropdownMenu>
         </div>
       </header>
+
+      {showDetailsToggle && (isMobile || canToggleSidebar) && (
+        <div className="px-3 pb-2 md:px-4 md:pb-3">
+          <div className="grid grid-cols-2 gap-2">
+            <Button
+              type="button"
+              variant={isDetailsVisible ? 'outline' : 'secondary'}
+              onClick={() => {
+                if (isDetailsVisible) {
+                  onToggleDetails();
+                }
+              }}
+            >
+              Conversación
+            </Button>
+            <Button
+              type="button"
+              variant={isDetailsVisible ? 'secondary' : 'outline'}
+              onClick={() => {
+                if (!isDetailsVisible) {
+                  onToggleDetails();
+                }
+              }}
+            >
+              Información
+            </Button>
+          </div>
+        </div>
+      )}
 
       <div className="flex-1 relative bg-gray-50/50 dark:bg-gray-900/50">
         <ScrollArea className="h-full p-4" ref={scrollAreaRef} onScroll={handleScroll}>

--- a/src/components/tickets/DetailsPanel.tsx
+++ b/src/components/tickets/DetailsPanel.tsx
@@ -287,9 +287,10 @@ export const getPrimaryImageUrl = (ticket: Ticket | null, attachments: Attachmen
 
 interface DetailsPanelProps {
   onClose?: () => void;
+  className?: string;
 }
 
-const DetailsPanel: React.FC<DetailsPanelProps> = ({ onClose }) => {
+const DetailsPanel: React.FC<DetailsPanelProps> = ({ onClose, className }) => {
   const { selectedTicket: ticket, updateTicket } = useTickets();
   const [isSendingEmail, setIsSendingEmail] = React.useState(false);
 
@@ -383,7 +384,7 @@ const DetailsPanel: React.FC<DetailsPanelProps> = ({ onClose }) => {
 
   if (!ticket) {
     return (
-       <aside className="w-full border-l border-border flex-col h-screen bg-muted/20 shrink-0 hidden lg:flex items-center justify-center p-6">
+       <aside className="hidden h-full w-full flex-col items-center justify-center border-l border-border bg-muted/20 p-6 lg:flex">
          <div className="text-center text-muted-foreground">
             <Info className="h-12 w-12 mx-auto mb-4" />
             <h3 className="font-semibold">Detalles del Ticket</h3>
@@ -507,10 +508,9 @@ const DetailsPanel: React.FC<DetailsPanelProps> = ({ onClose }) => {
         animate={{ opacity: 1 }}
         transition={{ duration: 0.5 }}
         className={cn(
-          "flex flex-col bg-muted/20 shrink-0 border-border",
-          onClose
-            ? "h-full md:h-screen w-full md:w-[360px] lg:w-[380px] border-l md:border-l"
-            : "h-screen w-full border-l"
+          'flex h-full shrink-0 flex-col border-border bg-muted/20',
+          onClose ? 'w-full border-0 md:border-l' : 'w-full border-l',
+          className,
         )}
     >
       <header className="sticky top-0 z-10 flex items-center justify-between gap-2 border-b border-border p-4 bg-muted/80 backdrop-blur supports-[backdrop-filter]:bg-muted/60">

--- a/src/components/tickets/NewTicketsPanel.tsx
+++ b/src/components/tickets/NewTicketsPanel.tsx
@@ -8,23 +8,105 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { useTickets } from '@/context/TicketContext';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Card } from '@/components/ui/card';
+import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable';
+import type { ImperativePanelHandle } from 'react-resizable-panels';
 
 const NewTicketsPanel: React.FC = () => {
   const isMobile = useIsMobile();
   const { loading, error, selectedTicket } = useTickets();
   const [isSidebarVisible, setIsSidebarVisible] = React.useState(!isMobile);
   const [isDetailsVisible, setIsDetailsVisible] = React.useState(!isMobile);
+  const [isWideLayout, setIsWideLayout] = React.useState<boolean>(() => {
+    if (typeof window === 'undefined') {
+      return true;
+    }
+    return window.matchMedia('(min-width: 1440px)').matches;
+  });
+  const detailsPanelRef = React.useRef<ImperativePanelHandle | null>(null);
+  const lastWideDetailsSize = React.useRef<number | null>(null);
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia('(min-width: 1440px)');
+    const applyMatch = (value: boolean) => setIsWideLayout(value);
+
+    applyMatch(mediaQuery.matches);
+
+    const handler = (event: MediaQueryListEvent) => applyMatch(event.matches);
+
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', handler);
+      return () => mediaQuery.removeEventListener('change', handler);
+    }
+
+    mediaQuery.addListener(handler);
+    return () => mediaQuery.removeListener(handler);
+  }, []);
+
+  React.useEffect(() => {
+    if (!isMobile) {
+      return;
+    }
+    setIsDetailsVisible(false);
+    // Show sidebar only if no ticket is selected on mobile
+    setIsSidebarVisible(!selectedTicket);
+  }, [isMobile, selectedTicket]);
 
   React.useEffect(() => {
     if (isMobile) {
-      setIsDetailsVisible(false);
-      // Show sidebar only if no ticket is selected on mobile
-      setIsSidebarVisible(!selectedTicket);
-    } else {
-      setIsDetailsVisible(true);
-      setIsSidebarVisible(true);
+      return;
     }
-  }, [isMobile, selectedTicket]);
+    if (isWideLayout) {
+      setIsDetailsVisible(true);
+    } else {
+      setIsDetailsVisible(false);
+    }
+    setIsSidebarVisible(true);
+  }, [isMobile, isWideLayout]);
+
+  React.useEffect(() => {
+    if (!isWideLayout) {
+      return;
+    }
+
+    const panel = detailsPanelRef.current;
+
+    if (!panel) {
+      return;
+    }
+
+    if (lastWideDetailsSize.current === null) {
+      const currentSize = panel.getSize();
+
+      if (currentSize > 0) {
+        lastWideDetailsSize.current = currentSize;
+      }
+    }
+
+    if (isDetailsVisible) {
+      const storedSize = lastWideDetailsSize.current;
+
+      if (panel.isCollapsed()) {
+        panel.expand(
+          typeof storedSize === 'number' && storedSize > 0 ? storedSize : undefined,
+        );
+      }
+
+      if (typeof storedSize === 'number' && storedSize > 0) {
+        const currentSize = panel.getSize();
+
+        if (Math.abs(currentSize - storedSize) > 0.5) {
+          panel.resize(storedSize);
+        }
+      }
+    } else if (!panel.isCollapsed()) {
+      lastWideDetailsSize.current = panel.getSize();
+      panel.collapse();
+    }
+  }, [isDetailsVisible, isWideLayout]);
 
   const toggleSidebar = () => setIsSidebarVisible(prev => !prev);
   const toggleDetails = () => setIsDetailsVisible(prev => !prev);
@@ -71,9 +153,9 @@ const NewTicketsPanel: React.FC = () => {
   }
 
   return (
-    <Card className="h-screen w-full bg-card shadow-xl rounded-xl border border-border backdrop-blur-sm overflow-hidden">
+    <Card className="relative flex h-full w-full flex-col overflow-hidden rounded-2xl border border-border bg-card shadow-xl backdrop-blur-sm">
       {isMobile ? (
-        <div className="relative h-full w-full overflow-hidden">
+        <div className="relative flex-1 overflow-hidden">
           <AnimatePresence>
             {isSidebarVisible && (
               <motion.div
@@ -82,17 +164,17 @@ const NewTicketsPanel: React.FC = () => {
                 animate={{ x: 0 }}
                 exit={{ x: '-100%' }}
                 transition={{ type: 'spring', stiffness: 300, damping: 30 }}
-                className="absolute top-0 left-0 h-full w-full z-20"
+                className="absolute left-0 top-0 z-20 h-full w-full"
               >
-                <Sidebar />
+                <Sidebar className="h-full w-full min-w-full" />
               </motion.div>
             )}
           </AnimatePresence>
           <motion.div
-             key="conversation"
-             className="absolute top-0 left-0 h-full w-full z-10"
-             animate={{ x: isSidebarVisible ? '100%' : '0%' }}
-             transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+            key="conversation"
+            className="absolute left-0 top-0 z-10 h-full w-full"
+            animate={{ x: isSidebarVisible ? '100%' : '0%' }}
+            transition={{ type: 'spring', stiffness: 300, damping: 30 }}
           >
             <ConversationPanel
               isMobile={true}
@@ -100,34 +182,104 @@ const NewTicketsPanel: React.FC = () => {
               isDetailsVisible={isDetailsVisible}
               onToggleSidebar={toggleSidebar}
               onToggleDetails={toggleDetails}
+              canToggleSidebar
+              showDetailsToggle
             />
           </motion.div>
           <AnimatePresence>
             {isDetailsVisible && (
-                <motion.div
-                    key="details"
-                    initial={{ x: '100%' }}
-                    animate={{ x: 0 }}
-                    exit={{ x: '100%' }}
-                    transition={{ type: 'spring', stiffness: 300, damping: 30 }}
-                    className="absolute top-0 left-0 h-full w-full z-30 bg-background"
-                >
-                    <DetailsPanel onClose={toggleDetails} />
-                </motion.div>
+              <motion.div
+                key="details"
+                initial={{ x: '100%' }}
+                animate={{ x: 0 }}
+                exit={{ x: '100%' }}
+                transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+                className="absolute left-0 top-0 z-30 h-full w-full overflow-y-auto bg-background"
+              >
+                <DetailsPanel onClose={toggleDetails} />
+              </motion.div>
             )}
           </AnimatePresence>
         </div>
+      ) : isWideLayout ? (
+        <ResizablePanelGroup direction="horizontal" className="flex h-full w-full overflow-hidden">
+          <ResizablePanel
+            defaultSize={22}
+            minSize={18}
+            maxSize={30}
+            className="min-w-[260px]"
+          >
+            <Sidebar className="h-full w-full shrink-0" />
+          </ResizablePanel>
+          <ResizableHandle withHandle className="bg-border/70 transition-colors hover:bg-primary/50" />
+          <ResizablePanel
+            defaultSize={48}
+            minSize={36}
+            className="min-w-[620px]"
+          >
+            <ConversationPanel
+              isMobile={false}
+              isSidebarVisible={true}
+              isDetailsVisible={isDetailsVisible}
+              onToggleSidebar={toggleSidebar}
+              onToggleDetails={toggleDetails}
+              showDetailsToggle
+            />
+          </ResizablePanel>
+          <ResizableHandle withHandle className="bg-border/70 transition-colors hover:bg-primary/50" />
+          <ResizablePanel
+            ref={detailsPanelRef}
+            defaultSize={30}
+            minSize={22}
+            maxSize={40}
+            collapsible
+            collapsedSize={0}
+            onResize={(size) => {
+              if (size > 0) {
+                lastWideDetailsSize.current = size;
+              }
+            }}
+            onCollapse={() =>
+              setIsDetailsVisible((prev) => (prev ? false : prev))
+            }
+            onExpand={() =>
+              setIsDetailsVisible((prev) => (prev ? prev : true))
+            }
+            className="min-w-[320px] max-w-[560px] overflow-hidden"
+          >
+            <DetailsPanel className="h-full w-full" />
+          </ResizablePanel>
+        </ResizablePanelGroup>
       ) : (
-        <div className="grid grid-cols-[320px_1fr_380px] h-full w-full">
-          <Sidebar />
-          <ConversationPanel
-            isMobile={false}
-            isSidebarVisible={isSidebarVisible}
-            isDetailsVisible={true}
-            onToggleSidebar={toggleSidebar}
-            onToggleDetails={toggleDetails}
-          />
-          <DetailsPanel />
+        <div className="flex h-full w-full overflow-hidden">
+          {isSidebarVisible && (
+            <Sidebar className="w-[clamp(260px,26vw,340px)] shrink-0 xl:w-[clamp(280px,22vw,360px)] 2xl:w-[clamp(300px,20vw,380px)]" />
+          )}
+          <div className="relative flex min-w-0 flex-1 bg-background">
+            <ConversationPanel
+              isMobile={false}
+              isSidebarVisible={isSidebarVisible}
+              isDetailsVisible={isDetailsVisible}
+              onToggleSidebar={toggleSidebar}
+              onToggleDetails={toggleDetails}
+              canToggleSidebar
+              showDetailsToggle
+            />
+            <AnimatePresence>
+              {isDetailsVisible && (
+                <motion.div
+                  key="compact-details"
+                  initial={{ x: '100%' }}
+                  animate={{ x: 0 }}
+                  exit={{ x: '100%' }}
+                  transition={{ type: 'spring', stiffness: 320, damping: 32 }}
+                  className="absolute inset-y-0 right-0 z-30 flex w-full max-w-[clamp(320px,42vw,520px)] overflow-hidden border-l border-border bg-card shadow-xl"
+                >
+                  <DetailsPanel onClose={toggleDetails} className="w-full" />
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </div>
         </div>
       )}
       <Toaster richColors />

--- a/src/components/tickets/Sidebar.tsx
+++ b/src/components/tickets/Sidebar.tsx
@@ -14,8 +14,13 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
+import { cn } from '@/lib/utils';
 
-const Sidebar: React.FC = () => {
+interface SidebarProps {
+  className?: string;
+}
+
+const Sidebar: React.FC<SidebarProps> = ({ className }) => {
   const { tickets, ticketsByCategory, selectedTicket, selectTicket } = useTickets();
   const [searchTerm, setSearchTerm] = React.useState('');
   const debouncedSearchTerm = useDebounce(searchTerm, 300);
@@ -55,7 +60,12 @@ const Sidebar: React.FC = () => {
   }, [ticketsByCategory, debouncedSearchTerm]);
 
   return (
-    <aside className="w-80 border-r border-border flex flex-col h-screen bg-muted/20 shrink-0">
+    <aside
+      className={cn(
+        'flex h-full min-w-0 shrink-0 flex-col border-r border-border bg-muted/20',
+        className,
+      )}
+    >
       <div className="p-4 space-y-4">
         <div className="flex justify-between items-center">
           <h1 className="text-2xl font-bold">Tickets</h1>

--- a/src/components/tickets/TicketAttachments.tsx
+++ b/src/components/tickets/TicketAttachments.tsx
@@ -26,6 +26,28 @@ const TicketAttachments: React.FC<Props> = ({ attachments }) => {
   const others = allowed.filter((p) => p.info.type !== 'image');
   const [openUrl, setOpenUrl] = useState<string | null>(null);
 
+  React.useEffect(() => {
+    if (!openUrl) {
+      return;
+    }
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpenUrl(null);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [openUrl]);
+
   if (!images.length && !others.length && !disallowed.length) return null;
 
   return (
@@ -83,7 +105,7 @@ const TicketAttachments: React.FC<Props> = ({ attachments }) => {
       )}
       {openUrl && (
         <div
-          className="fixed inset-0 z-50 bg-black/70 flex items-center justify-center p-4"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
           onClick={() => setOpenUrl(null)}
           role="dialog"
           aria-modal="true"

--- a/src/pages/TicketsPanel.tsx
+++ b/src/pages/TicketsPanel.tsx
@@ -5,10 +5,10 @@ import NewTicketsPanel from '@/components/tickets/NewTicketsPanel';
 import { TicketProvider } from '@/context/TicketContext';
 
 const TicketsPanelPage = () => {
-useRequireRole(['admin', 'empleado', 'super_admin'] as Role[]);
+  useRequireRole(['admin', 'empleado', 'super_admin'] as Role[]);
   return (
-    <div className="flex flex-col min-h-screen bg-background dark:bg-gradient-to-tr dark:from-slate-950 dark:to-slate-900 text-foreground py-8 px-2 sm:px-4 md:px-6 lg:px-8">
-      <div className="w-full max-w-7xl mx-auto mb-6 relative px-2">
+    <div className="flex min-h-screen flex-col bg-background dark:bg-gradient-to-tr dark:from-slate-950 dark:to-slate-900 text-foreground py-6 sm:py-8 px-2 sm:px-4 md:px-6 xl:px-10">
+      <div className="relative mx-auto flex w-full flex-1 max-w-[min(2200px,98vw)]">
         <TicketProvider>
           <NewTicketsPanel />
         </TicketProvider>


### PR DESCRIPTION
## Summary
- raise the breakpoint for the three-column desktop layout and manage the ticket, chat, and detail panes with a resizable panel group so the conversation can breathe on large monitors
- remember and collapse the desktop details width while keeping the mobile and compact overlays functional
- let the sidebar width flex with its container and widen the tickets page frame to better use the viewport

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf2572d3bc8322bee5eb2a33515003