### PR TITLE
Update pricing tiers and plan activation logic

### DIFF
--- a/src/components/sections/PricingSection.tsx
+++ b/src/components/sections/PricingSection.tsx
@@ -26,22 +26,40 @@ const pricingOptions = [
   {
     type: 'plan',
     name: 'Profesional Conectado',
-    price: 'Consultar precios', // Aquí iría el precio real o "Desde $XX"
+    price: '$65.000 / mes',
     duration: '',
-    description: 'Solución completa con Chatbot IA y CRM para optimizar la comunicación y gestión de usuarios.',
+    description: 'Solución completa con Chatbot IA avanzado y CRM para optimizar la comunicación y gestión de usuarios.',
     features: [
       'Todo en Inicia con IA, y además:',
-      'Chatbot IA Avanzado (más personalización)',
+      'Chatbot IA avanzado con entrenamiento personalizado',
       'CRM integrado para gestión de perfiles',
       'Carga de hasta 10 documentos',
       'Hasta 1000 interacciones/mes',
-      'Paneles analíticos básicos',
-      'Integraciones esenciales (ej. email)',
-      'Soporte estándar',
+      'Paneles analíticos con métricas de interacción',
+      'Integraciones esenciales (formularios, email, catálogos)',
+      'Soporte prioritario',
     ],
     cta: 'Elige Profesional',
     ctaLink: '/register?plan=profesional', // Ejemplo de link con plan
     highlight: true,
+  },
+  {
+    type: 'plan',
+    name: 'Full Automatizado',
+    price: '$95.000 / mes',
+    duration: '',
+    description: 'Automatización total con integraciones avanzadas y soporte dedicado para equipos exigentes.',
+    features: [
+      'Todo en Profesional Conectado, y además:',
+      'Interacciones ilimitadas por mes',
+      'Automatización end-to-end de campañas y seguimientos',
+      'Integraciones avanzadas con ERP, GovTech y BI',
+      'Orquestación omnicanal (email, WhatsApp, formularios)',
+      'Onboarding personalizado y soporte dedicado',
+    ],
+    cta: 'Escalar con Full',
+    ctaLink: '/register?plan=full',
+    highlight: false,
   },
   {
     type: 'contact', // Tarjeta especial

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -11,29 +11,30 @@ const Checkout = () => {
   const planInfo = {
     pro: {
       title: "Plan Pro",
-      price: "$ / mes",
+      price: "$65.000 / mes",
       benefits: [
-        "Hasta 200 preguntas y respuestas personalizadas por mes",
+        "Hasta 1000 preguntas e interacciones personalizadas por mes",
         "Entrenamiento optimizado para el rubro de tu empresa",
         "Panel de control con métricas e historial de uso",
         "Asistente inteligente con aprendizaje y mejoras continuas",
         "Alertas automáticas por palabra clave (ej: reclamos, urgencias)",
-        "Registro automático de conversaciones (planilla o sistema)",
+        "CRM integrado y registro automático de conversaciones",
+        "Integraciones esenciales con formularios, catálogos y email",
         "Soporte técnico prioritario y acceso anticipado a nuevas funcionalidades"
       ],
     },
     full: {
       title: "Plan Full",
-      price: "$ / mes",
+      price: "$95.000 / mes",
       benefits: [
         "Consultas ilimitadas",
         "Automatización completa de respuestas, seguimientos y derivaciones",
         "Envío automático de catálogos, promociones o formularios por email",
-        "Integración con herramientas externas (CRM, planillas, formularios, etc.)",
+        "Integración avanzada con herramientas externas (ERP, CRM, GovTech, BI)",
         "Acceso a panel administrativo completo con historial y métricas",
         "Dashboard mensual con indicadores de rendimiento del chatbot",
         "Soporte para empresas con múltiples unidades de negocio o servicios diferenciados",
-        "Soporte técnico dedicado y configuración avanzada incluida"
+        "Soporte técnico dedicado, onboarding y consultoría especializada"
       ],
     },
   };

--- a/src/pages/Perfil.tsx
+++ b/src/pages/Perfil.tsx
@@ -152,7 +152,7 @@ export default function Perfil() {
     link_web: "",
     plan: "gratis",
     preguntas_usadas: 0,
-    limite_preguntas: 50,
+    limite_preguntas: 100,
     rubro: "",
     horarios_ui: DIAS.map((_, idx) => ({
       abre: "09:00",
@@ -404,7 +404,7 @@ export default function Perfil() {
         link_web: data.link_web || "",
         plan: data.plan || "gratis",
         preguntas_usadas: data.preguntas_usadas ?? 0,
-        limite_preguntas: data.limite_preguntas ?? 50,
+        limite_preguntas: data.limite_preguntas ?? 100,
         rubro: data.rubro?.toLowerCase() || "",
         logo_url: data.logo_url || "",
         horarios_ui: horariosUi,
@@ -937,7 +937,7 @@ export default function Perfil() {
     plan === 'full'
       ? Infinity
       : plan === 'pro'
-      ? 200
+      ? perfil.limite_preguntas || 1000
       : perfil.limite_preguntas;
 
   const porcentaje =
@@ -1309,7 +1309,7 @@ export default function Perfil() {
                                   )
                                 }
                               >
-                                Mejorar a PRO ($35.000/mes)
+                                Mejorar a PRO ($65.000/mes)
                               </Button>
                               <Button
                                 className="w-full bg-accent hover:bg-accent/90 text-accent-foreground font-semibold"
@@ -1320,7 +1320,7 @@ export default function Perfil() {
                                   )
                                 }
                               >
-                                Mejorar a FULL ($60.000/mes)
+                                Mejorar a FULL ($95.000/mes)
                               </Button>
                             </div>
                           )}
@@ -1392,7 +1392,7 @@ export default function Perfil() {
                           )
                         }
                       >
-                        Mejorar a PRO ($35.000/mes)
+                        Mejorar a PRO ($65.000/mes)
                       </Button>
                       <Button
                         className="w-full bg-accent hover:bg-accent/90 text-accent-foreground font-semibold"
@@ -1403,7 +1403,7 @@ export default function Perfil() {
                           )
                         }
                       >
-                        Mejorar a FULL ($60.000/mes)
+                        Mejorar a FULL ($95.000/mes)
                       </Button>
                     </div>
                   )}


### PR DESCRIPTION
## Summary
- add plan definitions and Mercado Pago mapping to the backend with endpoints to fetch the profile, list plans, and activate paid tiers
- align the dashboard upgrade prompts and checkout copy with the new ARS $65k PRO and $95k FULL pricing and interaction limits
- refresh the public pricing section to highlight the PRO and FULL offerings alongside the existing free trial

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7297562208322b16d70ceb3c6a177