### PR TITLE
Fix municipal analytics chart dependencies

### DIFF
--- a/src/pages/MunicipalAnalytics.tsx
+++ b/src/pages/MunicipalAnalytics.tsx
@@ -593,6 +593,14 @@ export default function MunicipalAnalytics() {
     [stackedStatusData, statusKeys],
   );
 
+  const hasStatusData = useMemo(
+    () => statusSummary.some((item) => safeNumber(item.value) > 0),
+    [statusSummary],
+  );
+
+  const hasGenderData = genderData.length > 0;
+  const hasAgeData = ageData.length > 0;
+
   const chartCards = useMemo(() => {
     const cards: React.ReactNode[] = [];
 
@@ -793,9 +801,6 @@ export default function MunicipalAnalytics() {
   }, []);
 
   const hasMunicipalityRows = filteredMunicipalities.length > 0;
-  const hasStatusData = statusSummary.some((item) => safeNumber(item.value) > 0);
-  const hasGenderData = genderData.length > 0;
-  const hasAgeData = ageData.length > 0;
   const hasChartsData = charts && charts.length > 0;
   const hasHeatmapPoints = heatmapData.length > 0;
 


### PR DESCRIPTION
## Summary
- calculate the municipal status, gender, and age availability flags before the chart memoization so they are defined when React evaluates the dependency list
- keep the existing summary conditions using the newly hoisted booleans so the analytics page renders without triggering a temporal dead zone error

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1b567508883228f3e0208383f7335