### PR TITLE
Gracefully handle unavailable municipal analytics endpoint

### DIFF
--- a/src/utils/endpointAvailability.ts
+++ b/src/utils/endpointAvailability.ts
@@ -1,0 +1,50 @@
+import { safeLocalStorage } from '@/utils/safeLocalStorage';
+
+const STORAGE_PREFIX = 'endpoint-unavailable:';
+const DEFAULT_TTL_MS = 30 * 60 * 1000; // 30 minutes
+
+type StoredValue = {
+  expires: number;
+};
+
+const buildKey = (path: string) => `${STORAGE_PREFIX}${path}`;
+
+export function markEndpointUnavailable(path: string, ttlMs: number = DEFAULT_TTL_MS) {
+  try {
+    const expires = Date.now() + Math.max(0, ttlMs);
+    safeLocalStorage.setItem(buildKey(path), JSON.stringify({ expires } satisfies StoredValue));
+  } catch (error) {
+    console.warn('[endpointAvailability] Unable to persist endpoint flag', { path, error });
+  }
+}
+
+export function clearEndpointUnavailable(path: string) {
+  try {
+    safeLocalStorage.removeItem(buildKey(path));
+  } catch (error) {
+    console.warn('[endpointAvailability] Unable to clear endpoint flag', { path, error });
+  }
+}
+
+export function isEndpointMarkedUnavailable(path: string): boolean {
+  try {
+    const raw = safeLocalStorage.getItem(buildKey(path));
+    if (!raw) return false;
+    const parsed = JSON.parse(raw) as Partial<StoredValue>;
+    if (typeof parsed.expires === 'number') {
+      if (parsed.expires > Date.now()) {
+        return true;
+      }
+    }
+    safeLocalStorage.removeItem(buildKey(path));
+    return false;
+  } catch (error) {
+    console.warn('[endpointAvailability] Invalid flag detected, clearing', { path, error });
+    try {
+      safeLocalStorage.removeItem(buildKey(path));
+    } catch (removeError) {
+      console.warn('[endpointAvailability] Unable to remove corrupted flag', { path, removeError });
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- add shared helpers to cache endpoint availability with a temporary flag
- hide municipal analytics link after repeated failures and skip redundant fetches
- surface a warning banner with retry support when the professional analytics API is down

## Testing
- `npm run test` *(fails: requires server/*.cjs fixtures that are absent in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d19389e01483229676c1f87645cbfa