### PR TITLE
Fix ticket details layout and restore map widget

### DIFF
--- a/src/components/TicketMap.tsx
+++ b/src/components/TicketMap.tsx
@@ -114,7 +114,15 @@ const TicketMap: React.FC<TicketMapProps> = ({
         ? `https://www.openstreetmap.org/search?query=${encodeURIComponent(direccionCompleta)}`
         : '';
 
-  const [src, setSrc] = React.useState(googleSrc || osmSrc);
+  const initialSrc = React.useMemo(
+    () => googleSrc || osmSrc || '',
+    [googleSrc, osmSrc],
+  );
+  const [src, setSrc] = React.useState(initialSrc);
+
+  React.useEffect(() => {
+    setSrc(initialSrc);
+  }, [initialSrc]);
 
   if (!src) return null;
 

--- a/src/components/tickets/DetailsPanel.tsx
+++ b/src/components/tickets/DetailsPanel.tsx
@@ -464,8 +464,8 @@ const DetailsPanel: React.FC<DetailsPanelProps> = ({ onClose, className }) => {
   const openGoogleMaps = () => {
     if (!ticket) return;
 
-    const destLat = pickFirstCoordinate(ticket.latitud, ticket.lat_destino);
-    const destLon = pickFirstCoordinate(ticket.longitud, ticket.lon_destino);
+    const destLat = pickFirstCoordinate(ticket.lat_destino, ticket.latitud);
+    const destLon = pickFirstCoordinate(ticket.lon_destino, ticket.longitud);
     const originLat = pickFirstCoordinate(
       ticket.lat_actual,
       ticket.lat_origen,

--- a/src/components/tickets/NewTicketsPanel.tsx
+++ b/src/components/tickets/NewTicketsPanel.tsx
@@ -22,7 +22,7 @@ const NewTicketsPanel: React.FC = () => {
   const detailsPanelRef = React.useRef<ImperativePanelHandle | null>(null);
   const lastDetailsSize = React.useRef<number | null>(null);
   const lastMobileTicketId = React.useRef<string | number | null>(null);
-  const DETAILS_PANEL_MAX_SIZE = 50;
+  const DETAILS_PANEL_MAX_SIZE = 60;
 
   React.useEffect(() => {
     if (!isMobile) {
@@ -279,18 +279,18 @@ const NewTicketsPanel: React.FC = () => {
       ) : (
         <ResizablePanelGroup direction="horizontal" className="flex h-full w-full overflow-hidden">
           <ResizablePanel
-            defaultSize={26}
-            minSize={20}
-            maxSize={32}
-            className="min-w-[300px] max-w-[420px]"
+            defaultSize={24}
+            minSize={18}
+            maxSize={30}
+            className="lg:min-w-[240px] xl:min-w-[300px]"
           >
             <Sidebar className="h-full w-full shrink-0" />
           </ResizablePanel>
           <ResizableHandle withHandle className="w-2 bg-border/60 transition-colors hover:bg-primary/50" />
           <ResizablePanel
-            defaultSize={40}
-            minSize={34}
-            className="min-w-[520px]"
+            defaultSize={38}
+            minSize={32}
+            className="lg:min-w-[380px] xl:min-w-[520px]"
           >
             <ConversationPanel
               isMobile={false}
@@ -304,8 +304,8 @@ const NewTicketsPanel: React.FC = () => {
           <ResizableHandle withHandle className="w-2 bg-border/60 transition-colors hover:bg-primary/50" />
           <ResizablePanel
             ref={detailsPanelRef}
-            defaultSize={34}
-            minSize={26}
+            defaultSize={38}
+            minSize={28}
             maxSize={DETAILS_PANEL_MAX_SIZE}
             collapsible
             collapsedSize={0}
@@ -316,7 +316,7 @@ const NewTicketsPanel: React.FC = () => {
             }}
             onCollapse={() => setIsDetailsVisible(false)}
             onExpand={() => setIsDetailsVisible(true)}
-            className="min-w-[360px] lg:min-w-[420px]"
+            className="lg:min-w-[320px] xl:min-w-[440px]"
           >
             <DetailsPanel className="h-full w-full" />
           </ResizablePanel>

--- a/src/components/tickets/NewTicketsPanel.tsx
+++ b/src/components/tickets/NewTicketsPanel.tsx
@@ -22,6 +22,7 @@ const NewTicketsPanel: React.FC = () => {
   const detailsPanelRef = React.useRef<ImperativePanelHandle | null>(null);
   const lastDetailsSize = React.useRef<number | null>(null);
   const lastMobileTicketId = React.useRef<string | number | null>(null);
+  const DETAILS_PANEL_MAX_SIZE = 50;
 
   React.useEffect(() => {
     if (!isMobile) {
@@ -86,7 +87,7 @@ const NewTicketsPanel: React.FC = () => {
       const currentSize = panel.getSize();
 
       if (currentSize > 0) {
-        lastDetailsSize.current = currentSize;
+        lastDetailsSize.current = Math.min(currentSize, DETAILS_PANEL_MAX_SIZE);
       }
     }
 
@@ -94,20 +95,23 @@ const NewTicketsPanel: React.FC = () => {
       const storedSize = lastDetailsSize.current;
 
       if (panel.isCollapsed()) {
-        panel.expand(
-          typeof storedSize === 'number' && storedSize > 0 ? storedSize : undefined,
-        );
+        const sizeToApply =
+          typeof storedSize === 'number' && storedSize > 0
+            ? Math.min(storedSize, DETAILS_PANEL_MAX_SIZE)
+            : undefined;
+        panel.expand(sizeToApply);
       }
 
       if (typeof storedSize === 'number' && storedSize > 0) {
+        const targetSize = Math.min(storedSize, DETAILS_PANEL_MAX_SIZE);
         const currentSize = panel.getSize();
 
-        if (Math.abs(currentSize - storedSize) > 0.5) {
-          panel.resize(storedSize);
+        if (Math.abs(currentSize - targetSize) > 0.5) {
+          panel.resize(targetSize);
         }
       }
     } else if (!panel.isCollapsed()) {
-      lastDetailsSize.current = panel.getSize();
+      lastDetailsSize.current = Math.min(panel.getSize(), DETAILS_PANEL_MAX_SIZE);
       panel.collapse();
     }
   }, [isDetailsVisible, isMobile]);
@@ -284,9 +288,9 @@ const NewTicketsPanel: React.FC = () => {
           </ResizablePanel>
           <ResizableHandle withHandle className="w-2 bg-border/60 transition-colors hover:bg-primary/50" />
           <ResizablePanel
-            defaultSize={48}
-            minSize={40}
-            className="min-w-[600px]"
+            defaultSize={40}
+            minSize={34}
+            className="min-w-[520px]"
           >
             <ConversationPanel
               isMobile={false}
@@ -300,19 +304,19 @@ const NewTicketsPanel: React.FC = () => {
           <ResizableHandle withHandle className="w-2 bg-border/60 transition-colors hover:bg-primary/50" />
           <ResizablePanel
             ref={detailsPanelRef}
-            defaultSize={26}
-            minSize={20}
-            maxSize={36}
+            defaultSize={34}
+            minSize={26}
+            maxSize={DETAILS_PANEL_MAX_SIZE}
             collapsible
             collapsedSize={0}
             onResize={(size) => {
               if (size > 0) {
-                lastDetailsSize.current = size;
+                lastDetailsSize.current = Math.min(size, DETAILS_PANEL_MAX_SIZE);
               }
             }}
             onCollapse={() => setIsDetailsVisible(false)}
             onExpand={() => setIsDetailsVisible(true)}
-            className="min-w-[320px] max-w-[520px]"
+            className="min-w-[360px] lg:min-w-[420px]"
           >
             <DetailsPanel className="h-full w-full" />
           </ResizablePanel>

--- a/src/utils/location.ts
+++ b/src/utils/location.ts
@@ -1,0 +1,45 @@
+export const parseCoordinateValue = (value?: unknown): number | undefined => {
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || value === 0) {
+      return undefined;
+    }
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const sanitized = value.trim();
+
+    if (!sanitized) {
+      return undefined;
+    }
+
+    const normalized = sanitized.replace(',', '.');
+    const parsed = Number(normalized);
+
+    if (!Number.isFinite(parsed) || parsed === 0) {
+      return undefined;
+    }
+
+    return parsed;
+  }
+
+  return undefined;
+};
+
+export const hasCoordinateValue = (value?: unknown): boolean => {
+  return typeof parseCoordinateValue(value) === 'number';
+};
+
+export const pickFirstCoordinate = (
+  ...values: unknown[]
+): number | undefined => {
+  for (const value of values) {
+    const parsed = parseCoordinateValue(value);
+
+    if (typeof parsed === 'number') {
+      return parsed;
+    }
+  }
+
+  return undefined;
+};


### PR DESCRIPTION
## Summary
- widen the desktop ticket details panel and persist its preferred size so the full column content stays visible
- normalize ticket location data (including fallback addresses) so the embedded map renders reliably and shows trimmed labels
- update the Google Maps link logic to prefer coordinates, fall back to resolved addresses, and keep the mini map entry point available

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d001882340832284fcfcb2657da4c8