### PR TITLE
Revamp Cuatro Fincas demo with Winrey branding

### DIFF
--- a/cuatro-fincas-demo.html
+++ b/cuatro-fincas-demo.html
@@ -1,0 +1,531 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>Cuatro Fincas · Winrey</title>
+  <link rel="icon" href="https://chatboc-demo-widget-oigs.vercel.app/cuatrofincas/CFlogo.png" type="image/png" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@500;700&family=Poppins:wght@300;400;500;600&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --bosque:#0f3c33;
+      --acento:#d7b866;
+      --txt:#20322c;
+      --txt-2:#4a5e56;
+      --fondo:#f4f1ea;
+      --surface:#ffffff;
+      --bot-bg:#e3e7dc;
+      --radius:18px;
+      --shadow:0 14px 34px rgba(15,60,51,.18);
+    }
+
+    body.dark-mode {
+      --bosque:#9dd4be;
+      --acento:#f0e2a4;
+      --txt:#e8f1ed;
+      --txt-2:#b9c8c1;
+      --fondo:#0a1512;
+      --surface:#13211c;
+      --bot-bg:#1f322c;
+      --shadow:0 20px 40px rgba(0,0,0,.45);
+    }
+
+    * { box-sizing:border-box; margin:0; padding:0; }
+    body {
+      font-family:Poppins, sans-serif;
+      background:var(--fondo);
+      color:var(--txt);
+      min-height:100vh;
+    }
+
+    header {
+      position:sticky;top:0;z-index:10;
+      background:rgba(255,255,255,.88);
+      backdrop-filter:blur(12px);
+      padding:26px 40px;
+      display:flex;align-items:center;justify-content:center;
+      box-shadow:var(--shadow);
+      position:relative;
+    }
+
+    body.dark-mode header{background:rgba(10,21,18,.85);}
+
+    .logo-wrap {
+      position:absolute;left:22px;
+      display:flex;align-items:center;gap:12px;
+    }
+    .logo-mark {
+      width:68px;height:68px;
+      border-radius:50%;
+      border:2px solid var(--acento);
+      overflow:hidden;
+      background:rgba(255,255,255,.9);
+      box-shadow:0 8px 18px rgba(0,0,0,.12);
+      display:grid;place-items:center;
+      transition:transform .35s ease;
+    }
+    .logo-mark img { width:90%; height:90%; object-fit:contain; }
+    .logo-wrap:hover .logo-mark { transform:scale(1.06) rotate(-4deg); }
+    .logo-title {
+      font-family:"Playfair Display", serif;
+      color:var(--bosque);
+      font-size:1.3rem;
+      letter-spacing:2px;
+      text-transform:uppercase;
+    }
+
+    nav { display:flex; gap:18px; flex-wrap:wrap; justify-content:center; }
+    nav a {
+      color:var(--bosque);
+      text-decoration:none;
+      font-weight:500;
+      letter-spacing:.6px;
+      position:relative;
+      padding:8px 0;
+    }
+    nav a::after {
+      content:"";
+      position:absolute;left:0;bottom:-4px;
+      width:100%;height:2px;
+      background:var(--acento);
+      transform:scaleX(0);
+      transform-origin:left;
+      transition:transform .3s;
+    }
+    nav a:hover::after { transform:scaleX(1); }
+
+    .menu-toggle {
+      display:none;
+      position:absolute;left:24px;
+      background:transparent;border:none;cursor:pointer;
+      flex-direction:column;gap:4px;
+    }
+    .menu-toggle span { width:26px;height:3px;background:var(--bosque);border-radius:2px; }
+
+    .theme-toggle {
+      position:absolute;right:20px;
+      background:transparent;border:none;cursor:pointer;
+      font-size:1.45rem;color:var(--bosque);
+    }
+
+    @media(max-width:768px){
+      header{padding:20px 24px;}
+      nav{
+        display:none;
+        flex-direction:column;
+        position:absolute;top:100%;left:0;width:100%;
+        background:rgba(255,255,255,.96);
+        padding:18px 0;gap:10px;
+        box-shadow:var(--shadow);
+      }
+      nav.show{display:flex;}
+      body.dark-mode nav{background:rgba(10,21,18,.96);}
+      nav a{padding:6px 0;}
+      .menu-toggle{display:flex;}
+      .logo-wrap{position:static;justify-content:center;}
+    }
+
+    .hero {
+      max-width:1200px;margin:0 auto;padding:70px 20px 40px;
+      display:grid;grid-template-columns:1.05fr .95fr;gap:36px;align-items:center;
+    }
+    .hero-copy h1 {
+      font-family:"Playfair Display", serif;
+      font-size:3rem;line-height:1.1;margin-bottom:18px;
+      color:var(--bosque);
+    }
+    .hero-copy p {
+      font-size:1.1rem;color:var(--txt-2);margin-bottom:28px;
+    }
+    .cta-group { display:flex;gap:18px;flex-wrap:wrap; }
+    .cta {
+      padding:12px 28px;
+      border-radius:999px;
+      background:var(--bosque);
+      color:#fff;
+      font-weight:600;
+      letter-spacing:.5px;
+      text-decoration:none;
+      box-shadow:0 16px 32px rgba(15,60,51,.25);
+      transition:transform .3s ease, box-shadow .3s ease;
+    }
+    .cta.secondary { background:transparent;border:2px solid var(--bosque);color:var(--bosque); }
+    .cta:hover {
+      transform:translateY(-4px);
+      box-shadow:0 20px 40px rgba(15,60,51,.32);
+    }
+    .cta.secondary:hover { background:var(--bosque);color:#fff; }
+
+    .hero-visual {
+      position:relative;
+      border-radius:28px;
+      overflow:hidden;
+      box-shadow:var(--shadow);
+      background:linear-gradient(135deg, rgba(15,60,51,.82), rgba(12,37,30,.9)), url('https://images.unsplash.com/photo-1508979822048-3d08be11f86d?auto=format&fit=crop&w=900&q=80') center/cover;
+      min-height:500px;
+    }
+    .hero-visual::after {
+      content:"";
+      position:absolute;inset:24px;
+      border:1px solid rgba(255,255,255,.25);
+      border-radius:22px;
+    }
+    .hero-visual .badge {
+      position:absolute;bottom:30px;left:30px;
+      background:rgba(255,255,255,.92);
+      color:var(--bosque);
+      padding:16px 22px;
+      border-radius:16px;
+      font-weight:600;
+      box-shadow:0 12px 24px rgba(0,0,0,.18);
+    }
+
+    @media(max-width:960px){
+      .hero{grid-template-columns:1fr;}
+      .hero-visual{order:-1;min-height:420px;}
+    }
+
+    .section { padding:60px 20px; }
+    .section h2 {
+      text-align:center;
+      font-family:"Playfair Display", serif;
+      font-size:2.4rem;
+      margin-bottom:30px;
+      color:var(--bosque);
+    }
+
+    .highlights {
+      background:var(--surface);
+    }
+    .highlight-grid {
+      display:grid;grid-template-columns:repeat(auto-fit, minmax(250px, 1fr));gap:26px;
+      max-width:1100px;margin:0 auto;
+    }
+    .highlight-card {
+      background:var(--fondo);
+      padding:26px;
+      border-radius:var(--radius);
+      box-shadow:var(--shadow);
+      text-align:center;
+      display:flex;flex-direction:column;gap:12px;
+    }
+    .highlight-card span {
+      font-size:1.1rem;font-weight:600;color:var(--bosque);
+    }
+    .highlight-card p { color:var(--txt-2); font-size:.97rem; }
+
+    .experience {
+      background:linear-gradient(130deg, rgba(15,60,51,.12), rgba(215,184,102,.24));
+    }
+    .experience-grid {
+      max-width:1100px;margin:0 auto;display:grid;grid-template-columns:repeat(auto-fit, minmax(300px, 1fr));gap:24px;
+    }
+    .experience-card {
+      background:var(--surface);
+      padding:24px;
+      border-radius:var(--radius);
+      box-shadow:var(--shadow);
+      display:flex;gap:18px;align-items:flex-start;
+    }
+    .experience-icon {
+      width:52px;height:52px;border-radius:14px;
+      display:grid;place-items:center;
+      background:rgba(15,60,51,.12);
+      color:var(--bosque);
+      font-size:1.5rem;
+      transition:transform .3s ease;
+    }
+    .experience-card:hover .experience-icon { transform:scale(1.1); }
+    .experience-card h3 { font-size:1.15rem;margin-bottom:6px;color:var(--bosque); }
+    .experience-card p { color:var(--txt-2);font-size:.96rem; }
+
+    .cellar {
+      background:var(--surface);
+    }
+    .cellar-content {
+      max-width:1100px;margin:0 auto;display:grid;grid-template-columns:repeat(auto-fit, minmax(300px, 1fr));gap:32px;align-items:center;
+    }
+    .cellar-info h3 {
+      font-size:1.3rem;
+      color:var(--bosque);
+      margin-bottom:12px;
+    }
+    .cellar-info p {
+      color:var(--txt-2);
+      margin-bottom:18px;
+      line-height:1.6;
+    }
+    .cellar-highlights {
+      display:grid;gap:14px;
+    }
+    .cellar-highlights li {
+      list-style:none;
+      padding:14px 18px;
+      border-radius:var(--radius);
+      background:var(--fondo);
+      color:var(--txt-2);
+      box-shadow:var(--shadow);
+    }
+    .cellar-visual {
+      position:relative;
+      border-radius:26px;
+      overflow:hidden;
+      box-shadow:var(--shadow);
+      min-height:360px;
+      background:linear-gradient(135deg, rgba(15,60,51,.78), rgba(30,49,42,.92)), url('https://images.unsplash.com/photo-1528825871115-3581a5387919?auto=format&fit=crop&w=900&q=80') center/cover;
+    }
+    .cellar-visual::after {
+      content:"";
+      position:absolute;inset:20px;
+      border:1px solid rgba(215,184,102,.45);
+      border-radius:22px;
+    }
+    .cellar .cta-group { margin-top:22px; }
+
+    footer {
+      padding:30px 20px;margin-top:40px;text-align:center;font-size:.95rem;color:var(--txt-2);
+    }
+
+    .widget-helper {
+      position:fixed;right:130px;bottom:70px;
+      background:var(--bosque);
+      color:#fff;
+      padding:14px 26px;
+      border-radius:var(--radius);
+      font-weight:600;
+      box-shadow:var(--shadow);
+      cursor:pointer;
+      display:flex;align-items:center;gap:10px;
+      transition:transform .3s ease, box-shadow .3s ease;
+      animation:float 4s ease-in-out infinite;
+      z-index:9999;
+    }
+    .widget-helper svg { width:22px;height:22px; }
+    .widget-helper:hover { transform:translateY(-4px) scale(1.03);box-shadow:0 20px 40px rgba(15,60,51,.35); }
+
+    @keyframes float { 0%,100%{transform:translateY(0);} 50%{transform:translateY(-6px);} }
+  </style>
+</head>
+<body>
+  <header>
+    <button class="menu-toggle" aria-label="Menú"><span></span><span></span><span></span></button>
+    <div class="logo-wrap">
+      <div class="logo-mark">
+        <img src="https://chatboc-demo-widget-oigs.vercel.app/cuatrofincas/CFlogo.png" alt="Cuatro Fincas" onerror="this.src=window.__FALLBACK_LOGO" />
+      </div>
+      <span class="logo-title">Cuatro Fincas</span>
+    </div>
+    <nav>
+      <a href="#experiencia">Experiencia Winrey</a>
+      <a href="#reservas">Reservas</a>
+      <a href="#servicios">Servicios</a>
+      <a href="#visitas">Visitas guiadas</a>
+      <a href="#contacto">Contacto</a>
+    </nav>
+    <button id="themeToggle" class="theme-toggle" aria-label="Cambiar tema">☾</button>
+  </header>
+
+  <section class="hero">
+    <div class="hero-copy">
+      <h1>Tu sommelier digital para cada cosecha</h1>
+      <p>El asistente <strong>Winrey</strong> conecta a enoturistas y distribuidores con Cuatro Fincas. Gestiona reservas, responde consultas sobre varietales y acompaña el recorrido de la bodega en segundos.</p>
+      <div class="cta-group">
+        <a class="cta" onclick="window.postMessage({type:'chatboc:open'}, '*')">Descubrir el asistente</a>
+        <a class="cta secondary" href="#experiencia">Experiencias</a>
+        <a class="cta secondary" href="#reservas">Agendar visita</a>
+      </div>
+    </div>
+    <div class="hero-visual">
+      <div class="badge">Maridajes, reservas y boutique en un solo canal</div>
+    </div>
+  </section>
+
+  <section class="section highlights" id="experiencia">
+    <h2>Winrey potencia la experiencia enológica</h2>
+    <div class="highlight-grid">
+      <div class="highlight-card">
+        <span>Atención 24/7</span>
+        <p>Consultas sobre tours, degustaciones y disponibilidad de forma inmediata, desde cualquier dispositivo.</p>
+      </div>
+      <div class="highlight-card">
+        <span>Seguimiento integral</span>
+        <p>Respuestas personalizadas sobre pedidos, envíos y club de vinos con historial en tiempo real.</p>
+      </div>
+      <div class="highlight-card">
+        <span>Integraciones fluidas</span>
+        <p>Disponible en la web, WhatsApp empresarial y puntos de venta para brindar soporte sin fricciones.</p>
+      </div>
+      <div class="highlight-card">
+        <span>Contenido multimedia</span>
+        <p>Compartí fichas técnicas, videos del viñedo o sugerencias de maridajes para cada varietal.</p>
+      </div>
+    </div>
+  </section>
+
+  <section class="section experience" id="servicios">
+    <h2>Servicios gestionados por el asistente</h2>
+    <div class="experience-grid">
+      <div class="experience-card">
+        <div class="experience-icon">🍷</div>
+        <div>
+          <h3>Reservas de degustaciones</h3>
+          <p>Winrey coordina horarios, cupos y preferencias de cada grupo con confirmación instantánea.</p>
+        </div>
+      </div>
+      <div class="experience-card">
+        <div class="experience-icon">🚚</div>
+        <div>
+          <h3>Ventas directas</h3>
+          <p>Gestiona pedidos mayoristas o retail, calcula envíos y comparte promociones vigentes.</p>
+        </div>
+      </div>
+      <div class="experience-card">
+        <div class="experience-icon">📍</div>
+        <div>
+          <h3>Visitas guiadas</h3>
+          <p>Indica recorridos sugeridos, mapas del viñedo y opciones gastronómicas según la temporada.</p>
+        </div>
+      </div>
+      <div class="experience-card">
+        <div class="experience-icon">💬</div>
+        <div>
+          <h3>Soporte para distribuidores</h3>
+          <p>Desde fichas técnicas hasta estados de pedido, Winrey centraliza las respuestas en un solo canal.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="section cellar" id="reservas">
+    <h2>Reservas personalizadas para cada visita</h2>
+    <div class="cellar-content">
+      <div class="cellar-info">
+        <h3 id="visitas">Visitas guiadas y club de vinos</h3>
+        <p>Coordiná degustaciones privadas, recorridos entre viñedos o eventos corporativos con confirmación inmediata. Winrey reúne disponibilidad, preferencias y recordatorios en un mismo canal.</p>
+        <ul class="cellar-highlights">
+          <li>Gestión automática de horarios y cupos según cada sala de degustación.</li>
+          <li>Confirmaciones por WhatsApp y correo con itinerarios y sugerencias gastronómicas.</li>
+          <li>Registro de asistentes frecuente para beneficios en el club de vinos.</li>
+        </ul>
+        <div class="cta-group">
+          <a class="cta" onclick="window.postMessage({type:'chatboc:open'}, '*')">Reservar con Winrey</a>
+          <a class="cta secondary" href="#contacto">Contactar equipo</a>
+        </div>
+      </div>
+      <div class="cellar-visual" aria-hidden="true"></div>
+    </div>
+  </section>
+
+  <footer id="contacto">
+    © Cuatro Fincas · Winrey · Chatboc.ar
+  </footer>
+
+  <div class="widget-helper" onclick="window.postMessage({type:'chatboc:open'}, '*')">
+    <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/></svg>
+    <span>Habla con Winrey</span>
+  </div>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      window.__FALLBACK_LOGO = 'data:image/svg+xml;utf8,' + encodeURIComponent(`<svg xmlns="http://www.w3.org/2000/svg" width="220" height="220"><rect width="220" height="220" rx="24" fill="#0f3c33"/><text x="50%" y="55%" text-anchor="middle" font-family="Playfair Display" font-size="96" fill="#f4f1ea" font-weight="700">CF</text></svg>`);
+
+      const menuToggle = document.querySelector('.menu-toggle');
+      const nav = document.querySelector('nav');
+      const themeToggle = document.getElementById('themeToggle');
+
+      if(menuToggle && nav){
+        menuToggle.addEventListener('click', () => nav.classList.toggle('show'));
+      }
+
+      if(themeToggle){
+        themeToggle.addEventListener('click', () => {
+          document.body.classList.toggle('dark-mode');
+          themeToggle.textContent = document.body.classList.contains('dark-mode') ? '☀' : '☾';
+          injectWidget();
+        });
+      }
+
+      async function clearCaches(){
+        try{
+          Object.keys(localStorage).forEach(k => { if(k.includes('chatboc')) localStorage.removeItem(k); });
+          Object.keys(sessionStorage).forEach(k => { if(k.includes('chatboc')) sessionStorage.removeItem(k); });
+          if(indexedDB && indexedDB.databases){
+            const dbs = await indexedDB.databases();
+            dbs.forEach(db => { if(db.name && db.name.includes('chatboc')) indexedDB.deleteDatabase(db.name); });
+          }
+          if(navigator.serviceWorker && navigator.serviceWorker.getRegistrations){
+            const regs = await navigator.serviceWorker.getRegistrations();
+            regs.forEach(r => r.unregister());
+          }
+        }catch(e){
+          console.warn('No se pudo limpiar la caché del widget', e);
+        }
+      }
+
+      let currentScript = null;
+      const OWNER_TOKEN = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoyMiwiZXhwIjoxNzU5NTA2ODQxfQ.cRByDN2t7sA220yPk40AJ9k0iqkrS3BgzsedHZDMsPA';
+
+      async function injectWidget(){
+        if(currentScript) currentScript.remove();
+        if(window.chatbocDestroyWidget){
+          window.chatbocDestroyWidget(OWNER_TOKEN);
+        }
+
+        await clearCaches();
+
+        const isMobile = window.matchMedia('(max-width:768px)').matches;
+        const launcherSize = isMobile ? '90px' : '120px';
+        const theme = document.body.classList.contains('dark-mode') ? 'dark' : 'light';
+
+        const script = document.createElement('script');
+        script.src = 'https://chatboc.ar/widget.js?v=' + Date.now();
+        script.async = true;
+        script.setAttribute('data-owner-token', OWNER_TOKEN);
+        script.setAttribute('data-api-base', 'https://chatboc.ar');
+        script.setAttribute('data-default-open', 'false');
+        script.setAttribute('data-width', '460px');
+        script.setAttribute('data-height', '680px');
+        script.setAttribute('data-closed-width', launcherSize);
+        script.setAttribute('data-closed-height', launcherSize);
+        script.setAttribute('data-bottom', '20px');
+        script.setAttribute('data-right', '20px');
+        script.setAttribute('data-endpoint', 'pyme');
+        script.setAttribute('data-primary-color', '#0f3c33');
+        script.setAttribute('data-accent-color', '#d7b866');
+        script.setAttribute('data-theme', theme);
+        script.setAttribute('data-logo-url', 'https://chatboc-demo-widget-oigs.vercel.app/cuatrofincas/CFlogo.png');
+        script.setAttribute('data-header-logo-url', 'https://chatboc-demo-widget-oigs.vercel.app/cuatrofincas/CFlogo.png');
+        script.setAttribute('data-welcome-title', 'Hola, soy Winrey');
+        script.setAttribute('data-welcome-subtitle', 'Tu asistente de Cuatro Fincas');
+        script.setAttribute('data-allow-attachments', 'true');
+        script.setAttribute('data-allow-location', 'true');
+        script.setAttribute('data-allow-audio', 'true');
+
+        script.onload = () => enhanceLauncher();
+        script.onerror = () => console.error('No se pudo cargar el widget de Chatboc');
+
+        document.body.appendChild(script);
+        currentScript = script;
+      }
+
+      function enhanceLauncher(){
+        const launcher = document.querySelector('[id^="chatboc-launcher"],[class*="chatboc-launcher"]');
+        if(!launcher){
+          setTimeout(enhanceLauncher, 400);
+          return;
+        }
+        launcher.style.transition = 'transform .35s ease, box-shadow .35s ease';
+        launcher.style.boxShadow = '0 0 0 3px rgba(255,255,255,.8)';
+        launcher.addEventListener('mouseenter', () => launcher.style.transform = 'scale(1.1) rotate(3deg)');
+        launcher.addEventListener('mouseleave', () => launcher.style.transform = 'scale(1) rotate(0deg)');
+        launcher.addEventListener('mousedown', () => launcher.style.transform = 'scale(0.94) rotate(-3deg)');
+        launcher.addEventListener('mouseup', () => launcher.style.transform = 'scale(1.06) rotate(2deg)');
+      }
+
+      injectWidget();
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- restyle the Cuatro Fincas Winrey demo page with the winery's green and gold palette, updated imagery, and refined typography
- add a dedicated reservations section, responsive highlight cards, and corrected navigation anchors tied to real sections
- configure the embedded Chatboc widget with the new logo assets, matching colors, and theme-aware re-injection

## Testing
- Not run (static asset)


------
https://chatgpt.com/codex/tasks/task_e_68d6bf70f0888322ad6e7a0403faedd5