### PR TITLE
Add logistics tracking summary to ticket conversation view

### DIFF
--- a/src/components/tickets/ConversationPanel.tsx
+++ b/src/components/tickets/ConversationPanel.tsx
@@ -7,6 +7,7 @@ import { Badge } from '@/components/ui/badge';
 import { Ticket, TicketStatus, Message as TicketMessage } from '@/types/tickets';
 import { Message as ChatMessageData, SendPayload, AttachmentInfo } from '@/types/chat';
 import ChatMessage from './ChatMessage';
+import TicketLogisticsSummary from './TicketLogisticsSummary';
 import { AnimatePresence, motion } from 'framer-motion';
 import PredefinedMessagesModal from './PredefinedMessagesModal';
 import useSpeechRecognition from '@/hooks/useSpeechRecognition';
@@ -351,6 +352,12 @@ const ConversationPanel: React.FC<ConversationPanelProps> = ({
               Información
             </Button>
           </div>
+        </div>
+      )}
+
+      {showDetailsToggle && selectedTicket && (
+        <div className="px-3 pb-3 md:px-4 md:pb-4">
+          <TicketLogisticsSummary ticket={selectedTicket} />
         </div>
       )}
 

--- a/src/components/tickets/DetailsPanel.tsx
+++ b/src/components/tickets/DetailsPanel.tsx
@@ -36,7 +36,7 @@ import {
 import { FaWhatsapp } from 'react-icons/fa';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
-import { getContactPhone, getCitizenDni } from '@/utils/ticket';
+import { getContactPhone, getCitizenDni, getTicketChannel } from '@/utils/ticket';
 import { fmtAR } from '@/utils/date';
 import { getSpecializedContact, SpecializedContact } from '@/utils/contacts';
 import { deriveAttachmentInfo } from '@/utils/attachment';
@@ -497,8 +497,8 @@ const DetailsPanel: React.FC<DetailsPanelProps> = ({ onClose, className }) => {
     return base;
   };
 
-  const formatDate = (dateString: string | undefined) =>
-    dateString ? fmtAR(dateString) : 'No informado';
+  const formatDate = (dateString?: string) => fmtAR(dateString ?? '');
+  const channelLabel = React.useMemo(() => getTicketChannel(ticket), [ticket]);
 
 
   return (
@@ -738,7 +738,16 @@ const DetailsPanel: React.FC<DetailsPanelProps> = ({ onClose, className }) => {
                 <TicketStatusBar status={currentStatus} flow={statusFlow} />
                 <div className="flex justify-between items-center">
                     <span className="text-muted-foreground">Canal:</span>
-                    <span className="capitalize">{ticket.channel || 'N/A'}</span>
+                    <span
+                      className={cn(
+                        'font-medium',
+                        channelLabel === 'N/A'
+                          ? 'uppercase tracking-wide text-muted-foreground'
+                          : 'capitalize text-foreground'
+                      )}
+                    >
+                      {channelLabel}
+                    </span>
                 </div>
                 <div className="flex justify-between items-center">
                     <span className="text-muted-foreground">Creado:</span>

--- a/src/components/tickets/TicketLogisticsSummary.tsx
+++ b/src/components/tickets/TicketLogisticsSummary.tsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import TicketStatusBar from './TicketStatusBar';
+import TicketMap from '../TicketMap';
+import { Ticket } from '@/types/tickets';
+import { fmtAR } from '@/utils/date';
+import { getTicketChannel } from '@/utils/ticket';
+import { cn } from '@/lib/utils';
+import { CalendarClock, Clock3, MapPin, Building, Hash, MessageCircle, Tag } from 'lucide-react';
+
+interface TicketLogisticsSummaryProps {
+  ticket: Ticket;
+  className?: string;
+}
+
+type IconType = React.ComponentType<React.SVGProps<SVGSVGElement>>;
+
+const formatStatus = (status?: string | null) =>
+  status
+    ? status
+        .replace(/[_-]+/g, ' ')
+        .replace(/\b\w/g, (char) => char.toUpperCase())
+    : 'Sin estado';
+
+const hasCoordinateValue = (value?: number | null) =>
+  typeof value === 'number' && Number.isFinite(value) && value !== 0;
+
+const TicketLogisticsSummary: React.FC<TicketLogisticsSummaryProps> = ({ ticket, className }) => {
+  const statusFlow = Array.isArray(ticket.history)
+    ? ticket.history.map((h) => h.status).filter(Boolean)
+    : [];
+
+  const channelLabel = getTicketChannel(ticket);
+  const createdAtLabel = fmtAR(ticket.fecha);
+  const estimatedArrival = ticket.tiempo_estimado;
+
+  const metaItems = [
+    {
+      label: 'Creado el',
+      value: createdAtLabel,
+      icon: CalendarClock,
+      valueClassName: 'text-foreground',
+    },
+    {
+      label: 'Canal',
+      value: channelLabel,
+      icon: MessageCircle,
+      valueClassName:
+        channelLabel === 'N/A'
+          ? 'uppercase tracking-wide text-muted-foreground'
+          : 'capitalize text-foreground',
+    },
+    estimatedArrival
+      ? {
+          label: 'Tiempo estimado',
+          value: estimatedArrival,
+          icon: Clock3,
+          valueClassName: 'text-foreground',
+        }
+      : null,
+  ].filter(Boolean) as { label: string; value: string; icon: IconType; valueClassName?: string }[];
+
+  const detailItems = [
+    ticket.categoria
+      ? { label: 'Categoría', value: ticket.categoria, icon: Tag }
+      : null,
+    ticket.direccion
+      ? { label: 'Dirección', value: ticket.direccion, icon: MapPin }
+      : null,
+    ticket.esquinas_cercanas
+      ? { label: 'Esquinas', value: ticket.esquinas_cercanas, icon: Hash }
+      : null,
+    ticket.distrito
+      ? { label: 'Distrito', value: ticket.distrito, icon: Building }
+      : null,
+  ].filter(Boolean) as { label: string; value: string; icon?: IconType }[];
+
+  const hasLocation = Boolean(
+    ticket.direccion ||
+      hasCoordinateValue(ticket.latitud) ||
+      hasCoordinateValue(ticket.longitud) ||
+      hasCoordinateValue(ticket.lat_destino) ||
+      hasCoordinateValue(ticket.lon_destino) ||
+      hasCoordinateValue(ticket.lat_origen) ||
+      hasCoordinateValue(ticket.lon_origen) ||
+      hasCoordinateValue(ticket.lat_actual) ||
+      hasCoordinateValue(ticket.lon_actual) ||
+      hasCoordinateValue(ticket.origen_latitud) ||
+      hasCoordinateValue(ticket.origen_longitud) ||
+      hasCoordinateValue(ticket.municipio_latitud) ||
+      hasCoordinateValue(ticket.municipio_longitud)
+  );
+
+  const heading = ticket.categoria || ticket.asunto || 'Seguimiento del reclamo';
+
+  return (
+    <Card className={cn('bg-card/90 border border-primary/20 shadow-lg backdrop-blur-sm', className)}>
+      <CardContent className="space-y-4 p-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">
+              Ticket #{ticket.nro_ticket || '—'}
+            </p>
+            <h3 className="text-lg font-semibold leading-tight text-foreground">{heading}</h3>
+          </div>
+          <Badge variant="secondary" className="capitalize">
+            {formatStatus(ticket.estado)}
+          </Badge>
+        </div>
+
+        {metaItems.length > 0 && (
+          <div className="flex flex-wrap gap-2 sm:gap-3">
+            {metaItems.map((item) => (
+              <div
+                key={item.label}
+                className="flex items-center gap-2 rounded-full bg-muted/70 px-3 py-1.5 text-xs sm:text-sm text-muted-foreground"
+              >
+                <item.icon className="h-4 w-4 text-primary" />
+                <span className="font-medium text-foreground">{item.label}:</span>
+                <span className={cn('text-foreground', item.valueClassName)}>{item.value}</span>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {(ticket.estado || statusFlow.length > 0) && (
+          <TicketStatusBar status={ticket.estado} flow={statusFlow} />
+        )}
+
+        <div className="grid gap-4 md:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)]">
+          <div className="space-y-3 text-sm">
+            {detailItems.length > 0 && (
+              <div className="grid gap-3">
+                {detailItems.map((item) => (
+                  <div key={item.label} className="flex items-start gap-2">
+                    {item.icon && <item.icon className="mt-0.5 h-4 w-4 text-primary" />}
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                        {item.label}
+                      </p>
+                      <p className="font-medium leading-snug text-foreground">{item.value}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {hasLocation && (
+            <div className="overflow-hidden rounded-xl border border-border bg-muted/40 shadow-sm">
+              <TicketMap
+                ticket={ticket}
+                hideTitle
+                heightClassName="h-[160px] sm:h-[180px]"
+                showAddressHint={false}
+              />
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default TicketLogisticsSummary;

--- a/src/pages/TicketLookup.tsx
+++ b/src/pages/TicketLookup.tsx
@@ -9,7 +9,7 @@ import TicketTimeline from '@/components/tickets/TicketTimeline';
 import TicketMap from '@/components/TicketMap';
 import { Separator } from '@/components/ui/separator';
 import { getErrorMessage, ApiError } from '@/utils/api';
-import { getContactPhone, getCitizenDni } from '@/utils/ticket';
+import { getContactPhone, getCitizenDni, getTicketChannel } from '@/utils/ticket';
 import { getSpecializedContact, SpecializedContact } from '@/utils/contacts';
 import TicketStatusBar from '@/components/tickets/TicketStatusBar';
 import { collectAttachmentsFromTicket, getPrimaryImageUrl } from '@/components/tickets/DetailsPanel';
@@ -46,6 +46,7 @@ export default function TicketLookup() {
     () => estadoChat || ticket?.estado || statusFlow[statusFlow.length - 1] || '',
     [estadoChat, ticket?.estado, statusFlow],
   );
+  const channelLabel = React.useMemo(() => getTicketChannel(ticket), [ticket]);
   const hasLocation = React.useMemo(() => {
     if (!ticket) return false;
     const hasCoords =
@@ -305,7 +306,15 @@ export default function TicketLookup() {
                 <dt>Creado el:</dt>
                 <dd>{fmtAR(ticket.fecha)}</dd>
                 <dt>Canal:</dt>
-                <dd className="capitalize">{ticket.channel || 'N/A'}</dd>
+                <dd
+                  className={
+                    channelLabel === 'N/A'
+                      ? 'uppercase tracking-wide text-muted-foreground'
+                      : 'capitalize text-foreground'
+                  }
+                >
+                  {channelLabel}
+                </dd>
                 {estimatedArrival && (
                   <>
                     <dt>Tiempo estimado:</dt>

--- a/src/utils/ticket.ts
+++ b/src/utils/ticket.ts
@@ -34,3 +34,29 @@ export function getCitizenDni(ticket?: Ticket | null): string | undefined {
     (ticket as any)?.documento
   );
 }
+
+/**
+ * Returns a human readable channel label for the ticket.
+ * Falls back to "N/A" when no channel information is available.
+ */
+export function getTicketChannel(ticket?: Ticket | null): string {
+  if (!ticket) return 'N/A';
+
+  const rawChannel = (
+    (ticket as any)?.channel ??
+    (ticket as any)?.canal ??
+    ticket.channel
+  );
+
+  if (typeof rawChannel !== 'string') {
+    return 'N/A';
+  }
+
+  const trimmed = rawChannel.trim();
+
+  if (!trimmed || /^n\s*\/\s*a$/i.test(trimmed)) {
+    return 'N/A';
+  }
+
+  return trimmed.replace(/[_-]+/g, ' ').replace(/\s+/g, ' ');
+}


### PR DESCRIPTION
## Summary
- add a TicketLogisticsSummary card that highlights status, dates, channel fallback handling, and location map
- render the logistics summary inside the conversation panel when the compact details toggle is available
- normalize channel formatting and "Fecha no disponible" fallback in the ticket details and public lookup views

## Testing
- npm test *(fails: requires server/*.cjs test fixtures that are not present in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf33f0f4e483229e5aba1869601623