### PR TITLE
Adjust plan messaging limits and enterprise outreach

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,6 +19,140 @@ const sessionMiddleware = require('./session');
 const cartRoutes = require('./cartRoutes');
 const preferences = require('./preferences');
 
+const DEFAULT_WEEK_DAYS = [
+  'Lunes',
+  'Martes',
+  'Miércoles',
+  'Jueves',
+  'Viernes',
+  'Sábado',
+  'Domingo',
+];
+
+const PLAN_DEFINITIONS = {
+  gratis: {
+    name: 'Inicia con IA',
+    price: 0,
+    currency: 'ARS',
+    messageLimit: 100,
+    technologies: [
+      'Chatbot IA básico',
+      'Widget web personalizable',
+      'Carga de hasta 2 documentos (PDF/Excel)',
+    ],
+  },
+  pro: {
+    name: 'Plan Pro',
+    price: 65000,
+    currency: 'ARS',
+    messageLimit: 250,
+    technologies: [
+      'Chatbot IA avanzado y entrenamiento personalizado',
+      'CRM integrado para seguimiento de clientes',
+      'Integraciones esenciales (email, formularios, catálogos)',
+      'Paneles analíticos con métricas de interacción (hasta 250 mensajes/mes)',
+    ],
+  },
+  full: {
+    name: 'Plan Full',
+    price: 95000,
+    currency: 'ARS',
+    messageLimit: Infinity,
+    technologies: [
+      'Interacciones ilimitadas con automatización end-to-end de campañas y workflows',
+      'Integraciones avanzadas con sistemas externos (ERP, GovTech, BI)',
+      'Envío automático de catálogos, promociones y formularios',
+      'Soporte dedicado, onboarding y consultoría especializada',
+    ],
+  },
+};
+
+const MERCADO_PAGO_PLAN_MAP = {
+  '2c9380849764e81a01976585767f0040': 'pro',
+  '2c9380849763daeb0197658791ee00b1': 'full',
+};
+
+function ensureUserProfile(session) {
+  if (!session.userProfile) {
+    session.userProfile = {
+      id: 1,
+      nombre_empresa: 'Demo Chatboc',
+      telefono: '',
+      direccion: '',
+      ciudad: '',
+      provincia: '',
+      pais: 'Argentina',
+      latitud: null,
+      longitud: null,
+      link_web: '',
+      plan: 'gratis',
+      preguntas_usadas: 0,
+      limite_preguntas: PLAN_DEFINITIONS.gratis.messageLimit,
+      rubro: 'pyme',
+      logo_url: '',
+      horario_json: DEFAULT_WEEK_DAYS.map((dia, idx) => ({
+        dia,
+        abre: idx >= 5 ? '' : '09:00',
+        cierra: idx >= 5 ? '' : '20:00',
+        cerrado: idx >= 5,
+      })),
+      tecnologias_plan: PLAN_DEFINITIONS.gratis.technologies,
+      plan_precio: PLAN_DEFINITIONS.gratis.price,
+      plan_moneda: PLAN_DEFINITIONS.gratis.currency,
+      plan_actualizado_en: new Date().toISOString(),
+    };
+  }
+  return session.userProfile;
+}
+
+function normalizeLimit(limit) {
+  return limit === Infinity ? Number.MAX_SAFE_INTEGER : limit;
+}
+
+function applyPlanToProfile(profile, planKey) {
+  const definition = PLAN_DEFINITIONS[planKey];
+  if (!definition) {
+    throw new Error('Plan inválido');
+  }
+
+  profile.plan = planKey;
+  profile.limite_preguntas = normalizeLimit(definition.messageLimit);
+  profile.tecnologias_plan = definition.technologies;
+  profile.plan_precio = definition.price;
+  profile.plan_moneda = definition.currency;
+  profile.plan_actualizado_en = new Date().toISOString();
+  const usedQuestions = Number(profile.preguntas_usadas) || 0;
+  profile.preguntas_usadas = Math.min(usedQuestions, profile.limite_preguntas);
+  return profile;
+}
+
+function buildPlanPayload(planKey) {
+  const definition = PLAN_DEFINITIONS[planKey];
+  if (!definition) {
+    return null;
+  }
+  return {
+    slug: planKey,
+    name: definition.name,
+    price: definition.price,
+    currency: definition.currency,
+    message_limit: definition.messageLimit === Infinity ? null : definition.messageLimit,
+    unlimited: definition.messageLimit === Infinity,
+    technologies: definition.technologies,
+  };
+}
+
+function buildProfileResponse(profile) {
+  const definition = PLAN_DEFINITIONS[profile.plan] || PLAN_DEFINITIONS.gratis;
+  return {
+    ...profile,
+    limite_preguntas: normalizeLimit(definition.messageLimit),
+    plan_precio: definition.price,
+    plan_moneda: definition.currency,
+    tecnologias_plan: definition.technologies,
+  };
+}
+
 const app = express();
 app.use(express.json());
 
