### PR TITLE
Refine ticket workspace layout for desktop and mobile

### DIFF
--- a/src/components/tickets/ConversationPanel.tsx
+++ b/src/components/tickets/ConversationPanel.tsx
@@ -51,9 +51,19 @@ interface ConversationPanelProps {
   isDetailsVisible: boolean;
   onToggleSidebar: () => void;
   onToggleDetails: () => void;
+  canToggleSidebar?: boolean;
+  showDetailsToggle?: boolean;
 }
 
-const ConversationPanel: React.FC<ConversationPanelProps> = ({ isMobile, isSidebarVisible, isDetailsVisible, onToggleSidebar, onToggleDetails }) => {
+const ConversationPanel: React.FC<ConversationPanelProps> = ({
+  isMobile,
+  isSidebarVisible,
+  isDetailsVisible,
+  onToggleSidebar,
+  onToggleDetails,
+  canToggleSidebar = false,
+  showDetailsToggle = false,
+}) => {
   const { selectedTicket, updateTicket } = useTickets();
   const [message, setMessage] = useState('');
   const [messages, setMessages] = useState<ChatMessageData[]>([]);
@@ -223,7 +233,7 @@ const ConversationPanel: React.FC<ConversationPanelProps> = ({ isMobile, isSideb
 
   if (!selectedTicket) {
     return (
-      <div className="flex flex-col h-screen bg-background items-center justify-center text-center p-4">
+      <div className="flex h-full flex-col items-center justify-center bg-background p-4 text-center">
         <MessageSquare className="w-16 h-16 text-muted-foreground mb-4" />
         <h2 className="text-xl font-semibold">Selecciona un ticket</h2>
         <p className="text-muted-foreground">Elige un ticket de la lista para ver la conversación.</p>
@@ -253,12 +263,17 @@ const ConversationPanel: React.FC<ConversationPanelProps> = ({ isMobile, isSideb
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ duration: 0.5 }}
-        className="flex flex-col h-screen bg-background"
+        className="flex h-full min-w-0 flex-col bg-background"
     >
       <header className="p-3 border-b border-border flex items-center justify-between shrink-0 h-16">
         <div className="flex items-center space-x-3">
-          {(isMobile || !isSidebarVisible) && (
-            <Button variant="ghost" size="icon" onClick={onToggleSidebar} aria-label="Toggle Sidebar">
+          {canToggleSidebar && (
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onToggleSidebar}
+              aria-label={isSidebarVisible ? 'Ocultar lista de tickets' : 'Mostrar lista de tickets'}
+            >
               {isSidebarVisible ? <PanelLeftClose className="h-5 w-5" /> : <PanelLeft className="h-5 w-5" />}
             </Button>
           )}
@@ -275,7 +290,7 @@ const ConversationPanel: React.FC<ConversationPanelProps> = ({ isMobile, isSideb
           </div>
         </div>
         <div className="flex items-center space-x-2">
-          {isMobile && (
+          {showDetailsToggle && (
             <Button
               variant={isDetailsVisible ? 'secondary' : 'outline'}
               size="sm"
@@ -309,6 +324,35 @@ const ConversationPanel: React.FC<ConversationPanelProps> = ({ isMobile, isSideb
           </DropdownMenu>
         </div>
       </header>
+
+      {showDetailsToggle && !isMobile && canToggleSidebar && (
+        <div className="px-3 pb-2 md:px-4 md:pb-3">
+          <div className="grid grid-cols-2 gap-2">
+            <Button
+              type="button"
+              variant={isDetailsVisible ? 'outline' : 'secondary'}
+              onClick={() => {
+                if (isDetailsVisible) {
+                  onToggleDetails();
+                }
+              }}
+            >
+              Conversación
+            </Button>
+            <Button
+              type="button"
+              variant={isDetailsVisible ? 'secondary' : 'outline'}
+              onClick={() => {
+                if (!isDetailsVisible) {
+                  onToggleDetails();
+                }
+              }}
+            >
+              Información
+            </Button>
+          </div>
+        </div>
+      )}
 
       <div className="flex-1 relative bg-gray-50/50 dark:bg-gray-900/50">
         <ScrollArea className="h-full p-4" ref={scrollAreaRef} onScroll={handleScroll}>

--- a/src/components/tickets/DetailsPanel.tsx
+++ b/src/components/tickets/DetailsPanel.tsx
@@ -287,9 +287,10 @@ export const getPrimaryImageUrl = (ticket: Ticket | null, attachments: Attachmen
 
 interface DetailsPanelProps {
   onClose?: () => void;
+  className?: string;
 }
 
-const DetailsPanel: React.FC<DetailsPanelProps> = ({ onClose }) => {
+const DetailsPanel: React.FC<DetailsPanelProps> = ({ onClose, className }) => {
   const { selectedTicket: ticket, updateTicket } = useTickets();
   const [isSendingEmail, setIsSendingEmail] = React.useState(false);
 
@@ -383,7 +384,7 @@ const DetailsPanel: React.FC<DetailsPanelProps> = ({ onClose }) => {
 
   if (!ticket) {
     return (
-       <aside className="w-full border-l border-border flex-col h-screen bg-muted/20 shrink-0 hidden lg:flex items-center justify-center p-6">
+       <aside className="hidden h-full w-full flex-col items-center justify-center border-l border-border bg-muted/20 p-6 lg:flex">
          <div className="text-center text-muted-foreground">
             <Info className="h-12 w-12 mx-auto mb-4" />
             <h3 className="font-semibold">Detalles del Ticket</h3>
@@ -507,10 +508,9 @@ const DetailsPanel: React.FC<DetailsPanelProps> = ({ onClose }) => {
         animate={{ opacity: 1 }}
         transition={{ duration: 0.5 }}
         className={cn(
-          "flex flex-col bg-muted/20 shrink-0 border-border",
-          onClose
-            ? "h-full md:h-screen w-full md:w-[360px] lg:w-[380px] border-l md:border-l"
-            : "h-screen w-full border-l"
+          'flex h-full shrink-0 flex-col border-border bg-muted/20',
+          onClose ? 'w-full border-0 md:border-l' : 'w-full border-l',
+          className,
         )}
     >
       <header className="sticky top-0 z-10 flex items-center justify-between gap-2 border-b border-border p-4 bg-muted/80 backdrop-blur supports-[backdrop-filter]:bg-muted/60">

--- a/src/components/tickets/NewTicketsPanel.tsx
+++ b/src/components/tickets/NewTicketsPanel.tsx
@@ -8,26 +8,174 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { useTickets } from '@/context/TicketContext';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Card } from '@/components/ui/card';
+import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable';
+import type { ImperativePanelHandle } from 'react-resizable-panels';
+import { cn } from '@/lib/utils';
+import { PanelLeft, MessageSquare, Info } from 'lucide-react';
 
 const NewTicketsPanel: React.FC = () => {
   const isMobile = useIsMobile();
   const { loading, error, selectedTicket } = useTickets();
   const [isSidebarVisible, setIsSidebarVisible] = React.useState(!isMobile);
   const [isDetailsVisible, setIsDetailsVisible] = React.useState(!isMobile);
+  const [mobileView, setMobileView] = React.useState<'tickets' | 'chat' | 'details'>('chat');
+  const [isWideLayout, setIsWideLayout] = React.useState<boolean>(() => {
+    if (typeof window === 'undefined') {
+      return true;
+    }
+    return window.matchMedia('(min-width: 1440px)').matches;
+  });
+  const detailsPanelRef = React.useRef<ImperativePanelHandle | null>(null);
+  const lastWideDetailsSize = React.useRef<number | null>(null);
+  const lastMobileTicketId = React.useRef<string | number | null>(null);
 
   React.useEffect(() => {
-    if (isMobile) {
-      setIsDetailsVisible(false);
-      // Show sidebar only if no ticket is selected on mobile
-      setIsSidebarVisible(!selectedTicket);
-    } else {
-      setIsDetailsVisible(true);
-      setIsSidebarVisible(true);
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia('(min-width: 1440px)');
+    const applyMatch = (value: boolean) => setIsWideLayout(value);
+
+    applyMatch(mediaQuery.matches);
+
+    const handler = (event: MediaQueryListEvent) => applyMatch(event.matches);
+
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', handler);
+      return () => mediaQuery.removeEventListener('change', handler);
+    }
+
+    mediaQuery.addListener(handler);
+    return () => mediaQuery.removeListener(handler);
+  }, []);
+
+  React.useEffect(() => {
+    if (!isMobile) {
+      setMobileView('chat');
+      return;
+    }
+
+    if (!selectedTicket) {
+      lastMobileTicketId.current = null;
+      setMobileView('tickets');
+      return;
+    }
+
+    if (lastMobileTicketId.current !== selectedTicket.id) {
+      lastMobileTicketId.current = selectedTicket.id;
+      setMobileView('chat');
     }
   }, [isMobile, selectedTicket]);
 
-  const toggleSidebar = () => setIsSidebarVisible(prev => !prev);
-  const toggleDetails = () => setIsDetailsVisible(prev => !prev);
+  React.useEffect(() => {
+    if (!isMobile) {
+      return;
+    }
+
+    if (mobileView === 'tickets') {
+      setIsSidebarVisible(true);
+      setIsDetailsVisible(false);
+      return;
+    }
+
+    if (mobileView === 'details') {
+      setIsSidebarVisible(false);
+      setIsDetailsVisible(true);
+      return;
+    }
+
+    setIsSidebarVisible(false);
+    setIsDetailsVisible(false);
+  }, [isMobile, mobileView]);
+
+  React.useEffect(() => {
+    if (isMobile) {
+      return;
+    }
+
+    setIsSidebarVisible(true);
+    setIsDetailsVisible(isWideLayout);
+  }, [isMobile, isWideLayout]);
+
+  React.useEffect(() => {
+    if (!isWideLayout) {
+      return;
+    }
+
+    const panel = detailsPanelRef.current;
+
+    if (!panel) {
+      return;
+    }
+
+    if (lastWideDetailsSize.current === null) {
+      const currentSize = panel.getSize();
+
+      if (currentSize > 0) {
+        lastWideDetailsSize.current = currentSize;
+      }
+    }
+
+    if (isDetailsVisible) {
+      const storedSize = lastWideDetailsSize.current;
+
+      if (panel.isCollapsed()) {
+        panel.expand(
+          typeof storedSize === 'number' && storedSize > 0 ? storedSize : undefined,
+        );
+      }
+
+      if (typeof storedSize === 'number' && storedSize > 0) {
+        const currentSize = panel.getSize();
+
+        if (Math.abs(currentSize - storedSize) > 0.5) {
+          panel.resize(storedSize);
+        }
+      }
+    } else if (!panel.isCollapsed()) {
+      lastWideDetailsSize.current = panel.getSize();
+      panel.collapse();
+    }
+  }, [isDetailsVisible, isWideLayout]);
+
+  const toggleSidebar = () => {
+    if (isMobile) {
+      setMobileView((current) => (current === 'tickets' ? 'chat' : 'tickets'));
+      return;
+    }
+
+    setIsSidebarVisible((prev) => !prev);
+  };
+
+  const toggleDetails = () => {
+    if (isMobile) {
+      setMobileView((current) => (current === 'details' ? 'chat' : 'details'));
+      return;
+    }
+
+    setIsDetailsVisible((prev) => !prev);
+  };
+
+  const handleMobileTicketSelection = React.useCallback(() => {
+    if (!isMobile) {
+      return;
+    }
+
+    setMobileView('chat');
+  }, [isMobile]);
+
+  const mobileNavButtonClass = (
+    value: 'tickets' | 'chat' | 'details',
+    disabled?: boolean,
+  ) =>
+    cn(
+      'flex h-11 items-center justify-center gap-2 rounded-xl border px-3 text-sm font-semibold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50 disabled:shadow-none',
+      mobileView === value
+        ? 'border-primary bg-primary text-primary-foreground shadow-sm'
+        : 'border-border/70 bg-muted/60 text-muted-foreground hover:border-primary/40 hover:text-foreground',
+      disabled && 'hover:border-border/70 hover:text-muted-foreground',
+    );
 
   if (loading) {
     return (
@@ -71,63 +219,168 @@ const NewTicketsPanel: React.FC = () => {
   }
 
   return (
-    <Card className="h-screen w-full bg-card shadow-xl rounded-xl border border-border backdrop-blur-sm overflow-hidden">
+    <Card className="relative flex h-full w-full flex-col overflow-hidden rounded-3xl border border-border/70 bg-card/90 shadow-2xl backdrop-blur-md">
       {isMobile ? (
-        <div className="relative h-full w-full overflow-hidden">
-          <AnimatePresence>
-            {isSidebarVisible && (
-              <motion.div
-                key="sidebar"
-                initial={{ x: '-100%' }}
-                animate={{ x: 0 }}
-                exit={{ x: '-100%' }}
-                transition={{ type: 'spring', stiffness: 300, damping: 30 }}
-                className="absolute top-0 left-0 h-full w-full z-20"
+        <div className="flex h-full flex-col">
+          <div className="border-b border-border/70 bg-card/80 px-3 py-2 shadow-sm">
+            <div className="grid grid-cols-3 gap-2">
+              <button
+                type="button"
+                onClick={() => setMobileView('tickets')}
+                className={mobileNavButtonClass('tickets')}
+                aria-pressed={mobileView === 'tickets'}
               >
-                <Sidebar />
-              </motion.div>
-            )}
-          </AnimatePresence>
-          <motion.div
-             key="conversation"
-             className="absolute top-0 left-0 h-full w-full z-10"
-             animate={{ x: isSidebarVisible ? '100%' : '0%' }}
-             transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+                <PanelLeft className="h-4 w-4" />
+                <span>Tickets</span>
+              </button>
+              <button
+                type="button"
+                onClick={() => setMobileView('chat')}
+                className={mobileNavButtonClass('chat', !selectedTicket)}
+                aria-pressed={mobileView === 'chat'}
+                disabled={!selectedTicket}
+              >
+                <MessageSquare className="h-4 w-4" />
+                <span>Chat</span>
+              </button>
+              <button
+                type="button"
+                onClick={() => setMobileView('details')}
+                className={mobileNavButtonClass('details', !selectedTicket)}
+                aria-pressed={mobileView === 'details'}
+                disabled={!selectedTicket}
+              >
+                <Info className="h-4 w-4" />
+                <span>Info</span>
+              </button>
+            </div>
+          </div>
+          <div className="relative flex-1 overflow-hidden">
+            <AnimatePresence>
+              {isSidebarVisible && (
+                <motion.div
+                  key="sidebar"
+                  initial={{ x: '-100%' }}
+                  animate={{ x: 0 }}
+                  exit={{ x: '-100%' }}
+                  transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+                  className="absolute left-0 top-0 z-20 h-full w-full"
+                >
+                  <Sidebar className="h-full w-full min-w-full" onTicketSelected={handleMobileTicketSelection} />
+                </motion.div>
+              )}
+            </AnimatePresence>
+            <motion.div
+              key="conversation"
+              className="absolute left-0 top-0 z-10 h-full w-full"
+              animate={{ x: isSidebarVisible ? '100%' : '0%' }}
+              transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+            >
+              <ConversationPanel
+                isMobile={true}
+                isSidebarVisible={isSidebarVisible}
+                isDetailsVisible={isDetailsVisible}
+                onToggleSidebar={toggleSidebar}
+                onToggleDetails={toggleDetails}
+                canToggleSidebar
+                showDetailsToggle
+              />
+            </motion.div>
+            <AnimatePresence>
+              {isDetailsVisible && (
+                <motion.div
+                  key="details"
+                  initial={{ x: '100%' }}
+                  animate={{ x: 0 }}
+                  exit={{ x: '100%' }}
+                  transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+                  className="absolute left-0 top-0 z-30 h-full w-full overflow-y-auto bg-background"
+                >
+                  <DetailsPanel onClose={toggleDetails} />
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </div>
+        </div>
+      ) : isWideLayout ? (
+        <ResizablePanelGroup direction="horizontal" className="flex h-full w-full overflow-hidden">
+          <ResizablePanel
+            defaultSize={24}
+            minSize={20}
+            maxSize={30}
+            className="min-w-[320px] max-w-[420px]"
+          >
+            <Sidebar className="h-full w-full shrink-0" />
+          </ResizablePanel>
+          <ResizableHandle withHandle className="w-2 bg-border/60 transition-colors hover:bg-primary/50" />
+          <ResizablePanel
+            defaultSize={56}
+            minSize={46}
+            className="min-w-[760px]"
           >
             <ConversationPanel
-              isMobile={true}
+              isMobile={false}
+              isSidebarVisible={true}
+              isDetailsVisible={isDetailsVisible}
+              onToggleSidebar={toggleSidebar}
+              onToggleDetails={toggleDetails}
+              showDetailsToggle
+            />
+          </ResizablePanel>
+          <ResizableHandle withHandle className="w-2 bg-border/60 transition-colors hover:bg-primary/50" />
+          <ResizablePanel
+            ref={detailsPanelRef}
+            defaultSize={20}
+            minSize={18}
+            maxSize={32}
+            collapsible
+            collapsedSize={0}
+            onResize={(size) => {
+              if (size > 0) {
+                lastWideDetailsSize.current = size;
+              }
+            }}
+            onCollapse={() =>
+              setIsDetailsVisible((prev) => (prev ? false : prev))
+            }
+            onExpand={() =>
+              setIsDetailsVisible((prev) => (prev ? prev : true))
+            }
+            className="min-w-[340px] max-w-[600px]"
+          >
+            <DetailsPanel className="h-full w-full" />
+          </ResizablePanel>
+        </ResizablePanelGroup>
+      ) : (
+        <div className="flex h-full w-full overflow-hidden">
+          {isSidebarVisible && (
+            <Sidebar className="w-[clamp(260px,26vw,340px)] shrink-0 xl:w-[clamp(280px,22vw,360px)] 2xl:w-[clamp(300px,20vw,380px)]" />
+          )}
+          <div className="relative flex min-w-0 flex-1 bg-background">
+            <ConversationPanel
+              isMobile={false}
               isSidebarVisible={isSidebarVisible}
               isDetailsVisible={isDetailsVisible}
               onToggleSidebar={toggleSidebar}
               onToggleDetails={toggleDetails}
+              canToggleSidebar
+              showDetailsToggle
             />
-          </motion.div>
-          <AnimatePresence>
-            {isDetailsVisible && (
+            <AnimatePresence>
+              {isDetailsVisible && (
                 <motion.div
-                    key="details"
-                    initial={{ x: '100%' }}
-                    animate={{ x: 0 }}
-                    exit={{ x: '100%' }}
-                    transition={{ type: 'spring', stiffness: 300, damping: 30 }}
-                    className="absolute top-0 left-0 h-full w-full z-30 bg-background"
+                  key="compact-details"
+                  initial={{ x: '100%' }}
+                  animate={{ x: 0 }}
+                  exit={{ x: '100%' }}
+                  transition={{ type: 'spring', stiffness: 320, damping: 32 }}
+                  className="absolute inset-y-0 right-0 z-30 flex w-full max-w-[clamp(320px,42vw,520px)] overflow-hidden border-l border-border bg-card shadow-xl"
                 >
-                    <DetailsPanel onClose={toggleDetails} />
+                  <DetailsPanel onClose={toggleDetails} className="w-full" />
                 </motion.div>
-            )}
-          </AnimatePresence>
-        </div>
-      ) : (
-        <div className="grid grid-cols-[320px_1fr_380px] h-full w-full">
-          <Sidebar />
-          <ConversationPanel
-            isMobile={false}
-            isSidebarVisible={isSidebarVisible}
-            isDetailsVisible={true}
-            onToggleSidebar={toggleSidebar}
-            onToggleDetails={toggleDetails}
-          />
-          <DetailsPanel />
+              )}
+            </AnimatePresence>
+          </div>
         </div>
       )}
       <Toaster richColors />

--- a/src/components/tickets/Sidebar.tsx
+++ b/src/components/tickets/Sidebar.tsx
@@ -14,8 +14,14 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
+import { cn } from '@/lib/utils';
 
-const Sidebar: React.FC = () => {
+interface SidebarProps {
+  className?: string;
+  onTicketSelected?: () => void;
+}
+
+const Sidebar: React.FC<SidebarProps> = ({ className, onTicketSelected }) => {
   const { tickets, ticketsByCategory, selectedTicket, selectTicket } = useTickets();
   const [searchTerm, setSearchTerm] = React.useState('');
   const debouncedSearchTerm = useDebounce(searchTerm, 300);
@@ -55,7 +61,12 @@ const Sidebar: React.FC = () => {
   }, [ticketsByCategory, debouncedSearchTerm]);
 
   return (
-    <aside className="w-80 border-r border-border flex flex-col h-screen bg-muted/20 shrink-0">
+    <aside
+      className={cn(
+        'flex h-full min-w-0 shrink-0 flex-col border-r border-border bg-muted/20',
+        className,
+      )}
+    >
       <div className="p-4 space-y-4">
         <div className="flex justify-between items-center">
           <h1 className="text-2xl font-bold">Tickets</h1>
@@ -103,7 +114,10 @@ const Sidebar: React.FC = () => {
                       key={ticket.id}
                       ticket={ticket}
                       isSelected={selectedTicket?.id === ticket.id}
-                      onClick={() => selectTicket(ticket.id)}
+                      onClick={() => {
+                        selectTicket(ticket.id);
+                        onTicketSelected?.();
+                      }}
                     />
                   ))}
                 </div>

--- a/src/components/tickets/TicketAttachments.tsx
+++ b/src/components/tickets/TicketAttachments.tsx
@@ -26,6 +26,28 @@ const TicketAttachments: React.FC<Props> = ({ attachments }) => {
   const others = allowed.filter((p) => p.info.type !== 'image');
   const [openUrl, setOpenUrl] = useState<string | null>(null);
 
+  React.useEffect(() => {
+    if (!openUrl) {
+      return;
+    }
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpenUrl(null);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [openUrl]);
+
   if (!images.length && !others.length && !disallowed.length) return null;
 
   return (
@@ -83,7 +105,7 @@ const TicketAttachments: React.FC<Props> = ({ attachments }) => {
       )}
       {openUrl && (
         <div
-          className="fixed inset-0 z-50 bg-black/70 flex items-center justify-center p-4"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
           onClick={() => setOpenUrl(null)}
           role="dialog"
           aria-modal="true"
@@ -92,7 +114,7 @@ const TicketAttachments: React.FC<Props> = ({ attachments }) => {
             <img
               src={openUrl}
               alt="Adjunto ampliado"
-              className="max-h-[90vh] max-w-[90vw] rounded-lg shadow-2xl"
+              className="max-h-[95vh] max-w-[95vw] rounded-lg object-contain shadow-2xl"
             />
             <button
               onClick={() => setOpenUrl(null)}

--- a/src/pages/TicketsPanel.tsx
+++ b/src/pages/TicketsPanel.tsx
@@ -5,10 +5,10 @@ import NewTicketsPanel from '@/components/tickets/NewTicketsPanel';
 import { TicketProvider } from '@/context/TicketContext';
 
 const TicketsPanelPage = () => {
-useRequireRole(['admin', 'empleado', 'super_admin'] as Role[]);
+  useRequireRole(['admin', 'empleado', 'super_admin'] as Role[]);
   return (
-    <div className="flex flex-col min-h-screen bg-background dark:bg-gradient-to-tr dark:from-slate-950 dark:to-slate-900 text-foreground py-8 px-2 sm:px-4 md:px-6 lg:px-8">
-      <div className="w-full max-w-7xl mx-auto mb-6 relative px-2">
+    <div className="flex min-h-screen flex-col bg-background dark:bg-gradient-to-tr dark:from-slate-950 dark:to-slate-900 text-foreground py-4 sm:py-6 px-2 sm:px-4 md:px-5 lg:px-6 2xl:px-5">
+      <div className="relative mx-auto flex w-full flex-1 max-w-[min(2400px,calc(100vw-2rem))]">
         <TicketProvider>
           <NewTicketsPanel />
         </TicketProvider>


### PR DESCRIPTION
## Summary
- add a mobile navigation strip and synced state management so agents can flip between the ticket list, chat, and detail panes without losing context
- widen the default widescreen proportions and handles so the conversation column breathes on large monitors while keeping the details panel collapsible
- plumb ticket-selection callbacks and polish overlays, including a larger attachment lightbox and a wider page frame that uses more of the viewport

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf2572d3bc8322bee5eb2a33515003