### PR TITLE
Use municipal states endpoint for analytics filters

### DIFF
--- a/src/pages/MunicipalAnalytics.tsx
+++ b/src/pages/MunicipalAnalytics.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import { apiFetch, ApiError } from '@/utils/api';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -10,7 +10,6 @@ import {
   YAxis,
   Tooltip,
   Legend,
-  TooltipProps,
   PieChart,
   Pie,
   Cell,
@@ -18,19 +17,65 @@ import {
 import useRequireRole from '@/hooks/useRequireRole';
 import type { Role } from '@/utils/roles';
 import ChartTooltip from '@/components/analytics/ChartTooltip';
+import TicketStatsCharts from '@/components/TicketStatsCharts';
+import { AnalyticsHeatmap } from '@/components/analytics/Heatmap';
+import {
+  getHeatmapPoints,
+  getTicketStats,
+  getMunicipalTicketStates,
+  HeatPoint,
+  TicketStatsResponse,
+} from '@/services/statsService';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
 
 interface Municipality {
   name: string;
   totalTickets: number;
   categories: Record<string, number>;
   averageResponseHours: number;
+  statuses?: Record<string, number>;
+  genderBreakdown?: Record<string, number>;
+  ageRanges?: Record<string, number>;
 }
 
 interface AnalyticsResponse {
   municipalities: Municipality[];
   genderTotals?: Record<string, number>;
   ageRanges?: Record<string, number>;
+  statusTotals?: Record<string, number>;
 }
+
+type SortOption = 'tickets_desc' | 'response_asc' | 'response_desc';
+
+const STATUS_COLOR_PALETTE = Array.from({ length: 12 }, (_, idx) => `var(--chart-${idx + 1})`);
+
+const formatLabel = (value: string) =>
+  value
+    .split(/[_\s]+/)
+    .filter(Boolean)
+    .map((chunk) => chunk.charAt(0).toUpperCase() + chunk.slice(1))
+    .join(' ');
+
+const safeNumber = (value: unknown): number => {
+  const num = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(num) ? num : 0;
+};
 
 export default function MunicipalAnalytics() {
   useRequireRole(['admin', 'super_admin'] as Role[]);
@@ -41,139 +86,437 @@ export default function MunicipalAnalytics() {
   const [genderFilter, setGenderFilter] = useState('');
   const [ageMin, setAgeMin] = useState('');
   const [ageMax, setAgeMax] = useState('');
+  const [statusFilters, setStatusFilters] = useState<string[]>([]);
+  const [sortOption, setSortOption] = useState<SortOption>('tickets_desc');
+  const [heatmapData, setHeatmapData] = useState<HeatPoint[]>([]);
+  const [charts, setCharts] = useState<TicketStatsResponse['charts']>([]);
+  const [allowedStatuses, setAllowedStatuses] = useState<string[]>([]);
 
-  const fetchData = useCallback(() => {
+  useEffect(() => {
+    let active = true;
+    getMunicipalTicketStates()
+      .then((states) => {
+        if (!active) return;
+        setAllowedStatuses(states);
+      })
+      .catch((err) => {
+        if (!active) return;
+        setAllowedStatuses([]);
+        console.error('Error fetching allowed municipal states:', err);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const fetchData = useCallback(async () => {
     setLoading(true);
     setError(null);
+
     const qs = new URLSearchParams();
+    if (categoryFilter !== 'all') qs.append('categoria', categoryFilter);
     if (genderFilter) qs.append('genero', genderFilter);
     if (ageMin) qs.append('edad_min', ageMin);
     if (ageMax) qs.append('edad_max', ageMax);
-    apiFetch<AnalyticsResponse>(
-      `/municipal/analytics${qs.toString() ? `?${qs.toString()}` : ''}`,
-    )
-      .then((resp) => {
-        setData(resp);
-        setLoading(false);
-      })
-      .catch((err: any) => {
-        const message =
-          err instanceof ApiError ? err.message : 'Error al cargar analíticas.';
-        setError(message);
-        setLoading(false);
-      });
-  }, [genderFilter, ageMin, ageMax]);
+    statusFilters
+      .filter((status) => status)
+      .forEach((status) => qs.append('estado', status));
+
+    try {
+      const analyticsResponse = await apiFetch<AnalyticsResponse>(
+        `/municipal/analytics${qs.toString() ? `?${qs.toString()}` : ''}`,
+      );
+      setData(analyticsResponse);
+
+      const statsParams = {
+        tipo: 'municipio',
+        categoria: categoryFilter !== 'all' ? categoryFilter : undefined,
+        genero: genderFilter || undefined,
+        edad_min: ageMin || undefined,
+        edad_max: ageMax || undefined,
+        estado: statusFilters.length > 0 ? statusFilters : undefined,
+      };
+
+      const [statsResult, heatmapResult] = await Promise.allSettled([
+        getTicketStats(statsParams),
+        getHeatmapPoints({
+          tipo_ticket: 'municipio',
+          categoria: categoryFilter !== 'all' ? categoryFilter : undefined,
+          genero: genderFilter || undefined,
+          edad_min: ageMin || undefined,
+          edad_max: ageMax || undefined,
+          estado: statusFilters.length > 0 ? statusFilters : undefined,
+        }),
+      ]);
+
+      if (statsResult.status === 'fulfilled') {
+        setCharts(statsResult.value.charts || []);
+      } else {
+        setCharts([]);
+        console.error('Error fetching ticket stats:', statsResult.reason);
+      }
+
+      if (heatmapResult.status === 'fulfilled') {
+        setHeatmapData(heatmapResult.value);
+      } else {
+        setHeatmapData([]);
+        console.error('Error fetching heatmap data:', heatmapResult.reason);
+      }
+    } catch (err: any) {
+      const message =
+        err instanceof ApiError ? err.message : 'Error al cargar analíticas.';
+      setError(message);
+      setData(null);
+      setHeatmapData([]);
+      setCharts([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [categoryFilter, genderFilter, ageMin, ageMax, statusFilters]);
 
   useEffect(() => {
     fetchData();
   }, [fetchData]);
 
-  if (loading) return <p className="p-4 text-center">Cargando analíticas...</p>;
-  if (error) return <p className="p-4 text-destructive text-center">Error: {error}</p>;
-  if (!data || !Array.isArray(data.municipalities) || data.municipalities.length === 0)
-    return <p className="p-4 text-center text-muted-foreground">No hay datos disponibles.</p>;
+  const statusKeys = useMemo(() => {
+    const set = new Set<string>(allowedStatuses.filter(Boolean));
+    if (data?.statusTotals) {
+      Object.keys(data.statusTotals).forEach((status) => {
+        if (status) set.add(status);
+      });
+    }
+    data?.municipalities.forEach((m) => {
+      Object.keys(m.statuses || {}).forEach((status) => {
+        if (status) set.add(status);
+      });
+    });
+    return Array.from(set);
+  }, [allowedStatuses, data]);
 
-  const allCategories = Array.from(
-    new Set(
-      data.municipalities.flatMap((m) => Object.keys(m.categories || {}))
-    )
+  useEffect(() => {
+    setStatusFilters((prev) => {
+      if (prev.length === 0) return prev;
+      const filtered = prev.filter((status) => statusKeys.includes(status));
+      return filtered.length === prev.length ? prev : filtered;
+    });
+  }, [statusKeys]);
+
+  const allCategories = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          data?.municipalities.flatMap((m) => Object.keys(m.categories || {})) || [],
+        ),
+      ),
+    [data],
   );
 
-  const chartData = data.municipalities.map((m) => ({
-    name: m.name,
-    value:
-      categoryFilter === 'all'
-        ? m.totalTickets
-        : m.categories[categoryFilter] || 0,
-  }));
+  const filteredMunicipalities = useMemo(() => {
+    if (!data) return [] as Municipality[];
+    if (statusFilters.length === 0) return data.municipalities;
+    return data.municipalities.filter((m) => {
+      if (!m.statuses) return true;
+      return statusFilters.some((status) => safeNumber(m.statuses?.[status]) > 0);
+    });
+  }, [data, statusFilters]);
 
-  const categoryTotals = allCategories.map((c) => ({
-    name: c,
-    value: data.municipalities.reduce(
-      (sum, m) => sum + (m.categories[c] || 0),
-      0,
-    ),
-  }));
-  const totalTickets = data.municipalities.reduce((acc, m) => acc + m.totalTickets, 0);
-  const totalResponseHours = data.municipalities.reduce((acc, m) => acc + m.averageResponseHours, 0);
-  const averageResponseHours = totalResponseHours / data.municipalities.length;
+  const sortedMunicipalities = useMemo(() => {
+    const entries = [...filteredMunicipalities];
+    switch (sortOption) {
+      case 'response_asc':
+        return entries.sort(
+          (a, b) => safeNumber(a.averageResponseHours) - safeNumber(b.averageResponseHours),
+        );
+      case 'response_desc':
+        return entries.sort(
+          (a, b) => safeNumber(b.averageResponseHours) - safeNumber(a.averageResponseHours),
+        );
+      default:
+        return entries.sort((a, b) => {
+          const aValue =
+            categoryFilter === 'all'
+              ? safeNumber(a.totalTickets)
+              : safeNumber(a.categories?.[categoryFilter]);
+          const bValue =
+            categoryFilter === 'all'
+              ? safeNumber(b.totalTickets)
+              : safeNumber(b.categories?.[categoryFilter]);
+          return bValue - aValue;
+        });
+    }
+  }, [filteredMunicipalities, sortOption, categoryFilter]);
 
-  const genderData = data.genderTotals
-    ? Object.entries(data.genderTotals).map(([name, value]) => ({ name, value }))
-    : [];
-  const ageData = data.ageRanges
-    ? Object.entries(data.ageRanges).map(([name, value]) => ({ name, value }))
-    : [];
+  const totalTickets = useMemo(
+    () =>
+      filteredMunicipalities.reduce((acc, m) => {
+        const value =
+          categoryFilter === 'all'
+            ? safeNumber(m.totalTickets)
+            : safeNumber(m.categories?.[categoryFilter]);
+        return acc + value;
+      }, 0),
+    [filteredMunicipalities, categoryFilter],
+  );
 
-  const CustomTooltip = ({ active, payload }: TooltipProps<number, string>) => {
-    if (!active || !payload || payload.length === 0) return null;
-    const item = payload[0];
+  const responseValues = useMemo(
+    () =>
+      filteredMunicipalities
+        .map((m) => m.averageResponseHours)
+        .filter((value): value is number => typeof value === 'number' && !Number.isNaN(value)),
+    [filteredMunicipalities],
+  );
+
+  const averageResponseHours = responseValues.length
+    ? responseValues.reduce((sum, value) => sum + value, 0) / responseValues.length
+    : 0;
+
+  const categoryTotals = useMemo(
+    () =>
+      allCategories.map((category) => ({
+        name: category,
+        value: filteredMunicipalities.reduce(
+          (sum, m) => sum + safeNumber(m.categories?.[category]),
+          0,
+        ),
+      })),
+    [allCategories, filteredMunicipalities],
+  );
+
+  const chartData = useMemo(
+    () =>
+      sortedMunicipalities.map((m) => ({
+        name: m.name,
+        value:
+          categoryFilter === 'all'
+            ? safeNumber(m.totalTickets)
+            : safeNumber(m.categories?.[categoryFilter]),
+      })),
+    [sortedMunicipalities, categoryFilter],
+  );
+
+  const genderData = useMemo(
+    () =>
+      data?.genderTotals
+        ? Object.entries(data.genderTotals).map(([name, value]) => ({
+            name,
+            value: safeNumber(value),
+          }))
+        : [],
+    [data],
+  );
+
+  const ageData = useMemo(
+    () =>
+      data?.ageRanges
+        ? Object.entries(data.ageRanges).map(([name, value]) => ({
+            name,
+            value: safeNumber(value),
+          }))
+        : [],
+    [data],
+  );
+
+  const statusColors = useMemo(
+    () =>
+      statusKeys.reduce((acc, status, index) => {
+        acc[status] = STATUS_COLOR_PALETTE[index % STATUS_COLOR_PALETTE.length];
+        return acc;
+      }, {} as Record<string, string>),
+    [statusKeys],
+  );
+
+  const statusSummary = useMemo(
+    () =>
+      statusKeys.map((status) => {
+        const totalFromResponse = safeNumber(data?.statusTotals?.[status]);
+        const aggregated = safeNumber(
+          data?.municipalities.reduce(
+            (sum, m) => sum + safeNumber(m.statuses?.[status]),
+            0,
+          ),
+        );
+        return { status, value: totalFromResponse || aggregated };
+      }),
+    [data, statusKeys],
+  );
+
+  const stackedStatusData = useMemo(
+    () =>
+      sortedMunicipalities.map((m) => ({
+        name: m.name,
+        ...statusKeys.reduce((acc, status) => {
+          acc[status] = safeNumber(m.statuses?.[status]);
+          return acc;
+        }, {} as Record<string, number>),
+      })),
+    [sortedMunicipalities, statusKeys],
+  );
+
+  const heatmapCategories = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          heatmapData
+            .map((point) => point.categoria)
+            .filter((value): value is string => Boolean(value)),
+        ),
+      ),
+    [heatmapData],
+  );
+
+  const heatmapBarrios = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          heatmapData
+            .map((point) => point.barrio)
+            .filter((value): value is string => Boolean(value)),
+        ),
+      ),
+    [heatmapData],
+  );
+
+  const heatmapTipos = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          heatmapData
+            .map((point) => point.tipo_ticket)
+            .filter((value): value is string => Boolean(value)),
+        ),
+      ),
+    [heatmapData],
+  );
+
+  const updateStatusFilter = useCallback((status: string, checked: boolean) => {
+    setStatusFilters((prev) => {
+      if (checked) {
+        if (prev.includes(status)) return prev;
+        return [...prev, status];
+      }
+      return prev.filter((item) => item !== status);
+    });
+  }, []);
+
+  if (loading) return <p className="p-4 text-center">Cargando analíticas...</p>;
+  if (error) return <p className="p-4 text-destructive text-center">Error: {error}</p>;
+  if (!data || filteredMunicipalities.length === 0)
     return (
-      <div className="bg-background p-2 shadow-lg rounded-lg">
-        <p className="text-sm text-muted-foreground">{item.payload.name}</p>
-        <p className="text-sm font-bold">{item.value}</p>
-      </div>
+      <p className="p-4 text-center text-muted-foreground">
+        No hay datos disponibles con los filtros actuales.
+      </p>
     );
-  };
 
   return (
-    <div className="p-4 max-w-4xl mx-auto space-y-6">
+    <div className="p-4 max-w-6xl mx-auto space-y-6">
       <h1 className="text-3xl font-extrabold text-primary mb-4">Analíticas Profesionales</h1>
 
-      <div className="flex flex-wrap gap-4 items-center">
-        <label className="text-sm">
-          Categoría:
-          <select
-            className="ml-2 border rounded p-1 bg-background"
-            value={categoryFilter}
-            onChange={(e) => setCategoryFilter(e.target.value)}
+      <div className="space-y-4">
+        <div className="flex flex-wrap items-end gap-4">
+          <div>
+            <Label className="text-sm">Categoría</Label>
+            <select
+              className="mt-1 border rounded p-2 bg-background"
+              value={categoryFilter}
+              onChange={(e) => setCategoryFilter(e.target.value)}
+            >
+              <option value="all">Todas</option>
+              {allCategories.map((category) => (
+                <option key={category} value={category}>
+                  {category}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <Label className="text-sm">Género</Label>
+            <select
+              className="mt-1 border rounded p-2 bg-background"
+              value={genderFilter}
+              onChange={(e) => setGenderFilter(e.target.value)}
+            >
+              <option value="">Todos</option>
+              <option value="F">Femenino</option>
+              <option value="M">Masculino</option>
+              <option value="X">Otro</option>
+            </select>
+          </div>
+          <div>
+            <Label className="text-sm">Edad mínima</Label>
+            <input
+              type="number"
+              className="mt-1 border rounded p-2 w-24 bg-background"
+              value={ageMin}
+              onChange={(e) => setAgeMin(e.target.value)}
+            />
+          </div>
+          <div>
+            <Label className="text-sm">Edad máxima</Label>
+            <input
+              type="number"
+              className="mt-1 border rounded p-2 w-24 bg-background"
+              value={ageMax}
+              onChange={(e) => setAgeMax(e.target.value)}
+            />
+          </div>
+          <div>
+            <Label className="text-sm">Ordenar por</Label>
+            <Select value={sortOption} onValueChange={(value: SortOption) => setSortOption(value)}>
+              <SelectTrigger className="mt-1 w-48">
+                <SelectValue placeholder="Ordenar" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="tickets_desc">Mayor cantidad de tickets</SelectItem>
+                <SelectItem value="response_asc">Menor tiempo de respuesta</SelectItem>
+                <SelectItem value="response_desc">Mayor tiempo de respuesta</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <Button
+            className="bg-primary hover:bg-primary/90 text-primary-foreground"
+            onClick={fetchData}
           >
-            <option value="all">Todas</option>
-            {allCategories.map((c) => (
-              <option key={c} value={c}>
-                {c}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label className="text-sm">
-          Género:
-          <select
-            className="ml-2 border rounded p-1 bg-background"
-            value={genderFilter}
-            onChange={(e) => setGenderFilter(e.target.value)}
-          >
-            <option value="">Todos</option>
-            <option value="F">Femenino</option>
-            <option value="M">Masculino</option>
-            <option value="X">Otro</option>
-          </select>
-        </label>
-        <label className="text-sm">
-          Edad mínima:
-          <input
-            type="number"
-            className="ml-2 border rounded p-1 w-20 bg-background"
-            value={ageMin}
-            onChange={(e) => setAgeMin(e.target.value)}
-          />
-        </label>
-        <label className="text-sm">
-          Edad máxima:
-          <input
-            type="number"
-            className="ml-2 border rounded p-1 w-20 bg-background"
-            value={ageMax}
-            onChange={(e) => setAgeMax(e.target.value)}
-          />
-        </label>
-        <Button
-          className="bg-primary hover:bg-primary/90 text-primary-foreground"
-          onClick={fetchData}
-        >
-          Aplicar
-        </Button>
+            Aplicar filtros
+          </Button>
+        </div>
+
+        {statusKeys.length > 0 && (
+          <div>
+            <Label className="text-sm font-medium">Estados</Label>
+            <div className="mt-2 flex flex-wrap gap-3">
+              {statusKeys.map((status) => (
+                <label key={status} className="flex items-center gap-2 text-sm text-foreground">
+                  <Checkbox
+                    checked={statusFilters.includes(status)}
+                    onCheckedChange={(checked) => updateStatusFilter(status, checked === true)}
+                  />
+                  <span>{formatLabel(status)}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+        )}
       </div>
+
+      {statusSummary.length > 0 && (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          {statusSummary.map(({ status, value }) => (
+            <Card key={status}>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">{formatLabel(status)}</CardTitle>
+                <span
+                  className="h-2 w-2 rounded-full"
+                  style={{ backgroundColor: statusColors[status] }}
+                  aria-hidden
+                />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{safeNumber(value).toLocaleString('es-AR')}</div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
 
       <div className="grid gap-4 md:grid-cols-2">
         <Card>
@@ -193,7 +536,7 @@ export default function MunicipalAnalytics() {
             </svg>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{totalTickets}</div>
+            <div className="text-2xl font-bold">{totalTickets.toLocaleString('es-AR')}</div>
           </CardContent>
         </Card>
         <Card>
@@ -213,7 +556,11 @@ export default function MunicipalAnalytics() {
             </svg>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{averageResponseHours.toFixed(2)}</div>
+            <div className="text-2xl font-bold">
+              {Number.isFinite(averageResponseHours)
+                ? averageResponseHours.toFixed(2)
+                : '0.00'}
+            </div>
           </CardContent>
         </Card>
       </div>
@@ -227,7 +574,7 @@ export default function MunicipalAnalytics() {
             <ResponsiveContainer width="100%" height="100%">
               <BarChart data={chartData}>
                 <XAxis dataKey="name" />
-                <YAxis />
+                <YAxis allowDecimals={false} />
                 <Tooltip cursor={false} content={<ChartTooltip />} />
                 <Legend />
                 <Bar dataKey="value" fill="var(--color-value)" radius={4} />
@@ -252,13 +599,10 @@ export default function MunicipalAnalytics() {
                   cx="50%"
                   cy="50%"
                   outerRadius={80}
-                  label
+                  label={(entry) => `${entry.name}: ${entry.value}`}
                 >
                   {categoryTotals.map((entry, index) => (
-                    <Cell
-                      key={`cell-${index}`}
-                      fill={`var(--chart-${(index % 12) + 1})`}
-                    />
+                    <Cell key={`cell-${entry.name}`} fill={`var(--chart-${(index % 12) + 1})`} />
                   ))}
                 </Pie>
                 <Tooltip cursor={false} content={<ChartTooltip />} />
@@ -268,6 +612,35 @@ export default function MunicipalAnalytics() {
           </div>
         </CardContent>
       </Card>
+
+      {statusKeys.length > 0 && stackedStatusData.length > 0 && (
+        <Card className="shadow-lg">
+          <CardHeader>
+            <CardTitle className="text-xl">Estados por Municipio</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="h-80">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={stackedStatusData}>
+                  <XAxis dataKey="name" />
+                  <YAxis allowDecimals={false} />
+                  <Tooltip cursor={false} content={<ChartTooltip />} />
+                  <Legend />
+                  {statusKeys.map((status) => (
+                    <Bar
+                      key={status}
+                      dataKey={status}
+                      stackId="status"
+                      fill={statusColors[status]}
+                      radius={[4, 4, 0, 0]}
+                    />
+                  ))}
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       {genderData.length > 0 && (
         <Card className="shadow-lg">
@@ -279,7 +652,7 @@ export default function MunicipalAnalytics() {
               <ResponsiveContainer width="100%" height="100%">
                 <BarChart data={genderData}>
                   <XAxis dataKey="name" />
-                  <YAxis />
+                  <YAxis allowDecimals={false} />
                   <Tooltip cursor={false} content={<ChartTooltip />} />
                   <Legend />
                   <Bar dataKey="value" fill="var(--color-gender)" radius={4} />
@@ -300,7 +673,7 @@ export default function MunicipalAnalytics() {
               <ResponsiveContainer width="100%" height="100%">
                 <BarChart data={ageData}>
                   <XAxis dataKey="name" />
-                  <YAxis />
+                  <YAxis allowDecimals={false} />
                   <Tooltip cursor={false} content={<ChartTooltip />} />
                   <Legend />
                   <Bar dataKey="value" fill="var(--color-age)" radius={4} />
@@ -311,33 +684,84 @@ export default function MunicipalAnalytics() {
         </Card>
       )}
 
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-        {data.municipalities.map((m) => (
-          <Card key={m.name}>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">{m.name}</CardTitle>
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2"
-                className="h-4 w-4 text-muted-foreground"
-              >
-                <path d="M12 2v20M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
-              </svg>
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">{m.totalTickets}</div>
-              <p className="text-xs text-muted-foreground">
-                Promedio de respuesta: {m.averageResponseHours} h
-              </p>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
+      <Card className="shadow-lg">
+        <CardHeader>
+          <CardTitle className="text-xl">Detalle por Municipio</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Municipio</TableHead>
+                <TableHead>
+                  {categoryFilter === 'all'
+                    ? 'Tickets Totales'
+                    : `Tickets (${formatLabel(categoryFilter)})`}
+                </TableHead>
+                <TableHead>Prom. respuesta (h)</TableHead>
+                {statusKeys.map((status) => (
+                  <TableHead key={status}>{formatLabel(status)}</TableHead>
+                ))}
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {sortedMunicipalities.map((m) => (
+                <TableRow key={m.name}>
+                  <TableCell className="font-medium">{m.name}</TableCell>
+                  <TableCell>
+                    {(
+                      categoryFilter === 'all'
+                        ? safeNumber(m.totalTickets)
+                        : safeNumber(m.categories?.[categoryFilter])
+                    ).toLocaleString('es-AR')}
+                  </TableCell>
+                  <TableCell>
+                    {typeof m.averageResponseHours === 'number' && !Number.isNaN(m.averageResponseHours)
+                      ? m.averageResponseHours.toFixed(2)
+                      : '—'}
+                  </TableCell>
+                  {statusKeys.map((status) => (
+                    <TableCell key={status}>
+                      {safeNumber(m.statuses?.[status]).toLocaleString('es-AR')}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      {charts && charts.length > 0 && (
+        <Card className="shadow-lg">
+          <CardHeader>
+            <CardTitle className="text-xl">Indicadores adicionales</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <TicketStatsCharts charts={charts} />
+          </CardContent>
+        </Card>
+      )}
+
+      {heatmapData.length > 0 ? (
+        <AnalyticsHeatmap
+          initialHeatmapData={heatmapData}
+          availableCategories={heatmapCategories}
+          availableBarrios={heatmapBarrios}
+          availableTipos={heatmapTipos}
+        />
+      ) : (
+        <Card className="shadow-lg">
+          <CardHeader>
+            <CardTitle className="text-xl">Mapa de Calor</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">
+              No hay datos georreferenciados para mostrar con los filtros actuales.
+            </p>
+          </CardContent>
+        </Card>
+      )}
     </div>
   );
 }

--- a/src/pages/MunicipalStats.tsx
+++ b/src/pages/MunicipalStats.tsx
@@ -3,7 +3,7 @@ import { apiFetch, ApiError } from '@/utils/api';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { ChartContainer } from '@/components/ui/chart';
-import { BarChart, Bar, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import { BarChart, Bar, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer, TooltipProps } from 'recharts';
 import { Button } from '@/components/ui/button';
 import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from '@/components/ui/accordion';
 import useRequireRole from '@/hooks/useRequireRole';
@@ -17,6 +17,18 @@ interface StatItem {
 interface StatsResponse {
   stats: StatItem[];
 }
+
+const CustomTooltip = ({ active, payload }: TooltipProps<number, string>) => {
+  if (!active || !payload?.length) return null;
+  const item = payload[0];
+  const label = (item as any).payload?.name ?? item.name;
+  return (
+    <div className="bg-background p-2 shadow-lg rounded-lg">
+      <p className="text-sm text-muted-foreground">{label}</p>
+      <p className="text-sm font-bold">{item.value}</p>
+    </div>
+  );
+};
 
 export default function MunicipalStats() {
   useRequireRole(['admin', 'super_admin'] as Role[]);
@@ -196,13 +208,7 @@ export default function MunicipalStats() {
                 <BarChart data={data.stats.map(s => ({ name: s.label, value: typeof s.value === 'number' && !isNaN(s.value) ? s.value : 0 }))}>
                   <XAxis dataKey="name" tickFormatter={(value) => value.slice(0, 15)} />
                   <YAxis />
-                  <Tooltip
-                    cursor={false}
-                    content={<div className="bg-background p-2 shadow-lg rounded-lg">
-                      <p className="text-sm text-muted-foreground">{'{payload?.[0]?.payload?.name}'}</p>
-                      <p className="text-sm font-bold">{'{payload?.[0]?.value}'}</p>
-                    </div>}
-                  />
+                  <Tooltip cursor={false} content={<CustomTooltip />} />
                   <Legend />
                   <Bar dataKey="value" fill="var(--color-value)" radius={4} />
                 </BarChart>


### PR DESCRIPTION
## Summary
- fetch the list of allowed ticket states from the new `/municipal/estados` endpoint
- seed municipal analytics filters, tables, and status summaries with the backend-provided states so they stay consistent even when the current dataset omits some statuses

## Testing
- npm test *(fails: missing ../server/*.cjs fixtures required by Vitest suites)*

------
https://chatgpt.com/codex/tasks/task_e_68d0b542f63c83229214d895132ce5b9