### PR TITLE
Refine municipal analytics charts spacing

### DIFF
--- a/src/components/TicketStatsCharts.tsx
+++ b/src/components/TicketStatsCharts.tsx
@@ -7,10 +7,12 @@ import {
   Tooltip,
   Legend,
   Title,
+  Filler,
 } from 'chart.js';
+import type { ChartOptions } from 'chart.js';
 import React from 'react';
 
-ChartJS.register(BarElement, CategoryScale, LinearScale, Tooltip, Legend, Title);
+ChartJS.register(BarElement, CategoryScale, LinearScale, Tooltip, Legend, Title, Filler);
 
 export interface ChartBlock {
   title: string;
@@ -23,33 +25,86 @@ interface Props {
 
 function SingleChart({ title, data }: ChartBlock) {
   const labels = Object.keys(data);
-  const values = Object.values(data);
+  const values = labels.map((key) => {
+    const value = data[key];
+    return typeof value === 'number' && Number.isFinite(value) ? value : Number(value) || 0;
+  });
+
   const chartData = {
     labels,
     datasets: [
       {
         label: title,
         data: values,
-        backgroundColor: 'rgba(59,130,246,0.5)',
+        backgroundColor: 'hsl(var(--primary) / 0.65)',
+        hoverBackgroundColor: 'hsl(var(--primary) / 0.85)',
+        borderRadius: 6,
+        maxBarThickness: 48,
       },
     ],
   };
-  const options = {
+
+  const options: ChartOptions<'bar'> = {
     responsive: true,
+    maintainAspectRatio: false,
     plugins: {
       legend: { display: false },
-      title: { display: true, text: title },
+      title: { display: false },
+      tooltip: {
+        backgroundColor: 'hsl(var(--popover))',
+        titleColor: 'hsl(var(--popover-foreground))',
+        bodyColor: 'hsl(var(--popover-foreground))',
+        borderColor: 'hsl(var(--border))',
+        borderWidth: 1,
+      },
     },
-  } as const;
-  return <Bar data={chartData} options={options} />;
+    scales: {
+      x: {
+        ticks: {
+          color: 'hsl(var(--muted-foreground))',
+          maxRotation: 40,
+          minRotation: 0,
+          autoSkip: true,
+        },
+        grid: { display: false },
+      },
+      y: {
+        beginAtZero: true,
+        ticks: {
+          color: 'hsl(var(--muted-foreground))',
+          precision: 0,
+        },
+        grid: {
+          color: 'hsl(var(--border) / 0.3)',
+        },
+      },
+    },
+    layout: {
+      padding: {
+        top: 8,
+        bottom: 8,
+        left: 0,
+        right: 0,
+      },
+    },
+  };
+
+  return (
+    <div className="flex h-full flex-col rounded-lg border border-border bg-card/80 p-4 shadow-sm">
+      <h3 className="text-sm font-semibold text-foreground">{title}</h3>
+      <div className="mt-4 h-64">
+        <Bar data={chartData} options={options} updateMode="resize" />
+      </div>
+    </div>
+  );
 }
 
 export default function TicketStatsCharts({ charts }: Props) {
   if (!charts || charts.length === 0) return null;
   return (
-    <div className="grid gap-8 md:grid-cols-2">
+    <div className="grid auto-rows-[minmax(0,1fr)] gap-6 md:grid-cols-2 xl:grid-cols-3">
       {charts.map((c, idx) => (
-        <SingleChart key={idx} {...c} />
+        <SingleChart key={`${c.title}-${idx}`} {...c} />
       ))}
     </div>
   );

--- a/src/utils/endpointAvailability.ts
+++ b/src/utils/endpointAvailability.ts
@@ -1,0 +1,50 @@
+import { safeLocalStorage } from '@/utils/safeLocalStorage';
+
+const STORAGE_PREFIX = 'endpoint-unavailable:';
+const DEFAULT_TTL_MS = 30 * 60 * 1000; // 30 minutes
+
+type StoredValue = {
+  expires: number;
+};
+
+const buildKey = (path: string) => `${STORAGE_PREFIX}${path}`;
+
+export function markEndpointUnavailable(path: string, ttlMs: number = DEFAULT_TTL_MS) {
+  try {
+    const expires = Date.now() + Math.max(0, ttlMs);
+    safeLocalStorage.setItem(buildKey(path), JSON.stringify({ expires } satisfies StoredValue));
+  } catch (error) {
+    console.warn('[endpointAvailability] Unable to persist endpoint flag', { path, error });
+  }
+}
+
+export function clearEndpointUnavailable(path: string) {
+  try {
+    safeLocalStorage.removeItem(buildKey(path));
+  } catch (error) {
+    console.warn('[endpointAvailability] Unable to clear endpoint flag', { path, error });
+  }
+}
+
+export function isEndpointMarkedUnavailable(path: string): boolean {
+  try {
+    const raw = safeLocalStorage.getItem(buildKey(path));
+    if (!raw) return false;
+    const parsed = JSON.parse(raw) as Partial<StoredValue>;
+    if (typeof parsed.expires === 'number') {
+      if (parsed.expires > Date.now()) {
+        return true;
+      }
+    }
+    safeLocalStorage.removeItem(buildKey(path));
+    return false;
+  } catch (error) {
+    console.warn('[endpointAvailability] Invalid flag detected, clearing', { path, error });
+    try {
+      safeLocalStorage.removeItem(buildKey(path));
+    } catch (removeError) {
+      console.warn('[endpointAvailability] Unable to remove corrupted flag', { path, removeError });
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- restyle the shared TicketStatsCharts component to render responsive card-like panels with consistent heights and spacing
- reorganize municipal analytics visualizations into a responsive grid so charts no longer overlap and maintain breathing room across breakpoints
- gate chart rendering on available data to avoid empty panels while preserving the existing statistics table and filters

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d19389e01483229676c1f87645cbfa