### PR TITLE
fix(chat): Include attachment ID in message payload

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -181,6 +181,7 @@ const ChatInput = forwardRef<ChatInputHandle, Props>(({ onSendMessage, isTyping,
             : undefined;
 
         attachmentData = {
+          id: normalized.id,
           url: absoluteUploadedUrl,
           name: uploadedName,
           mimeType: uploadedMime,
@@ -356,6 +357,7 @@ const ChatInput = forwardRef<ChatInputHandle, Props>(({ onSendMessage, isTyping,
       onSendMessage({
         text: `Audio adjunto: ${uploadedName}`,
         attachmentInfo: {
+          id: normalized.id,
           name: uploadedName,
           url: absoluteUploadedUrl,
           mimeType: uploadedMime,

--- a/tests/uploadResponse.test.ts
+++ b/tests/uploadResponse.test.ts
@@ -93,4 +93,15 @@ describe('normalizeUploadResponse', () => {
     expect(normalized.size).toBe(54321);
     expect(normalized.mimeType).toBe('image/jpeg');
   });
+
+  it('handles responses with an attachment ID', () => {
+    const payload = {
+      id: 12345,
+      url: '/static/uploads/file.pdf'
+    };
+
+    const normalized = normalizeUploadResponse(payload);
+    expect(normalized.id).toBe(12345);
+    expect(normalized.url).toBe('/static/uploads/file.pdf');
+  });
 });


### PR DESCRIPTION
Following the previous fix to improve upload response parsing, a new error was discovered. The backend was rejecting messages with attachments with a 400 Bad Request, indicating that the `attachmentInfo` field was invalid or missing required fields.

Analysis of the server logs (`ArchivoAdjunto (ID: 276)`) suggested that the backend requires the database ID of the uploaded attachment to be sent in the message payload.

This commit addresses this by:
1.  Enhancing `normalizeUploadResponse` to extract not just the URL and metadata, but also the attachment's ID. A new `ID_KEYS` list and helper functions have been added for this purpose.
2.  Updating the `ChatInput` component to include the extracted `id` in the `attachmentInfo` object that is sent to the `/ask` endpoint.
3.  Adding a new test case to `uploadResponse.test.ts` to ensure the ID extraction works correctly.