### PR TITLE
Fix: Implement global 401 handling and consolidate maps

### DIFF
--- a/src/pages/Perfil.tsx
+++ b/src/pages/Perfil.tsx
@@ -419,14 +419,9 @@ export default function Perfil() {
       await refreshUser();
 
     } catch (err) {
-      if (err instanceof ApiError && err.status === 401) {
-        // Si el token es inválido o expiró, forzar logout
-        safeLocalStorage.removeItem("user");
-        safeLocalStorage.removeItem("authToken");
-        navigate("/login"); // Usar navigate para la redirección
-      } else {
-        setError(getErrorMessage(err, "Error al cargar el perfil."));
-      }
+      // El manejo de 401 es global en apiFetch, que redirigirá la página.
+      // Solo necesitamos manejar otros errores que no sean de autenticación.
+      setError(getErrorMessage(err, "Error al cargar el perfil."));
     } finally {
       setLoadingGuardar(false);
     }


### PR DESCRIPTION
This commit resolves the issue of the admin profile page appearing blank by addressing the root cause: unhandled authentication errors. It also completes the user's original request to consolidate the two maps on the page.

Changes:
- Implemented a global 401 error handler in `src/utils/api.ts`. For any request from the main application that receives a 401 Unauthorized response, the session is cleared, and the user is redirected to the login page. This prevents the application from entering a broken state due to an expired session.
- Refactored the `Perfil.tsx` page to use a single, consolidated map component.
- The `AnalyticsHeatmap` component now displays both the ticket activity heatmap and the admin's location marker.
- The consolidated map allows the admin to set their location by clicking on it.
- Removed redundant, specific 401 error handling from `Perfil.tsx` now that it's handled globally.