### PR TITLE
Handle local fallback URLs for audio uploads

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -90,8 +90,7 @@ const ChatInput = forwardRef<ChatInputHandle, Props>(({ onSendMessage, isTyping,
         });
         const originalFile = attachmentPreview.file;
         const normalized = normalizeUploadResponse(response);
-        const uploadedUrl =
-          normalized.url ||
+        const fallbackRawUrl =
           coalesceString(
             response.url,
             response.attachmentUrl,
@@ -99,7 +98,40 @@ const ChatInput = forwardRef<ChatInputHandle, Props>(({ onSendMessage, isTyping,
             response.fileUrl,
             response.file_url,
             response.archivo_url,
+            response.public_url,
+            response.publicUrl,
+            response.secure_url,
+            response.fallbackUrl,
+            response.fallback_url,
+            response.fallbackPublicUrl,
+            response.fallback_public_url,
+            response.local_url,
+            response.localUrl,
+            response.local_path,
+            response.localPath,
+            response.local_relative_path,
+            response.localRelativePath,
+            response.storage_path,
+            response.storagePath,
+            response.storage_url,
+            response.storageUrl,
+            response.static_url,
+            response.staticUrl,
+            response.relative_url,
+            response.relativeUrl,
+            response.full_path,
+            response.fullPath,
+            response.public_path,
+            response.publicPath,
+            response.path,
+            response.web_path,
+            response.webPath,
           );
+        const uploadedUrl =
+          normalized.url ||
+          (fallbackRawUrl
+            ? normalizeUploadResponse(fallbackRawUrl).url || fallbackRawUrl
+            : undefined);
 
         if (!uploadedUrl) {
           throw new Error('La respuesta del servidor no incluyó la URL del archivo subido.');
@@ -215,8 +247,7 @@ const ChatInput = forwardRef<ChatInputHandle, Props>(({ onSendMessage, isTyping,
       });
 
       const normalized = normalizeUploadResponse(data);
-      const uploadedUrl =
-        normalized.url ||
+      const fallbackRawUrl =
         coalesceString(
           data.url,
           data.attachmentUrl,
@@ -224,7 +255,40 @@ const ChatInput = forwardRef<ChatInputHandle, Props>(({ onSendMessage, isTyping,
           data.fileUrl,
           data.file_url,
           data.archivo_url,
+          data.public_url,
+          data.publicUrl,
+          data.secure_url,
+          data.fallbackUrl,
+          data.fallback_url,
+          data.fallbackPublicUrl,
+          data.fallback_public_url,
+          data.local_url,
+          data.localUrl,
+          data.local_path,
+          data.localPath,
+          data.local_relative_path,
+          data.localRelativePath,
+          data.storage_path,
+          data.storagePath,
+          data.storage_url,
+          data.storageUrl,
+          data.static_url,
+          data.staticUrl,
+          data.relative_url,
+          data.relativeUrl,
+          data.full_path,
+          data.fullPath,
+          data.public_path,
+          data.publicPath,
+          data.path,
+          data.web_path,
+          data.webPath,
         );
+      const uploadedUrl =
+        normalized.url ||
+        (fallbackRawUrl
+          ? normalizeUploadResponse(fallbackRawUrl).url || fallbackRawUrl
+          : undefined);
 
       if (!uploadedUrl) {
         throw new Error("La respuesta del servidor para la subida del audio fue inválida.");

--- a/src/components/tickets/ConversationPanel.tsx
+++ b/src/components/tickets/ConversationPanel.tsx
@@ -312,8 +312,7 @@ const ConversationPanel: React.FC<ConversationPanelProps> = ({
           body: formData,
         });
         const normalized = normalizeUploadResponse(response);
-        const uploadedUrl =
-          normalized.url ||
+        const fallbackRawUrl =
           coalesceString(
             response.url,
             response.attachmentUrl,
@@ -321,7 +320,40 @@ const ConversationPanel: React.FC<ConversationPanelProps> = ({
             response.fileUrl,
             response.file_url,
             response.archivo_url,
+            response.public_url,
+            response.publicUrl,
+            response.secure_url,
+            response.fallbackUrl,
+            response.fallback_url,
+            response.fallbackPublicUrl,
+            response.fallback_public_url,
+            response.local_url,
+            response.localUrl,
+            response.local_path,
+            response.localPath,
+            response.local_relative_path,
+            response.localRelativePath,
+            response.storage_path,
+            response.storagePath,
+            response.storage_url,
+            response.storageUrl,
+            response.static_url,
+            response.staticUrl,
+            response.relative_url,
+            response.relativeUrl,
+            response.full_path,
+            response.fullPath,
+            response.public_path,
+            response.publicPath,
+            response.path,
+            response.web_path,
+            response.webPath,
           );
+        const uploadedUrl =
+          normalized.url ||
+          (fallbackRawUrl
+            ? normalizeUploadResponse(fallbackRawUrl).url || fallbackRawUrl
+            : undefined);
 
         if (!uploadedUrl) {
           throw new Error('La respuesta del servidor no incluyó la URL del archivo subido.');

--- a/src/utils/uploadResponse.ts
+++ b/src/utils/uploadResponse.ts
@@ -33,10 +33,34 @@ export interface UploadResponsePayload {
   permalinkUrl?: string;
   webUrl?: string;
   web_url?: string;
+  fallbackUrl?: string;
+  fallback_url?: string;
+  fallbackPublicUrl?: string;
+  fallback_public_url?: string;
+  fallbackPath?: string;
+  fallback_path?: string;
+  fallbackPublicPath?: string;
+  fallback_public_path?: string;
+  relativeUrl?: string;
+  relative_url?: string;
   local_url?: string;
   localUrl?: string;
+  local_path?: string;
+  localPath?: string;
+  local_file_path?: string;
+  localFilePath?: string;
+  local_relative_path?: string;
+  localRelativePath?: string;
+  local_public_path?: string;
+  localPublicPath?: string;
   storageUrl?: string;
   storage_url?: string;
+  storagePath?: string;
+  storage_path?: string;
+  staticUrl?: string;
+  static_url?: string;
+  staticPath?: string;
+  static_path?: string;
   gcsUrl?: string;
   gcs_url?: string;
   bucketUrl?: string;
@@ -44,6 +68,10 @@ export interface UploadResponsePayload {
   path?: string;
   fullPath?: string;
   full_path?: string;
+  downloadPath?: string;
+  download_path?: string;
+  webPath?: string;
+  web_path?: string;
   publicPath?: string;
   public_path?: string;
   relativePath?: string;
@@ -164,16 +192,28 @@ const PRIMARY_URL_KEYS: Array<keyof UploadResponsePayload | string> = [
   "fileUrl",
   "file_url",
   "archivo_url",
+  "fallbackUrl",
+  "fallback_url",
+  "fallbackPublicUrl",
+  "fallback_public_url",
+  "fallbackPath",
+  "fallback_path",
+  "fallbackPublicPath",
+  "fallback_public_path",
   "public_url",
   "publicUrl",
   "url_publica",
   "urlPublica",
   "url_public",
   "urlPublic",
+  "relativeUrl",
+  "relative_url",
   "signedUrl",
   "signed_url",
   "downloadUrl",
   "download_url",
+  "downloadPath",
+  "download_path",
   "mediaUrl",
   "media_url",
   "assetUrl",
@@ -183,6 +223,12 @@ const PRIMARY_URL_KEYS: Array<keyof UploadResponsePayload | string> = [
   "href",
   "link",
   "location",
+  "webPath",
+  "web_path",
+  "staticUrl",
+  "static_url",
+  "staticPath",
+  "static_path",
   "uri",
   "resourceUrl",
   "resource_url",
@@ -195,10 +241,22 @@ const PRIMARY_URL_KEYS: Array<keyof UploadResponsePayload | string> = [
   "localUrl",
   "storageUrl",
   "storage_url",
+  "storagePath",
+  "storage_path",
   "gcsUrl",
   "gcs_url",
   "bucketUrl",
   "bucket_url",
+  "local_url",
+  "localUrl",
+  "local_path",
+  "localPath",
+  "local_file_path",
+  "localFilePath",
+  "local_relative_path",
+  "localRelativePath",
+  "local_public_path",
+  "localPublicPath",
   "path",
   "fullPath",
   "full_path",
@@ -254,6 +312,10 @@ const THUMB_KEYS: Array<keyof UploadResponsePayload | string> = [
   "thumbnail_url",
   "previewUrl",
   "preview_url",
+  "previewPath",
+  "preview_path",
+  "fallbackThumbUrl",
+  "fallback_thumb_url",
   "miniatura",
   "miniatura_url",
   "small",
@@ -305,7 +367,7 @@ const URL_CONTAINER_PRIORITIES = [
   "media",
 ];
 
-const visitedForExtraction = new WeakSet<object>();
+let visitedForExtraction = new WeakSet<object>();
 
 function isLikelyUrl(value: string): boolean {
   const trimmed = value.trim();
@@ -319,6 +381,12 @@ function isLikelyUrl(value: string): boolean {
       return true;
     }
   }
+  if (!trimmed.includes(" ") && trimmed.includes("\\")) {
+    const lastSegment = trimmed.split(/[?#]/)[0].split(/\\/).pop();
+    if (lastSegment && lastSegment.includes(".")) {
+      return true;
+    }
+  }
   return false;
 }
 
@@ -328,6 +396,45 @@ function decodeMaybe(value: string): string {
   } catch {
     return value;
   }
+}
+
+function normalizePathSeparators(value: string): string {
+  return value.replace(/\\/g, "/");
+}
+
+function sanitizePotentialUrl(value?: string): string | undefined {
+  if (!value) return undefined;
+  const normalized = normalizePathSeparators(value).trim();
+  if (!normalized) return undefined;
+
+  if (normalized.startsWith("//")) {
+    return normalized;
+  }
+
+  const protocolMatch = normalized.match(/^([a-z][a-z0-9+\-.]*):/i);
+  if (protocolMatch) {
+    const scheme = protocolMatch[1]?.toLowerCase() ?? "";
+    if (scheme && scheme.length > 1) {
+      return normalized;
+    }
+    // If it's a single-letter scheme like "C:", treat it as a filesystem path and keep processing.
+  }
+
+  const staticMatch = normalized.match(/\/static\/[\w./-]+/i);
+  if (staticMatch && staticMatch[0]) {
+    const candidate = staticMatch[0];
+    return candidate.startsWith("/") ? candidate : `/${candidate}`;
+  }
+
+  if (normalized.startsWith("/")) {
+    return normalized;
+  }
+
+  if (/^(?:static|uploads|media)\//i.test(normalized)) {
+    return `/${normalized}`;
+  }
+
+  return normalized;
 }
 
 function coerceNumber(value: unknown): number | undefined {
@@ -433,7 +540,7 @@ function pickStringFromNodes(
   keys: Array<keyof UploadResponsePayload | string>,
   validator?: (value: string) => boolean,
 ): string | undefined {
-  visitedForExtraction.clear();
+  visitedForExtraction = new WeakSet<object>();
   for (const node of nodes) {
     for (const key of keys) {
       if (!(key in node)) continue;
@@ -473,7 +580,7 @@ function pickNumberFromNodes(
 }
 
 function searchUrlContainers(nodes: UploadResponsePayload[]): string | undefined {
-  visitedForExtraction.clear();
+  visitedForExtraction = new WeakSet<object>();
   for (const node of nodes) {
     for (const key of Object.keys(node)) {
       if (!URL_CONTAINER_KEYS.has(key)) continue;
@@ -511,7 +618,16 @@ function searchUrlContainers(nodes: UploadResponsePayload[]): string | undefined
 export function normalizeUploadResponse(
   raw: unknown,
 ): NormalizedUploadMetadata {
-  if (!raw || typeof raw !== "object") {
+  if (!raw) {
+    return {};
+  }
+
+  if (typeof raw === "string") {
+    const candidate = sanitizePotentialUrl(raw);
+    return candidate ? { url: candidate, name: decodeMaybe(candidate.split(/[?#]/)[0].split("/").pop() || "") } : {};
+  }
+
+  if (typeof raw !== "object") {
     return {};
   }
 
@@ -520,20 +636,22 @@ export function normalizeUploadResponse(
     return {};
   }
 
-  const url =
+  const rawUrlCandidate =
     pickStringFromNodes(nodes, PRIMARY_URL_KEYS, isLikelyUrl) ||
     searchUrlContainers(nodes);
+  const url = sanitizePotentialUrl(rawUrlCandidate);
 
   const name = pickStringFromNodes(nodes, NAME_KEYS, (value) => value.length > 0);
   const mimeType = pickStringFromNodes(nodes, MIME_KEYS, (value) => value.includes("/"));
   const size = pickNumberFromNodes(nodes, SIZE_KEYS);
-  const thumbUrl =
+  const rawThumbCandidate =
     pickStringFromNodes(nodes, THUMB_KEYS, isLikelyUrl) ||
     searchUrlContainers(
       nodes.filter((node) =>
         Object.keys(node).some((key) => URL_CONTAINER_KEYS.has(key)),
       ),
     );
+  const thumbUrl = sanitizePotentialUrl(rawThumbCandidate);
 
   const derivedName =
     name ||

--- a/tests/uploadResponse.test.ts
+++ b/tests/uploadResponse.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+
+import { normalizeUploadResponse } from '../src/utils/uploadResponse';
+
+describe('normalizeUploadResponse', () => {
+  it('extracts usable URL when backend falls back to local storage', () => {
+    const payload = {
+      success: true,
+      archivoAdjunto: {
+        id: 268,
+        original_filename: 'audio-grabado-123.webm',
+        mime_type: 'audio/webm',
+        size: 45892,
+        local_path: '/opt/render/project/src/static/uploads/municipio_1/audio-grabado-123.webm',
+        local_relative_path: 'static/uploads/municipio_1/audio-grabado-123.webm',
+        storage_path: 'static/uploads/municipio_1/audio-grabado-123.webm',
+      },
+      analisisArchivo: {
+        transcription: null,
+      },
+    };
+
+    const normalized = normalizeUploadResponse(payload);
+
+    expect(normalized.url).toBe('/static/uploads/municipio_1/audio-grabado-123.webm');
+    expect(normalized.name).toBe('audio-grabado-123.webm');
+    expect(normalized.mimeType).toBe('audio/webm');
+    expect(normalized.size).toBe(45892);
+  });
+
+  it('normalizes plain string responses into accessible URLs', () => {
+    const normalized = normalizeUploadResponse('/opt/render/project/src/static/uploads/demo/file.mp3');
+
+    expect(normalized.url).toBe('/static/uploads/demo/file.mp3');
+    expect(normalized.name).toBe('file.mp3');
+  });
+
+  it('converts Windows style fallback paths to web paths', () => {
+    const payload = {
+      result: {
+        fallbackUrl: 'C:\\render\\project\\static\\uploads\\municipio_1\\voice-note.ogg',
+        mime_type: 'audio/ogg',
+      },
+    };
+
+    const normalized = normalizeUploadResponse(payload);
+    expect(normalized.url).toBe('/static/uploads/municipio_1/voice-note.ogg');
+    expect(normalized.mimeType).toBe('audio/ogg');
+    expect(normalized.name).toBe('voice-note.ogg');
+  });
+});


### PR DESCRIPTION
## Summary
- normalize additional upload response URL fields and sanitize filesystem-style paths so local fallbacks produce usable links
- update chat input and ticket conversation panel to reuse the normalized URL or sanitize fallback fields before dispatching messages
- add unit tests covering local storage responses, plain string payloads, and Windows-style fallback paths

## Testing
- npx vitest run tests/uploadResponse.test.ts
- npm test *(fails: several suites require missing server/*.cjs fixtures in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3e858ac088322b371e9a54730b99d