### PR TITLE
Add interactive location map to profile page

### DIFF
--- a/src/components/ui/AddressAutocomplete.tsx
+++ b/src/components/ui/AddressAutocomplete.tsx
@@ -12,6 +12,7 @@ interface AddressAutocompleteProps {
   persistKey?: string;
   readOnly?: boolean;
   disabled?: boolean;
+  id?: string;
 }
 
 const MAPTILER_KEY = import.meta.env.VITE_MAPTILER_KEY || "";
@@ -26,6 +27,7 @@ const AddressAutocomplete: React.FC<AddressAutocompleteProps> = ({
   persistKey,
   readOnly = false,
   disabled = false,
+  id,
 }) => {
   const [query, setQuery] = useState(value?.label || "");
   const [options, setOptions] = useState<string[]>([]);
@@ -99,6 +101,7 @@ const AddressAutocomplete: React.FC<AddressAutocompleteProps> = ({
   if (readOnly || disabled) {
     return (
       <Input
+        id={id}
         value={query}
         readOnly
         disabled={disabled}
@@ -111,6 +114,7 @@ const AddressAutocomplete: React.FC<AddressAutocompleteProps> = ({
   return (
     <div className="relative">
       <Input
+        id={id}
         value={query}
         onChange={(e) => {
           const val = e.target.value;


### PR DESCRIPTION
## Summary
- add geocoding state and manual location handling on the profile so admins can adjust their business coordinates
- render a dedicated map card with MapLibre and only show the analytics heatmap when ticket data is available
- wire the profile form to AddressAutocomplete and allow the component to receive an input id for better labeling

## Testing
- npm test *(fails: repository lacks server/*.cjs modules required by municipal analytics tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b67abf908322a4cf553b8dbe5517