### PR TITLE
Add interactive route tracker to ticket lookup

### DIFF
--- a/src/components/TicketMap.tsx
+++ b/src/components/TicketMap.tsx
@@ -1,5 +1,13 @@
 import React from 'react';
 import { cn } from '@/lib/utils';
+import { TicketHistoryEvent } from '@/types/tickets';
+import {
+  ALLOWED_TICKET_STATUSES,
+  AllowedTicketStatus,
+  formatTicketStatusLabel,
+  normalizeTicketStatus,
+} from '@/utils/ticketStatus';
+import { formatHistoryDate, pickHistoryDate } from '@/utils/ticketHistory';
 
 export interface TicketLocation {
   latitud?: number | null;
@@ -45,6 +53,12 @@ interface TicketMapProps {
   title?: React.ReactNode;
   heightClassName?: string;
   showAddressHint?: boolean;
+  status?: string | null;
+  history?: TicketHistoryEvent[] | null;
+  estimatedTime?: string | null;
+  createdAtLabel?: string | null;
+  lastUpdatedLabel?: string | null;
+  currentStatusLabel?: string | null;
 }
 
 const TicketMap: React.FC<TicketMapProps> = ({
@@ -54,6 +68,12 @@ const TicketMap: React.FC<TicketMapProps> = ({
   title = 'Ubicación aproximada',
   heightClassName,
   showAddressHint = true,
+  status,
+  history,
+  estimatedTime,
+  createdAtLabel,
+  lastUpdatedLabel,
+  currentStatusLabel,
 }) => {
   const direccionCompleta = buildFullAddress(ticket);
   const destLat =
@@ -112,6 +132,162 @@ const TicketMap: React.FC<TicketMapProps> = ({
 
   const [src, setSrc] = React.useState(googleSrc || osmSrc);
 
+  React.useEffect(() => {
+    setSrc(googleSrc || osmSrc);
+  }, [googleSrc, osmSrc]);
+
+  const historyEntries = React.useMemo(
+    () => (Array.isArray(history) ? history : []),
+    [history],
+  );
+
+  const historyStatuses = React.useMemo(
+    () =>
+      historyEntries
+        .map((entry) => normalizeTicketStatus(entry?.status))
+        .filter(
+          (value): value is AllowedTicketStatus => Boolean(value),
+        ),
+    [historyEntries],
+  );
+
+  const highestHistoryIndex = React.useMemo(() => {
+    let highest = -1;
+    historyStatuses.forEach((value) => {
+      const idx = ALLOWED_TICKET_STATUSES.indexOf(value);
+      if (idx > highest) {
+        highest = idx;
+      }
+    });
+    return highest;
+  }, [historyStatuses]);
+
+  const normalizedStatus = React.useMemo(
+    () => normalizeTicketStatus(status),
+    [status],
+  );
+
+  const resolvedIndex = React.useMemo(() => {
+    if (
+      normalizedStatus &&
+      ALLOWED_TICKET_STATUSES.includes(normalizedStatus)
+    ) {
+      return ALLOWED_TICKET_STATUSES.indexOf(normalizedStatus);
+    }
+    return -1;
+  }, [normalizedStatus]);
+
+  const effectiveIndex =
+    resolvedIndex !== -1 ? resolvedIndex : highestHistoryIndex;
+
+  const resolvedStatus: AllowedTicketStatus | null =
+    resolvedIndex !== -1
+      ? ALLOWED_TICKET_STATUSES[resolvedIndex]
+      : highestHistoryIndex >= 0
+        ? ALLOWED_TICKET_STATUSES[highestHistoryIndex]
+        : null;
+
+  const progressFraction =
+    ALLOWED_TICKET_STATUSES.length > 1 && effectiveIndex >= 0
+      ? effectiveIndex / (ALLOWED_TICKET_STATUSES.length - 1)
+      : 0;
+
+  const progressPercentage = Math.max(
+    0,
+    Math.min(100, progressFraction * 100),
+  );
+
+  const dispatchedStatusRef = React.useRef<AllowedTicketStatus | null>(null);
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined' || !resolvedStatus) {
+      return;
+    }
+
+    if (dispatchedStatusRef.current === resolvedStatus) {
+      return;
+    }
+
+    dispatchedStatusRef.current = resolvedStatus;
+    window.dispatchEvent(
+      new CustomEvent<AllowedTicketStatus>('route-status', {
+        detail: resolvedStatus,
+      }),
+    );
+  }, [resolvedStatus]);
+
+  const statusTimestamps = React.useMemo(() => {
+    const map = new Map<AllowedTicketStatus, string | null>();
+
+    historyEntries.forEach((entry) => {
+      const normalized = normalizeTicketStatus(entry?.status);
+      if (!normalized || map.has(normalized)) {
+        return;
+      }
+
+      const formatted = formatHistoryDate(pickHistoryDate(entry));
+      if (formatted) {
+        map.set(normalized, formatted);
+      }
+    });
+
+    if (createdAtLabel && !map.has('nuevo')) {
+      map.set('nuevo', createdAtLabel);
+    }
+
+    if (lastUpdatedLabel && resolvedStatus && !map.has(resolvedStatus)) {
+      map.set(resolvedStatus, lastUpdatedLabel);
+    }
+
+    return map;
+  }, [historyEntries, createdAtLabel, lastUpdatedLabel, resolvedStatus]);
+
+  const statusTimeline = React.useMemo(
+    () =>
+      ALLOWED_TICKET_STATUSES.map((step) => ({
+        status: step,
+        label: formatTicketStatusLabel(step),
+        timestamp: statusTimestamps.get(step) ?? null,
+      })),
+    [statusTimestamps],
+  );
+
+  const resolvedStatusLabel = React.useMemo(() => {
+    if (currentStatusLabel) {
+      return currentStatusLabel;
+    }
+
+    if (resolvedStatus) {
+      return formatTicketStatusLabel(resolvedStatus);
+    }
+
+    return null;
+  }, [currentStatusLabel, resolvedStatus]);
+
+  const formatCoordinatePair = (
+    lat?: number | null,
+    lon?: number | null,
+  ): string | null => {
+    if (
+      typeof lat === 'number' &&
+      Number.isFinite(lat) &&
+      typeof lon === 'number' &&
+      Number.isFinite(lon)
+    ) {
+      return `${lat.toFixed(4)}, ${lon.toFixed(4)}`;
+    }
+    return null;
+  };
+
+  const originCoordinatesLabel = formatCoordinatePair(originLat, originLon);
+  const destinationCoordinatesLabel = formatCoordinatePair(destLat, destLon);
+  const originLabel = ticket.municipio_nombre?.trim() || 'Origen';
+  const destinationLabel =
+    ticket.direccion?.trim() ||
+    ticket.esquinas_cercanas?.trim() ||
+    direccionCompleta ||
+    'Destino';
+
   if (!src) return null;
 
   const heightClasses = heightClassName ?? 'h-[150px] sm:h-[180px]';
@@ -121,13 +297,17 @@ const TicketMap: React.FC<TicketMapProps> = ({
       {!hideTitle && title && (
         <h4 className="font-semibold mb-2">{title}</h4>
       )}
-      <div className={cn('w-full rounded overflow-hidden', heightClasses)}>
+      <div className={cn('relative w-full overflow-hidden rounded', heightClasses)}>
         <iframe
+          className="absolute inset-0 h-full w-full"
           width="100%"
           height="100%"
           style={{ border: 0 }}
           loading="lazy"
           allowFullScreen
+          title={
+            typeof title === 'string' ? title : 'Mapa del reclamo'
+          }
           src={src}
           onError={() => {
             if (src !== osmSrc) {
@@ -135,6 +315,106 @@ const TicketMap: React.FC<TicketMapProps> = ({
             }
           }}
         />
+        <div className="pointer-events-none absolute inset-0 flex flex-col justify-between p-3 sm:p-4">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+            <div className="pointer-events-auto rounded-lg bg-background/80 p-3 text-xs shadow-md backdrop-blur-sm sm:text-sm">
+              <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                Origen
+              </p>
+              <p className="font-semibold text-foreground">{originLabel}</p>
+              {originCoordinatesLabel && (
+                <p className="text-[11px] text-muted-foreground">
+                  {originCoordinatesLabel}
+                </p>
+              )}
+            </div>
+            <div className="pointer-events-auto rounded-lg bg-background/80 p-3 text-xs shadow-md backdrop-blur-sm sm:text-sm">
+              <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                Destino
+              </p>
+              <p className="font-semibold text-foreground">
+                {destinationLabel}
+              </p>
+              {destinationCoordinatesLabel && (
+                <p className="text-[11px] text-muted-foreground">
+                  {destinationCoordinatesLabel}
+                </p>
+              )}
+            </div>
+          </div>
+          <div className="pointer-events-auto rounded-xl bg-background/85 p-3 text-[11px] shadow-lg backdrop-blur-sm sm:text-xs">
+            <div className="flex flex-wrap items-center justify-between gap-2 text-muted-foreground">
+              <span className="font-semibold text-foreground">
+                Seguimiento del reclamo
+              </span>
+              {resolvedStatusLabel && (
+                <span className="text-foreground">{resolvedStatusLabel}</span>
+              )}
+              {estimatedTime && (
+                <span>
+                  ETA{' '}
+                  <span className="text-foreground">{estimatedTime}</span>
+                </span>
+              )}
+            </div>
+            <div className="relative mt-3 h-2 w-full overflow-hidden rounded-full bg-muted/50">
+              <div
+                className="absolute inset-y-0 left-0 rounded-full bg-primary transition-all duration-500 ease-out"
+                style={{ width: `${progressPercentage}%` }}
+              />
+              {ALLOWED_TICKET_STATUSES.map((step, idx) => {
+                const position =
+                  ALLOWED_TICKET_STATUSES.length > 1
+                    ? (idx / (ALLOWED_TICKET_STATUSES.length - 1)) * 100
+                    : 0;
+                const completed = idx <= effectiveIndex && effectiveIndex >= 0;
+                return (
+                  <div
+                    key={step}
+                    className={cn(
+                      'absolute top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-background transition-colors',
+                      completed ? 'bg-primary shadow-sm' : 'bg-muted/80',
+                    )}
+                    style={{ left: `${position}%` }}
+                  />
+                );
+              })}
+              <div
+                className="absolute top-1/2 h-5 w-5 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-background bg-primary text-primary-foreground shadow-lg transition-all duration-500 ease-out"
+                style={{ left: `${progressPercentage}%` }}
+              />
+            </div>
+            <div className="mt-3 grid gap-2 sm:grid-cols-3">
+              {statusTimeline.map((item) => (
+                <div
+                  key={item.status}
+                  className="rounded-lg bg-muted/40 px-2 py-2"
+                >
+                  <p className="text-xs font-semibold text-foreground sm:text-sm">
+                    {item.label}
+                  </p>
+                  <p className="text-[11px] text-muted-foreground">
+                    {item.timestamp || '—'}
+                  </p>
+                </div>
+              ))}
+            </div>
+            <div className="mt-3 flex flex-wrap items-center justify-between gap-2 text-[11px] text-muted-foreground">
+              {createdAtLabel && (
+                <span>
+                  Creado:{' '}
+                  <span className="text-foreground">{createdAtLabel}</span>
+                </span>
+              )}
+              {lastUpdatedLabel && (
+                <span>
+                  Actualizado:{' '}
+                  <span className="text-foreground">{lastUpdatedLabel}</span>
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
       </div>
       {direccionCompleta && showAddressHint && (
         <div className="text-xs mt-1 text-muted-foreground truncate">

--- a/src/utils/ticketHistory.ts
+++ b/src/utils/ticketHistory.ts
@@ -1,0 +1,52 @@
+import { shiftDateByHours } from '@/utils/date';
+
+const CANDIDATE_DATE_KEYS = ['date', 'fecha', 'created_at', 'updated_at', 'timestamp'] as const;
+
+type HistoryLike = Record<string, unknown> | null | undefined;
+
+export const pickHistoryDate = (
+  entry: unknown,
+): string | number | Date | null => {
+  if (!entry || typeof entry !== 'object') {
+    return null;
+  }
+
+  const record = entry as HistoryLike;
+
+  for (const key of CANDIDATE_DATE_KEYS) {
+    const raw = record?.[key as keyof typeof record];
+    if (
+      typeof raw === 'string' ||
+      typeof raw === 'number' ||
+      raw instanceof Date
+    ) {
+      return raw;
+    }
+  }
+
+  return null;
+};
+
+export const formatHistoryDate = (
+  value: string | number | Date | null | undefined,
+): string | null => {
+  if (!value && value !== 0) return null;
+
+  const shifted = shiftDateByHours(value, -3);
+
+  if (!shifted) {
+    return null;
+  }
+
+  try {
+    return new Intl.DateTimeFormat('es-AR', {
+      day: '2-digit',
+      month: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(shifted);
+  } catch (error) {
+    console.error('Error formatting history date', error);
+    return null;
+  }
+};


### PR DESCRIPTION
## Summary
- add shared helpers to normalize and format ticket history dates
- surface computed creation dates and status metadata in the logistics summary
- redesign the ticket map with a delivery-style progress overlay driven by ticket status

## Testing
- npm test *(fails: relies on server-side .cjs fixtures that are not present in the workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d000f60ad08322ac27c4b5a3fa18c5