### PR TITLE
fix: Ensure heatmap renders correctly on profile page

### DIFF
--- a/src/pages/Perfil.tsx
+++ b/src/pages/Perfil.tsx
@@ -1235,7 +1235,7 @@ export default function Perfil() {
                   </form>
                 </CardContent>
               </Card>
-              {isStaff && !!municipalityCoords && (
+              {isStaff && (
                 <AnalyticsHeatmap
                   initialHeatmapData={heatmapData}
                   adminLocation={municipalityCoords}


### PR DESCRIPTION
This commit resolves an issue where the heatmap on the profile page would not render if the administrator's location was not set.

The previous fix for a page crash was too restrictive, preventing the map from showing at all in some cases. This change removes the unnecessary conditional check, allowing the `AnalyticsHeatmap` component to render for all staff users. The component itself has a fallback mechanism to center the map based on ticket data or a default location if the admin's location is not available.