### PR TITLE
fix(chat): Send empty text with audio attachments

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -355,7 +355,7 @@ const ChatInput = forwardRef<ChatInputHandle, Props>(({ onSendMessage, isTyping,
           : undefined;
 
       onSendMessage({
-        text: `Audio adjunto: ${uploadedName}`,
+        text: '',
         attachmentInfo: {
           id: normalized.id,
           name: uploadedName,


### PR DESCRIPTION
After fixing the attachment payload, it was discovered that the backend was still not processing audio files correctly. The frontend was sending a text message "Audio adjunto: ..." along with the audio file, which caused the backend's AI to treat it as a text query instead of a file to be analyzed.

This commit fixes the issue by changing the `text` field to an empty string when sending an audio attachment. This makes the behavior consistent with image uploads and signals to the backend that it should process the file itself.