@@ -43,6 +177,82 @@ app.use(cors(corsOptions));
 app.options('*', cors(corsOptions));
 
 app.use(sessionMiddleware);
+
+app.get('/plans', (req, res) => {
+  const plans = Object.keys(PLAN_DEFINITIONS).map((key) => buildPlanPayload(key));
+  res.json({ plans });
+});
+
+app.get('/me', (req, res) => {
+  const profile = buildProfileResponse(ensureUserProfile(req.session));
+  res.json(profile);
+});
+
+app.get('/perfil', (req, res) => {
+  const profile = buildProfileResponse(ensureUserProfile(req.session));
+  res.json(profile);
+});
+
+app.put('/perfil', (req, res) => {
+  const profile = ensureUserProfile(req.session);
+  const editableFields = [
+    'nombre_empresa',
+    'telefono',
+    'direccion',
+    'ciudad',
+    'provincia',
+    'pais',
+    'latitud',
+    'longitud',
+    'link_web',
+    'logo_url',
+  ];
+
+  editableFields.forEach((field) => {
+    if (Object.prototype.hasOwnProperty.call(req.body, field)) {
+      profile[field] = req.body[field];
+    }
+  });
+
+  if (typeof req.body.horario_json === 'string') {
+    try {
+      const parsed = JSON.parse(req.body.horario_json);
+      if (Array.isArray(parsed)) {
+        profile.horario_json = parsed;
+      }
+    } catch (error) {
+      console.warn('No se pudo parsear horario_json', error);
+    }
+  }
+
+  const response = buildProfileResponse(profile);
+  res.json({ mensaje: 'Perfil actualizado correctamente.', perfil: response });
+});
+
+app.post('/plan/activate', (req, res) => {
+  const { plan, preapproval_plan_id: preapprovalPlanId } = req.body || {};
+  let planKey = typeof plan === 'string' ? plan.toLowerCase() : null;
+  if (!planKey && typeof preapprovalPlanId === 'string') {
+    planKey = MERCADO_PAGO_PLAN_MAP[preapprovalPlanId] || null;
+  }
+
+  if (!planKey || !PLAN_DEFINITIONS[planKey]) {
+    return res.status(400).json({ error: 'Plan inválido.' });
+  }
+
+  const profile = ensureUserProfile(req.session);
+  try {
+    applyPlanToProfile(profile, planKey);
+  } catch (error) {
+    return res.status(400).json({ error: error.message });
+  }
+
+  res.json({
+    mensaje: `Plan ${PLAN_DEFINITIONS[planKey].name} activado correctamente.`,
+    perfil: buildProfileResponse(profile),
+    plan: buildPlanPayload(planKey),
+  });
+});
 
 const FILES_DIR = path.join(__dirname, 'files');
 const UPLOADS_DIR = path.join(__dirname, 'uploads');

--- a/src/components/sections/PricingSection.tsx
+++ b/src/components/sections/PricingSection.tsx
@@ -26,22 +26,40 @@ const pricingOptions = [
   {
     type: 'plan',
     name: 'Profesional Conectado',
-    price: 'Consultar precios', // Aquí iría el precio real o "Desde $XX"
+    price: '$65.000 / mes',
     duration: '',
-    description: 'Solución completa con Chatbot IA y CRM para optimizar la comunicación y gestión de usuarios.',
+    description: 'Solución completa con Chatbot IA avanzado y CRM para optimizar la comunicación y gestión de usuarios.',
     features: [
       'Todo en Inicia con IA, y además:',
-      'Chatbot IA Avanzado (más personalización)',
+      'Chatbot IA avanzado con entrenamiento personalizado',
       'CRM integrado para gestión de perfiles',
       'Carga de hasta 10 documentos',
-      'Hasta 1000 interacciones/mes',
-      'Paneles analíticos básicos',
-      'Integraciones esenciales (ej. email)',
-      'Soporte estándar',
+      'Hasta 250 interacciones/mes',
+      'Paneles analíticos con métricas de interacción',
+      'Integraciones esenciales (formularios, email, catálogos)',
+      'Soporte prioritario',
     ],
     cta: 'Elige Profesional',
     ctaLink: '/register?plan=profesional', // Ejemplo de link con plan
     highlight: true,
+  },
+  {
+    type: 'plan',
+    name: 'Full Automatizado',
+    price: '$95.000 / mes',
+    duration: '',
+    description: 'Automatización total con integraciones avanzadas y soporte dedicado para equipos exigentes.',
+    features: [
+      'Todo en Profesional Conectado, y además:',
+      'Interacciones totalmente ilimitadas por mes',
+      'Automatización end-to-end de campañas y seguimientos',
+      'Integraciones avanzadas con ERP, GovTech y BI',
+      'Orquestación omnicanal (email, WhatsApp, formularios)',
+      'Onboarding personalizado y soporte dedicado',
+    ],
+    cta: 'Escalar con Full',
+    ctaLink: '/register?plan=full',
+    highlight: false,
   },
   {
     type: 'contact', // Tarjeta especial
@@ -55,8 +73,8 @@ const pricingOptions = [
         'Seguridad y cumplimiento normativo avanzado',
         'Capacitación y soporte dedicado',
     ],
-    cta: 'Contactar para Solución a Medida',
-    ctaLink: '/contacto', // O un mailto: o link a agendar reunión
+    cta: 'Consultar precio por WhatsApp',
+    ctaLink: 'https://wa.me/5492613168608?text=Hola!%20Quiero%20una%20propuesta%20empresarial%20o%20gubernamental%20de%20Chatboc',
     highlight: false, // Podría tener un estilo visual diferente
   }
 ];

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -11,29 +11,30 @@ const Checkout = () => {
   const planInfo = {
     pro: {
       title: "Plan Pro",
-      price: "$ / mes",
+      price: "$65.000 / mes",
       benefits: [
-        "Hasta 200 preguntas y respuestas personalizadas por mes",
+        "Hasta 250 preguntas e interacciones personalizadas por mes",
         "Entrenamiento optimizado para el rubro de tu empresa",
         "Panel de control con métricas e historial de uso",
         "Asistente inteligente con aprendizaje y mejoras continuas",
         "Alertas automáticas por palabra clave (ej: reclamos, urgencias)",
-        "Registro automático de conversaciones (planilla o sistema)",
+        "CRM integrado y registro automático de conversaciones",
+        "Integraciones esenciales con formularios, catálogos y email",
         "Soporte técnico prioritario y acceso anticipado a nuevas funcionalidades"
       ],
     },
     full: {
       title: "Plan Full",
-      price: "$ / mes",
+      price: "$95.000 / mes",
       benefits: [
-        "Consultas ilimitadas",
+        "Consultas ilimitadas sin tope de mensajes",
         "Automatización completa de respuestas, seguimientos y derivaciones",
         "Envío automático de catálogos, promociones o formularios por email",
-        "Integración con herramientas externas (CRM, planillas, formularios, etc.)",
+        "Integración avanzada con herramientas externas (ERP, CRM, GovTech, BI)",
         "Acceso a panel administrativo completo con historial y métricas",
         "Dashboard mensual con indicadores de rendimiento del chatbot",
         "Soporte para empresas con múltiples unidades de negocio o servicios diferenciados",
-        "Soporte técnico dedicado y configuración avanzada incluida"
+        "Soporte técnico dedicado, onboarding y consultoría especializada"
       ],
     },
   };

--- a/src/pages/Perfil.tsx
+++ b/src/pages/Perfil.tsx
@@ -152,7 +152,7 @@ export default function Perfil() {
     link_web: "",
     plan: "gratis",
     preguntas_usadas: 0,
-    limite_preguntas: 50,
+    limite_preguntas: 100,
     rubro: "",
     horarios_ui: DIAS.map((_, idx) => ({
       abre: "09:00",
@@ -404,7 +404,7 @@ export default function Perfil() {
         link_web: data.link_web || "",
         plan: data.plan || "gratis",
         preguntas_usadas: data.preguntas_usadas ?? 0,
-        limite_preguntas: data.limite_preguntas ?? 50,
+        limite_preguntas: data.limite_preguntas ?? 100,
         rubro: data.rubro?.toLowerCase() || "",
         logo_url: data.logo_url || "",
         horarios_ui: horariosUi,
@@ -937,7 +937,7 @@ export default function Perfil() {
     plan === 'full'
       ? Infinity
       : plan === 'pro'
-      ? 200
+      ? perfil.limite_preguntas || 250
       : perfil.limite_preguntas;
 
   const porcentaje =
@@ -1309,7 +1309,7 @@ export default function Perfil() {
                                   )
                                 }
                               >
-                                Mejorar a PRO ($35.000/mes)
+                                Mejorar a PRO ($65.000/mes)
                               </Button>
                               <Button
                                 className="w-full bg-accent hover:bg-accent/90 text-accent-foreground font-semibold"
@@ -1320,7 +1320,7 @@ export default function Perfil() {
                                   )
                                 }
                               >
-                                Mejorar a FULL ($60.000/mes)
+                                Mejorar a FULL ($95.000/mes)
                               </Button>
                             </div>
                           )}
@@ -1392,7 +1392,7 @@ export default function Perfil() {
                           )
                         }
                       >
-                        Mejorar a PRO ($35.000/mes)
+                        Mejorar a PRO ($65.000/mes)
                       </Button>
                       <Button
                         className="w-full bg-accent hover:bg-accent/90 text-accent-foreground font-semibold"
@@ -1403,7 +1403,7 @@ export default function Perfil() {
                           )
                         }
                       >
-                        Mejorar a FULL ($60.000/mes)
+                        Mejorar a FULL ($95.000/mes)
                       </Button>
                     </div>
                   )}


### PR DESCRIPTION
## Summary
- lower the backend Plan Pro quota to 250 monthly interactions and highlight unlimited messaging for Plan Full
- align pricing, checkout, and dashboard UI copy with the updated limits
- point the enterprise/government CTA to WhatsApp for direct pricing consultations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7297562208322b16d70ceb3c6a177