### PR TITLE
Add analytics CRM module with dashboards and API

### DIFF
--- a/analytics/cache.js
+++ b/analytics/cache.js
@@ -1,0 +1,46 @@
+const DEFAULT_TTL_MS = Number(process.env.ANALYTICS_CACHE_TTL_MS || 10 * 60 * 1000);
+
+class ResponseCache {
+  constructor() {
+    this.store = new Map();
+  }
+
+  get(key) {
+    const hit = this.store.get(key);
+    if (!hit) return null;
+    if (Date.now() > hit.expiresAt) {
+      this.store.delete(key);
+      return null;
+    }
+    return hit.value;
+  }
+
+  set(key, value, ttlMs = DEFAULT_TTL_MS) {
+    const expiresAt = Date.now() + Math.max(ttlMs, 1000);
+    this.store.set(key, { value, expiresAt });
+  }
+
+  invalidate(prefix) {
+    if (!prefix) {
+      this.store.clear();
+      return;
+    }
+    for (const key of this.store.keys()) {
+      if (key.startsWith(prefix)) {
+        this.store.delete(key);
+      }
+    }
+  }
+
+  stats() {
+    return {
+      size: this.store.size,
+      ttlMs: DEFAULT_TTL_MS,
+    };
+  }
+}
+
+const cache = new ResponseCache();
+
+export { ResponseCache, cache, DEFAULT_TTL_MS };
+export default cache;

--- a/analytics/dataGenerator.js
+++ b/analytics/dataGenerator.js
@@ -1,0 +1,236 @@
+import { trackJobRun } from './observability.js';
+
+function createRandom(seed = 42) {
+  let value = seed % 2147483647;
+  if (value <= 0) {
+    value += 2147483646;
+  }
+  return () => {
+    value = (value * 16807) % 2147483647;
+    return (value - 1) / 2147483646;
+  };
+}
+
+function pick(rand, array) {
+  return array[Math.floor(rand() * array.length)];
+}
+
+function round(value, decimals = 2) {
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+}
+
+function buildGeoCell(lat, lon, resolution = 0.02) {
+  const row = Math.round(lat / resolution);
+  const col = Math.round(lon / resolution);
+  return `cell-${resolution}-${row}-${col}`;
+}
+
+function generateDataset({ tenants, days = 180, seed = 42 } = {}) {
+  const start = Date.now();
+  const rand = createRandom(seed);
+  const tenantDefinitions =
+    tenants && tenants.length
+      ? tenants
+      : [
+          { id: 'tenant-municipio-1', type: 'municipio' },
+          { id: 'tenant-municipio-2', type: 'municipio' },
+          { id: 'tenant-pyme-1', type: 'pyme' },
+          { id: 'tenant-pyme-2', type: 'pyme' },
+        ];
+
+  const categoriesMunicipio = ['iluminacion', 'limpieza', 'calles', 'seguridad', 'espacio-publico'];
+  const categoriesPyme = ['soporte', 'ventas', 'logistica', 'posventa'];
+  const canales = ['whatsapp', 'web', 'email', 'presencial'];
+  const estados = ['abierto', 'en_proceso', 'resuelto', 'backlog'];
+  const severidades = ['baja', 'media', 'alta'];
+  const zonas = ['zona-norte', 'zona-sur', 'zona-centro', 'zona-oeste'];
+  const etiquetas = ['prioritario', 'seguimiento', 'automatizado', 'manual'];
+  const productos = Array.from({ length: 30 }, (_, i) => `producto-${i + 1}`);
+  const servicios = Array.from({ length: 10 }, (_, i) => `servicio-${i + 1}`);
+  const plantillas = ['bienvenida', 'seguimiento', 'recordatorio', 'promocion'];
+
+  const tickets = [];
+  const interactions = [];
+  const orders = [];
+  const surveys = [];
+  const agents = [];
+  const geoCells = new Map();
+
+  tenantDefinitions.forEach((tenant, tenantIdx) => {
+    const agentCount = tenant.type === 'municipio' ? 15 : 10;
+    for (let a = 0; a < agentCount; a += 1) {
+      const id = `${tenant.id}-agent-${a + 1}`;
+      agents.push({
+        id,
+        tenant_id: tenant.id,
+        nombre: `Agente ${tenantIdx + 1}-${a + 1}`,
+        rol: a === 0 ? 'admin' : a < 5 ? 'operador' : 'visor',
+        equipo: a % 3 === 0 ? 'equipo-a' : a % 3 === 1 ? 'equipo-b' : 'equipo-c',
+      });
+    }
+  });
+
+  const now = Date.now();
+  const startDay = now - days * 24 * 60 * 60 * 1000;
+
+  let ticketAutoId = 1;
+  let interactionAutoId = 1;
+  let orderAutoId = 1;
+  let surveyAutoId = 1;
+
+  tenantDefinitions.forEach((tenant) => {
+    const dailyBase = tenant.type === 'municipio' ? 180 : 120;
+    for (let day = 0; day < days; day += 1) {
+      const dayStart = startDay + day * 24 * 60 * 60 * 1000;
+      const volumeMultiplier = 0.6 + rand() * 0.8;
+      const ticketCount = Math.floor(dailyBase * volumeMultiplier);
+      for (let i = 0; i < ticketCount; i += 1) {
+        const createdAt = new Date(dayStart + rand() * 24 * 60 * 60 * 1000);
+        const categoria =
+          tenant.type === 'municipio'
+            ? pick(rand, categoriesMunicipio)
+            : pick(rand, categoriesPyme);
+        const estado = pick(rand, estados);
+        const canal = pick(rand, canales);
+        const assignedAgent = pick(rand, agents.filter((agent) => agent.tenant_id === tenant.id));
+        const latBase = tenant.type === 'municipio' ? -34.6 : -34.45;
+        const lonBase = tenant.type === 'municipio' ? -58.45 : -58.55;
+        const lat = round(latBase + (rand() - 0.5) * 0.3, 6);
+        const lon = round(lonBase + (rand() - 0.5) * 0.3, 6);
+        const barrio = pick(rand, zonas);
+        const zona = pick(rand, zonas);
+        const cellId = buildGeoCell(lat, lon, 0.015 + rand() * 0.01);
+        const origin = rand() > 0.4 ? 'bot' : 'humano';
+        const firstResponseMinutes = Math.floor(rand() * 8 * 60);
+        const resolutionMinutes = Math.floor(firstResponseMinutes + rand() * 48 * 60);
+        const primerRespuesta = new Date(createdAt.getTime() + firstResponseMinutes * 60 * 1000);
+        const cerradoEn =
+          estado === 'resuelto'
+            ? new Date(createdAt.getTime() + resolutionMinutes * 60 * 1000)
+            : null;
+        const ticketId = `T-${tenant.id}-${ticketAutoId}`;
+
+        const ticket = {
+          id: ticketId,
+          tenant_id: tenant.id,
+          canal,
+          categoria,
+          subcategoria: `${categoria}-sub-${Math.ceil(rand() * 3)}`,
+          estado,
+          severidad: pick(rand, severidades),
+          creado_en: createdAt.toISOString(),
+          primer_respuesta_en: primerRespuesta.toISOString(),
+          cerrado_en: cerradoEn ? cerradoEn.toISOString() : null,
+          ubicacion: {
+            lat,
+            lon,
+            barrio,
+            zona,
+            cell_id: cellId,
+          },
+          origen: origin,
+          adjuntos_count: Math.floor(rand() * 4),
+          etiquetas: etiquetas.filter(() => rand() > 0.6),
+          asignado_a: assignedAgent?.id || null,
+          pyme_id: tenant.type === 'pyme' ? `${tenant.id}-cliente-${Math.ceil(rand() * 200)}` : null,
+          canal_origen: origin,
+          sla_breach: rand() > 0.82,
+          reapertura: rand() > 0.88,
+          automatizado: origin === 'bot' && rand() > 0.3,
+        };
+        tickets.push(ticket);
+        ticketAutoId += 1;
+
+        const geoKey = `${tenant.id}-${ticket.ubicacion.cell_id}`;
+        const geoEntry = geoCells.get(geoKey) || {
+          tenant_id: tenant.id,
+          cell_id: ticket.ubicacion.cell_id,
+          lat,
+          lon,
+          count: 0,
+          categories: {},
+        };
+        geoEntry.count += 1;
+        geoEntry.categories[categoria] = (geoEntry.categories[categoria] || 0) + 1;
+        geoCells.set(geoKey, geoEntry);
+
+        const interactionCount = 2 + Math.floor(rand() * 4);
+        for (let j = 0; j < interactionCount; j += 1) {
+          const timestamp = new Date(createdAt.getTime() + j * 30 * 60 * 1000 + rand() * 10 * 60 * 1000);
+          const tipo = j === 0 ? 'mensaje' : rand() > 0.7 ? 'plantilla' : 'mensaje';
+          const canalInteraccion = canal;
+          const actor = j === 0 ? 'usuario' : rand() > 0.5 ? 'agente' : 'bot';
+          const plantilla = tipo === 'plantilla' ? pick(rand, plantillas) : null;
+          interactions.push({
+            id: interactionAutoId,
+            ticket_id: ticket.id,
+            tipo,
+            canal: canalInteraccion,
+            timestamp: timestamp.toISOString(),
+            actor,
+            plantilla,
+            tenant_id: tenant.id,
+          });
+          interactionAutoId += 1;
+        }
+
+        if (tenant.type === 'pyme') {
+          const includeOrder = rand() > 0.35;
+          if (includeOrder) {
+            const itemCount = 1 + Math.floor(rand() * 4);
+            const items = Array.from({ length: itemCount }, () => {
+              const sku = pick(rand, productos.concat(servicios));
+              const qty = 1 + Math.floor(rand() * 5);
+              const price = 5000 + rand() * 45000;
+              return { sku, qty, precio: round(price, 2) };
+            });
+            const total = round(items.reduce((acc, item) => acc + item.qty * item.precio, 0), 2);
+            orders.push({
+              id: `O-${tenant.id}-${orderAutoId}`,
+              tenant_id: tenant.id,
+              items,
+              total,
+              estado: pick(rand, ['nuevo', 'pagado', 'cancelado', 'en_proceso']),
+              canal,
+              creado_en: createdAt.toISOString(),
+              ubicacion: { lat, lon, barrio, zona },
+              ticket_id: ticket.id,
+            });
+            orderAutoId += 1;
+          }
+        }
+
+        if (rand() > 0.6) {
+          const tipoEncuesta = rand() > 0.5 ? 'CSAT' : 'NPS';
+          const score = tipoEncuesta === 'CSAT' ? 1 + Math.floor(rand() * 5) : Math.floor(rand() * 11) - 1;
+          surveys.push({
+            id: `S-${surveyAutoId}`,
+            tenant_id: tenant.id,
+            ticket_id: ticket.id,
+            tipo: tipoEncuesta,
+            score,
+            comentario: rand() > 0.7 ? `retro-${Math.floor(rand() * 1000)}` : null,
+            timestamp: new Date(createdAt.getTime() + rand() * 3 * 24 * 60 * 60 * 1000).toISOString(),
+          });
+          surveyAutoId += 1;
+        }
+      }
+    }
+  });
+
+  const duration = Date.now() - start;
+  trackJobRun('analytics-seed', duration);
+  return {
+    generatedAt: new Date().toISOString(),
+    tickets,
+    interactions,
+    orders,
+    surveys,
+    agents,
+    geoCells: Array.from(geoCells.values()),
+    tenants: tenantDefinitions,
+  };
+}
+
+export { generateDataset };

--- a/analytics/filters.js
+++ b/analytics/filters.js
@@ -1,0 +1,69 @@
+import { parse } from 'url';
+
+function parseDate(value, fallback) {
+  if (!value) return fallback;
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? fallback : new Date(timestamp);
+}
+
+function parseArrayParam(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) return value;
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function parseBBox(value) {
+  if (!value) return null;
+  const parts = value.split(',').map((n) => Number(n));
+  if (parts.length !== 4 || parts.some((n) => Number.isNaN(n))) {
+    return null;
+  }
+  return {
+    minLng: Math.min(parts[0], parts[2]),
+    minLat: Math.min(parts[1], parts[3]),
+    maxLng: Math.max(parts[0], parts[2]),
+    maxLat: Math.max(parts[1], parts[3]),
+  };
+}
+
+function parseFilters(req) {
+  const url = parse(req.url, true);
+  const query = url.query || {};
+  const now = new Date();
+  const from = parseDate(query.from, new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000));
+  const to = parseDate(query.to, now);
+  const tenantId = (query.tenant_id || '').toString().trim();
+  const context = (query.context || query.view || '').toString().trim() || null;
+
+  const filters = {
+    tenantId,
+    from,
+    to,
+    context,
+    canal: parseArrayParam(query.canal),
+    categoria: parseArrayParam(query.categoria || query.rubro),
+    estado: parseArrayParam(query.estado),
+    agente: parseArrayParam(query.agente),
+    zona: parseArrayParam(query.zona || query.barrio),
+    etiquetas: parseArrayParam(query.etiquetas),
+    rubro: parseArrayParam(query.rubro),
+    pyme: parseArrayParam(query.pyme),
+    bbox: parseBBox(query.bbox),
+    search: (query.search || '').toString().trim() || null,
+    metric: (query.metric || '').toString().trim() || 'tickets_total',
+    group: (query.group || '').toString().trim() || null,
+    dimension: (query.dimension || '').toString().trim() || 'categoria',
+    subject: (query.subject || '').toString().trim() || 'zonas',
+  };
+
+  if (!filters.tenantId) {
+    throw new Error('tenant_id es obligatorio');
+  }
+
+  return filters;
+}
+
+export { parseFilters };

--- a/analytics/index.js
+++ b/analytics/index.js
@@ -1,0 +1,5 @@
+import router from './router.js';
+import cache from './cache.js';
+import { dataset } from './store.js';
+
+export { router, cache, dataset };

--- a/analytics/observability.js
+++ b/analytics/observability.js
@@ -1,0 +1,75 @@
+const metrics = {
+  requests: 0,
+  cacheHits: 0,
+  cacheMisses: 0,
+  errors: 0,
+  latencies: [],
+  lastJobs: [],
+};
+
+function trackRequest(durationMs, { cacheHit = false } = {}) {
+  metrics.requests += 1;
+  if (cacheHit) {
+    metrics.cacheHits += 1;
+  } else {
+    metrics.cacheMisses += 1;
+  }
+  if (Number.isFinite(durationMs)) {
+    metrics.latencies.push(durationMs);
+    if (metrics.latencies.length > 1000) {
+      metrics.latencies.shift();
+    }
+  }
+}
+
+function trackError() {
+  metrics.errors += 1;
+}
+
+function trackJobRun(name, durationMs) {
+  metrics.lastJobs.unshift({
+    name,
+    durationMs,
+    ranAt: new Date().toISOString(),
+  });
+  metrics.lastJobs = metrics.lastJobs.slice(0, 20);
+}
+
+function percentile(values, p) {
+  if (!values.length) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const idx = Math.floor((sorted.length - 1) * p);
+  return sorted[idx];
+}
+
+function getHealthSnapshot(cacheStats = { size: 0, ttlMs: 0 }) {
+  const durations = metrics.latencies;
+  return {
+    requests: metrics.requests,
+    cache: {
+      hits: metrics.cacheHits,
+      misses: metrics.cacheMisses,
+      size: cacheStats.size,
+      ttlMs: cacheStats.ttlMs,
+      hitRate:
+        metrics.cacheHits + metrics.cacheMisses === 0
+          ? 0
+          : Number(
+              (
+                (metrics.cacheHits /
+                  (metrics.cacheHits + metrics.cacheMisses)) *
+                100
+              ).toFixed(2),
+            ),
+    },
+    errors: metrics.errors,
+    latency: {
+      p50: percentile(durations, 0.5),
+      p90: percentile(durations, 0.9),
+      p95: percentile(durations, 0.95),
+    },
+    lastJobs: metrics.lastJobs,
+  };
+}
+
+export { trackRequest, trackError, trackJobRun, getHealthSnapshot };

--- a/analytics/rbac.js
+++ b/analytics/rbac.js
@@ -1,0 +1,65 @@
+const ROLE_ORDER = {
+  admin: 3,
+  operador: 2,
+  operator: 2,
+  visor: 1,
+  viewer: 1,
+};
+
+function resolveRole(session, headerRole) {
+  const rawSessionRole = session?.analyticsRole;
+  const candidate = headerRole || rawSessionRole || 'admin';
+  const normalized = candidate.toString().trim().toLowerCase();
+  return ROLE_ORDER[normalized] ? normalized : 'admin';
+}
+
+function ensureContext(session) {
+  if (!session.analyticsContext) {
+    session.analyticsContext = {
+      role: 'admin',
+      teams: ['global'],
+      tenantIds: ['tenant-municipio-1'],
+    };
+  }
+  return session.analyticsContext;
+}
+
+function authorize(role, requiredRole) {
+  const currentLevel = ROLE_ORDER[role] || 0;
+  const requiredLevel = ROLE_ORDER[requiredRole] || 0;
+  return currentLevel >= requiredLevel;
+}
+
+function sanitizeForRole(role, payload) {
+  if (ROLE_ORDER[role] >= ROLE_ORDER.admin) {
+    return payload;
+  }
+  if (!payload || typeof payload !== 'object') return payload;
+  const clone = JSON.parse(JSON.stringify(payload));
+  if (Array.isArray(clone.points)) {
+    clone.points = clone.points.map((p) => ({
+      lat: Number(p.lat?.toFixed?.(5) ?? p.lat),
+      lon: Number(p.lon?.toFixed?.(5) ?? p.lon),
+      count: p.count,
+      cellId: p.cellId,
+    }));
+  }
+  if (Array.isArray(clone.cells)) {
+    clone.cells = clone.cells.map((cell) => ({
+      cellId: cell.cellId,
+      count: cell.count,
+      centroid: cell.centroid,
+      breakdown: cell.breakdown,
+    }));
+  }
+  if (Array.isArray(clone.series)) {
+    clone.series = clone.series.map((entry) => ({
+      date: entry.date,
+      value: entry.value,
+      breakdown: entry.breakdown,
+    }));
+  }
+  return clone;
+}
+
+export { resolveRole, ensureContext, authorize, sanitizeForRole };

--- a/analytics/router.js
+++ b/analytics/router.js
@@ -1,0 +1,227 @@
+import express from 'express';
+import cache from './cache.js';
+import {
+  dataset,
+  summary,
+  filterTickets,
+  filterInteractions,
+  computeTimeseries,
+  computeBreakdown,
+  computeHeatmap,
+  computePoints,
+  computeTop,
+  computeOperations,
+  computeCohorts,
+  computeHotspots,
+  computeChronic,
+  getFiltersCatalog,
+  computePymeMetrics,
+} from './store.js';
+import { parseFilters } from './filters.js';
+import { resolveRole, ensureContext, authorize, sanitizeForRole } from './rbac.js';
+import { trackRequest, trackError, getHealthSnapshot } from './observability.js';
+
+const router = express.Router();
+
+const FEATURE_ENABLED =
+  process.env.ANALYTICS_ENABLED === undefined || process.env.ANALYTICS_ENABLED !== 'false';
+
+router.use((req, res, next) => {
+  if (!FEATURE_ENABLED) {
+    res.status(503).json({ message: 'Analytics module disabled' });
+    return;
+  }
+  next();
+});
+
+router.use((req, res, next) => {
+  ensureContext(req.session);
+  const headerRole = req.headers['x-analytics-role'];
+  const role = resolveRole(req.session, headerRole);
+  req.analyticsRole = role;
+  req.analyticsContext = req.session.analyticsContext;
+  req.session.analyticsRole = role;
+  next();
+});
+
+function buildCacheKey(req, role) {
+  const sortedEntries = Object.entries(req.query || {})
+    .filter(([key]) => key !== '_')
+    .sort((a, b) => (a[0] < b[0] ? -1 : 1));
+  const queryString = sortedEntries.map(([key, value]) => `${key}=${value}`).join('&');
+  return `${role}:${req.path}?${queryString}`;
+}
+
+function handleRequest({ requiredRole = 'visor', resolver }) {
+  return async (req, res) => {
+    const start = Date.now();
+    let filters;
+    try {
+      filters = parseFilters(req);
+    } catch (error) {
+      trackError();
+      res.status(400).json({ message: error.message });
+      return;
+    }
+
+    const role = req.analyticsRole;
+    if (!authorize(role, requiredRole)) {
+      res.status(403).json({ message: 'Permiso insuficiente' });
+      return;
+    }
+
+    const cacheKey = buildCacheKey(req, role);
+    const cached = cache.get(cacheKey);
+    if (cached) {
+      trackRequest(Date.now() - start, { cacheHit: true });
+      res.json(cached);
+      return;
+    }
+
+    try {
+      const payload = await resolver(filters, req);
+      const sanitized = sanitizeForRole(role, payload);
+      cache.set(cacheKey, sanitized);
+      trackRequest(Date.now() - start, { cacheHit: false });
+      res.json(sanitized);
+    } catch (error) {
+      trackError();
+      res.status(500).json({ message: 'Error interno', details: error.message });
+    }
+  };
+}
+
+router.get(
+  '/summary',
+  handleRequest({
+    requiredRole: 'visor',
+    resolver: (filters) => summary(filters),
+  }),
+);
+
+router.get(
+  '/timeseries',
+  handleRequest({
+    requiredRole: 'visor',
+    resolver: (filters) => {
+      const tickets = filterTickets(filters);
+      return {
+        metric: filters.metric,
+        group: filters.group,
+        series: computeTimeseries(tickets, filters.metric, filters.group),
+      };
+    },
+  }),
+);
+
+router.get(
+  '/breakdown',
+  handleRequest({
+    requiredRole: 'visor',
+    resolver: (filters) => {
+      const tickets = filterTickets(filters);
+      return {
+        dimension: filters.dimension,
+        items: computeBreakdown(tickets, filters.dimension),
+      };
+    },
+  }),
+);
+
+router.get(
+  '/geo/heatmap',
+  handleRequest({
+    requiredRole: 'visor',
+    resolver: (filters) => {
+      const tickets = filterTickets(filters);
+      return {
+        cells: computeHeatmap(tickets),
+        hotspots: computeHotspots(tickets),
+        chronic: computeChronic(tickets),
+      };
+    },
+  }),
+);
+
+router.get(
+  '/geo/points',
+  handleRequest({
+    requiredRole: 'operador',
+    resolver: (filters) => {
+      const tickets = filterTickets(filters);
+      return {
+        points: computePoints(tickets, 1000),
+      };
+    },
+  }),
+);
+
+router.get(
+  '/top',
+  handleRequest({
+    requiredRole: 'visor',
+    resolver: (filters) => {
+      const tickets = filterTickets(filters);
+      return {
+        subject: filters.subject,
+        items: computeTop(tickets, filters.subject),
+      };
+    },
+  }),
+);
+
+router.get(
+  '/operations',
+  handleRequest({
+    requiredRole: 'operador',
+    resolver: (filters) => {
+      const tickets = filterTickets(filters);
+      return computeOperations(tickets);
+    },
+  }),
+);
+
+router.get(
+  '/cohorts',
+  handleRequest({
+    requiredRole: 'visor',
+    resolver: (filters) => {
+      const tickets = filterTickets(filters);
+      const ticketIds = new Set(tickets.map((ticket) => ticket.id));
+      const relevantOrders = dataset.orders.filter(
+        (order) => order.tenant_id === filters.tenantId && ticketIds.has(order.ticket_id),
+      );
+      return {
+        cohorts: computeCohorts(relevantOrders),
+      };
+    },
+  }),
+);
+
+router.get(
+  '/whatsapp/templates',
+  handleRequest({
+    requiredRole: 'operador',
+    resolver: (filters) => {
+      const tickets = filterTickets(filters);
+      const interactions = filterInteractions(filters, tickets);
+      const metrics = computePymeMetrics([], tickets, interactions);
+      return { templates: metrics.plantillas };
+    },
+  }),
+);
+
+router.get(
+  '/filters',
+  handleRequest({
+    requiredRole: 'visor',
+    resolver: (filters) => getFiltersCatalog(filters.tenantId),
+  }),
+);
+
+router.get('/internal/health', (req, res) => {
+  const snapshot = getHealthSnapshot(cache.stats());
+  res.json(snapshot);
+});
+
+export default router;

--- a/analytics/store.js
+++ b/analytics/store.js
@@ -1,0 +1,567 @@
+import { generateDataset } from './dataGenerator.js';
+
+const dataset = generateDataset({ days: 120 });
+
+function toDate(value) {
+  return value ? new Date(value) : null;
+}
+
+function minutesBetween(startIso, endIso) {
+  const start = toDate(startIso);
+  const end = toDate(endIso);
+  if (!start || !end) return null;
+  return (end.getTime() - start.getTime()) / 60000;
+}
+
+function percentiles(values) {
+  if (!values.length) {
+    return { p50: 0, p90: 0, p95: 0 };
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const p = (ratio) => {
+    const index = Math.floor((sorted.length - 1) * ratio);
+    return Number(sorted[index].toFixed(2));
+  };
+  return {
+    p50: p(0.5),
+    p90: p(0.9),
+    p95: p(0.95),
+  };
+}
+
+function round(value, digits = 2) {
+  return Number(value.toFixed(digits));
+}
+
+function filterByRange(itemDate, from, to) {
+  const date = toDate(itemDate);
+  return date && date >= from && date <= to;
+}
+
+function withinBBox(point, bbox) {
+  if (!bbox) return true;
+  const { lat, lon } = point?.ubicacion || point;
+  if (typeof lat !== 'number' || typeof lon !== 'number') return false;
+  return lon >= bbox.minLng && lon <= bbox.maxLng && lat >= bbox.minLat && lat <= bbox.maxLat;
+}
+
+function matchesFilters(ticket, filters) {
+  if (!filterByRange(ticket.creado_en, filters.from, filters.to)) return false;
+  if (!withinBBox(ticket, filters.bbox)) return false;
+  if (filters.canal.length && !filters.canal.includes(ticket.canal)) return false;
+  if (filters.categoria.length && !filters.categoria.includes(ticket.categoria)) return false;
+  if (filters.estado.length && !filters.estado.includes(ticket.estado)) return false;
+  if (filters.agente.length && !filters.agente.includes(ticket.asignado_a)) return false;
+  if (filters.zona.length) {
+    const zone = ticket.ubicacion?.zona || ticket.ubicacion?.barrio;
+    if (!zone || !filters.zona.includes(zone)) return false;
+  }
+  if (filters.etiquetas.length) {
+    const tags = Array.isArray(ticket.etiquetas) ? ticket.etiquetas : [];
+    if (!filters.etiquetas.every((tag) => tags.includes(tag))) return false;
+  }
+  if (filters.search) {
+    const combined = [
+      ticket.id,
+      ticket.categoria,
+      ticket.subcategoria,
+      ticket.estado,
+      ticket.asignado_a,
+      ticket.ubicacion?.barrio,
+      ticket.ubicacion?.zona,
+    ]
+      .filter(Boolean)
+      .map((value) => value.toString().toLowerCase())
+      .join(' ');
+    if (!combined.includes(filters.search.toLowerCase())) return false;
+  }
+  return true;
+}
+
+function filterTickets(filters) {
+  return dataset.tickets.filter(
+    (ticket) => ticket.tenant_id === filters.tenantId && matchesFilters(ticket, filters),
+  );
+}
+
+function filterInteractions(filters, tickets) {
+  const ids = new Set(tickets.map((ticket) => ticket.id));
+  return dataset.interactions.filter((item) => ids.has(item.ticket_id));
+}
+
+function filterOrders(filters, tickets) {
+  if (!tickets.length) return [];
+  const ids = new Set(tickets.map((ticket) => ticket.id));
+  return dataset.orders.filter(
+    (order) =>
+      order.tenant_id === filters.tenantId &&
+      ids.has(order.ticket_id) &&
+      filterByRange(order.creado_en, filters.from, filters.to),
+  );
+}
+
+function filterSurveys(filters, tickets) {
+  const ids = new Set(tickets.map((ticket) => ticket.id));
+  return dataset.surveys.filter(
+    (survey) =>
+      survey.tenant_id === filters.tenantId &&
+      ids.has(survey.ticket_id) &&
+      filterByRange(survey.timestamp, filters.from, filters.to),
+  );
+}
+
+function computeSlaMetrics(tickets) {
+  const tta = [];
+  const ttr = [];
+  tickets.forEach((ticket) => {
+    const ack = minutesBetween(ticket.creado_en, ticket.primer_respuesta_en);
+    if (Number.isFinite(ack)) {
+      tta.push(round(ack / 60, 2));
+    }
+    const resolution = minutesBetween(ticket.creado_en, ticket.cerrado_en);
+    if (Number.isFinite(resolution)) {
+      ttr.push(round(resolution / 60, 2));
+    }
+  });
+  return {
+    ack: percentiles(tta),
+    resolve: percentiles(ttr),
+  };
+}
+
+function computeEfficiency(tickets) {
+  if (!tickets.length) {
+    return {
+      firstContact: 0,
+      reopenRate: 0,
+      automationRate: 0,
+    };
+  }
+  const firstContact = tickets.filter(
+    (ticket) => minutesBetween(ticket.primer_respuesta_en, ticket.cerrado_en) <= 60,
+  ).length;
+  const reopen = tickets.filter((ticket) => ticket.reapertura).length;
+  const automated = tickets.filter((ticket) => ticket.automatizado).length;
+  return {
+    firstContact: round((firstContact / tickets.length) * 100, 2),
+    reopenRate: round((reopen / tickets.length) * 100, 2),
+    automationRate: round((automated / tickets.length) * 100, 2),
+  };
+}
+
+function computeVolume(tickets) {
+  const byDay = new Map();
+  const byCanal = new Map();
+  const byCategoria = new Map();
+  const byZona = new Map();
+  tickets.forEach((ticket) => {
+    const day = ticket.creado_en.slice(0, 10);
+    byDay.set(day, (byDay.get(day) || 0) + 1);
+    byCanal.set(ticket.canal, (byCanal.get(ticket.canal) || 0) + 1);
+    byCategoria.set(ticket.categoria, (byCategoria.get(ticket.categoria) || 0) + 1);
+    const zone = ticket.ubicacion?.zona || ticket.ubicacion?.barrio || 'sin_zona';
+    byZona.set(zone, (byZona.get(zone) || 0) + 1);
+  });
+  return {
+    perDay: Array.from(byDay.entries()).map(([date, value]) => ({ date, value })),
+    byChannel: Array.from(byCanal.entries()).map(([label, value]) => ({ label, value })),
+    byCategory: Array.from(byCategoria.entries()).map(([label, value]) => ({ label, value })),
+    byZone: Array.from(byZona.entries()).map(([label, value]) => ({ label, value })),
+  };
+}
+
+function computeQuality(surveys, tickets) {
+  const byType = surveys.reduce((acc, survey) => {
+    const key = survey.tipo.toLowerCase();
+    if (!acc[key]) {
+      acc[key] = [];
+    }
+    acc[key].push(survey.score);
+    return acc;
+  }, {});
+  const byAgent = new Map();
+  surveys.forEach((survey) => {
+    const ticket = tickets.find((item) => item.id === survey.ticket_id);
+    if (!ticket?.asignado_a) return;
+    const agentScores = byAgent.get(ticket.asignado_a) || [];
+    agentScores.push(survey.score);
+    byAgent.set(ticket.asignado_a, agentScores);
+  });
+  const mapScores = (entries) =>
+    Object.entries(entries).map(([key, values]) => ({
+      label: key,
+      average: round(values.reduce((a, b) => a + b, 0) / values.length, 2),
+      responses: values.length,
+    }));
+  return {
+    byType: mapScores(byType),
+    byAgent: Array.from(byAgent.entries()).map(([label, values]) => ({
+      label,
+      average: round(values.reduce((a, b) => a + b, 0) / values.length, 2),
+      responses: values.length,
+    })),
+  };
+}
+
+function computePymeMetrics(orders, tickets, interactions) {
+  if (!orders.length) {
+    return {
+      totalOrders: 0,
+      ticketMedio: 0,
+      ingresos: [],
+      topProductos: [],
+      conversion: tickets.length ? 0 : 0,
+      recurrencia: { d30: 0, d60: 0, d90: 0 },
+      horasPico: [],
+      plantillas: [],
+      canales: [],
+    };
+  }
+  const totals = orders.map((order) => order.total);
+  const ticketMedio = round(totals.reduce((a, b) => a + b, 0) / orders.length, 2);
+  const ingresos = {};
+  const productos = new Map();
+  const clientes = new Map();
+  const canales = new Map();
+  const horas = new Map();
+  orders.forEach((order) => {
+    const day = order.creado_en.slice(0, 10);
+    ingresos[day] = (ingresos[day] || 0) + order.total;
+    order.items.forEach((item) => {
+      productos.set(item.sku, (productos.get(item.sku) || 0) + item.qty);
+    });
+    const cliente = order.ticket_id;
+    const historial = clientes.get(cliente) || [];
+    historial.push(order.creado_en);
+    clientes.set(cliente, historial);
+    canales.set(order.canal, (canales.get(order.canal) || 0) + 1);
+    const createdAt = new Date(order.creado_en);
+    horas.set(createdAt.getHours(), (horas.get(createdAt.getHours()) || 0) + 1);
+  });
+  const recurrence = { d30: 0, d60: 0, d90: 0 };
+  clientes.forEach((dates) => {
+    const sorted = dates.sort();
+    if (sorted.length <= 1) return;
+    const first = new Date(sorted[0]);
+    sorted.slice(1).forEach((date) => {
+      const diffDays = Math.floor((new Date(date).getTime() - first.getTime()) / (24 * 60 * 60 * 1000));
+      if (diffDays <= 30) recurrence.d30 += 1;
+      if (diffDays <= 60) recurrence.d60 += 1;
+      if (diffDays <= 90) recurrence.d90 += 1;
+    });
+  });
+  const plantillas = interactions
+    .filter((item) => item.tipo === 'plantilla')
+    .reduce((acc, item) => {
+      const key = item.plantilla || 'desconocida';
+      if (!acc[key]) {
+        acc[key] = { plantilla: key, envios: 0, respuestas: 0, bloqueos: 0 };
+      }
+      acc[key].envios += 1;
+      if (item.actor === 'usuario') {
+        acc[key].respuestas += 1;
+      }
+      if (item.actor === 'bot' && Math.random() > 0.8) {
+        acc[key].bloqueos += 1;
+      }
+      return acc;
+    }, {});
+
+  return {
+    totalOrders: orders.length,
+    ticketMedio,
+    ingresos: Object.entries(ingresos).map(([date, value]) => ({ date, value: round(value, 2) })),
+    topProductos: Array.from(productos.entries())
+      .map(([label, value]) => ({ label, value }))
+      .sort((a, b) => b.value - a.value)
+      .slice(0, 20),
+    conversion: tickets.length ? round((orders.length / tickets.length) * 100, 2) : 0,
+    recurrencia: recurrence,
+    horasPico: Array.from(horas.entries())
+      .map(([hour, value]) => ({ hour, value }))
+      .sort((a, b) => a.hour - b.hour),
+    canales: Array.from(canales.entries()).map(([label, value]) => ({ label, value })),
+    plantillas: Object.values(plantillas).map((item) => ({
+      ...item,
+      ctr: item.envios ? round((item.respuestas / item.envios) * 100, 2) : 0,
+    })),
+  };
+}
+
+function computeHeatmap(tickets) {
+  const cells = new Map();
+  tickets.forEach((ticket) => {
+    const cellId = ticket.ubicacion?.cell_id;
+    if (!cellId) return;
+    const key = `${ticket.tenant_id}-${cellId}`;
+    const entry = cells.get(key) || {
+      cellId,
+      tenant_id: ticket.tenant_id,
+      count: 0,
+      centroid_lat: ticket.ubicacion.lat,
+      centroid_lon: ticket.ubicacion.lon,
+      breakdown: {},
+    };
+    entry.count += 1;
+    entry.breakdown[ticket.categoria] = (entry.breakdown[ticket.categoria] || 0) + 1;
+    cells.set(key, entry);
+  });
+  return Array.from(cells.values());
+}
+
+function computePoints(tickets, limit = 500) {
+  return tickets
+    .filter((ticket) => ticket.ubicacion?.lat && ticket.ubicacion?.lon)
+    .slice(0, limit)
+    .map((ticket) => ({
+      cellId: ticket.ubicacion.cell_id,
+      lat: ticket.ubicacion.lat,
+      lon: ticket.ubicacion.lon,
+      categoria: ticket.categoria,
+      estado: ticket.estado,
+    }));
+}
+
+function computeTimeseries(tickets, metric, group) {
+  const byDay = new Map();
+  tickets.forEach((ticket) => {
+    const day = ticket.creado_en.slice(0, 10);
+    const entry = byDay.get(day) || { date: day, value: 0, breakdown: {} };
+    if (metric === 'sla_ttr') {
+      const minutes = minutesBetween(ticket.creado_en, ticket.cerrado_en);
+      if (minutes) {
+        entry.value += minutes / 60;
+      }
+    } else {
+      entry.value += 1;
+    }
+    if (group === 'categoria') {
+      entry.breakdown[ticket.categoria] = (entry.breakdown[ticket.categoria] || 0) + 1;
+    }
+    if (group === 'canal') {
+      entry.breakdown[ticket.canal] = (entry.breakdown[ticket.canal] || 0) + 1;
+    }
+    if (group === 'estado') {
+      entry.breakdown[ticket.estado] = (entry.breakdown[ticket.estado] || 0) + 1;
+    }
+    byDay.set(day, entry);
+  });
+  return Array.from(byDay.values()).sort((a, b) => (a.date < b.date ? -1 : 1));
+}
+
+function computeBreakdown(tickets, dimension) {
+  const groups = new Map();
+  tickets.forEach((ticket) => {
+    let key = 'otros';
+    if (dimension === 'categoria') key = ticket.categoria;
+    if (dimension === 'canal') key = ticket.canal;
+    if (dimension === 'estado') key = ticket.estado;
+    if (dimension === 'agente') key = ticket.asignado_a || 'sin_asignar';
+    if (dimension === 'zona') key = ticket.ubicacion?.zona || 'sin_zona';
+    groups.set(key, (groups.get(key) || 0) + 1);
+  });
+  return Array.from(groups.entries())
+    .map(([label, value]) => ({ label, value }))
+    .sort((a, b) => b.value - a.value);
+}
+
+function computeTop(tickets, subject) {
+  if (subject === 'zonas') {
+    return computeBreakdown(tickets, 'zona').slice(0, 10);
+  }
+  if (subject === 'calles') {
+    const groups = new Map();
+    tickets.forEach((ticket) => {
+      const street = ticket.ubicacion?.barrio || 'sin_barrio';
+      groups.set(street, (groups.get(street) || 0) + 1);
+    });
+    return Array.from(groups.entries())
+      .map(([label, value]) => ({ label, value }))
+      .sort((a, b) => b.value - a.value)
+      .slice(0, 10);
+  }
+  if (subject === 'productos') {
+    const groups = new Map();
+    dataset.orders
+      .filter((order) => order.tenant_id === tickets[0]?.tenant_id)
+      .forEach((order) => {
+        order.items.forEach((item) => {
+          groups.set(item.sku, (groups.get(item.sku) || 0) + item.qty);
+        });
+      });
+    return Array.from(groups.entries())
+      .map(([label, value]) => ({ label, value }))
+      .sort((a, b) => b.value - a.value)
+      .slice(0, 20);
+  }
+  return [];
+}
+
+function computeOperations(tickets) {
+  const now = Date.now();
+  const queues = tickets.filter((ticket) => ticket.estado !== 'resuelto');
+  const agingBuckets = {
+    '0-4h': 0,
+    '4-24h': 0,
+    '1-3d': 0,
+    '3-7d': 0,
+    '>7d': 0,
+  };
+  queues.forEach((ticket) => {
+    const created = new Date(ticket.creado_en).getTime();
+    const diffHours = (now - created) / (60 * 60 * 1000);
+    if (diffHours <= 4) agingBuckets['0-4h'] += 1;
+    else if (diffHours <= 24) agingBuckets['4-24h'] += 1;
+    else if (diffHours <= 72) agingBuckets['1-3d'] += 1;
+    else if (diffHours <= 168) agingBuckets['3-7d'] += 1;
+    else agingBuckets['>7d'] += 1;
+  });
+  const slaBreaches = tickets.filter((ticket) => ticket.sla_breach).length;
+  const automated = tickets.filter((ticket) => ticket.automatizado).length;
+  const agentsLoad = new Map();
+  tickets.forEach((ticket) => {
+    if (!ticket.asignado_a) return;
+    const data = agentsLoad.get(ticket.asignado_a) || { abiertos: 0, tiempoMedio: 0, satisfacción: null };
+    if (ticket.estado !== 'resuelto') {
+      data.abiertos += 1;
+    }
+    const duration = minutesBetween(ticket.creado_en, ticket.cerrado_en);
+    if (duration) {
+      data.tiempoMedio += duration;
+    }
+    agentsLoad.set(ticket.asignado_a, data);
+  });
+  const agentsTable = Array.from(agentsLoad.entries()).map(([agentId, data]) => ({
+    agente: agentId,
+    abiertos: data.abiertos,
+    tiempoMedio: data.abiertos ? round(data.tiempoMedio / data.abiertos, 2) : 0,
+    satisfaccion: round(3 + Math.random() * 2, 2),
+  }));
+  return {
+    abiertos: queues.length,
+    slaBreaches,
+    automated,
+    agingBuckets,
+    agents: agentsTable,
+  };
+}
+
+function computeCohorts(orders) {
+  const cohorts = new Map();
+  orders.forEach((order) => {
+    const month = order.creado_en.slice(0, 7);
+    const cohort = cohorts.get(month) || { cohort: month, pedidos: 0, ingresos: 0 };
+    cohort.pedidos += 1;
+    cohort.ingresos += order.total;
+    cohorts.set(month, cohort);
+  });
+  return Array.from(cohorts.values())
+    .map((cohort) => ({ ...cohort, ingresos: round(cohort.ingresos, 2) }))
+    .sort((a, b) => (a.cohort < b.cohort ? -1 : 1));
+}
+
+function computeHotspots(tickets) {
+  const heatmap = computeHeatmap(tickets);
+  return heatmap
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 10)
+    .map((cell) => ({
+      cellId: cell.cellId,
+      count: cell.count,
+      centroid: [cell.centroid_lat, cell.centroid_lon],
+      breakdown: cell.breakdown,
+    }));
+}
+
+function computeChronic(tickets) {
+  const byZone = new Map();
+  tickets.forEach((ticket) => {
+    const zone = ticket.ubicacion?.zona || ticket.ubicacion?.barrio || 'sin_zona';
+    const week = `${ticket.creado_en.slice(0, 4)}-W${Math.ceil(new Date(ticket.creado_en).getDate() / 7)}`;
+    const key = `${zone}-${week}`;
+    byZone.set(key, (byZone.get(key) || 0) + 1);
+  });
+  const zones = new Map();
+  byZone.forEach((count, key) => {
+    const [zone, week] = key.split('-W');
+    const zoneEntry = zones.get(zone) || [];
+    zoneEntry.push({ week: `W${week}`, count });
+    zones.set(zone, zoneEntry);
+  });
+  return Array.from(zones.entries())
+    .filter(([, weeks]) => weeks.length >= 4 && weeks.every((item) => item.count >= 3))
+    .map(([zone, weeks]) => ({ zone, weeks }));
+}
+
+function getFiltersCatalog(tenantId) {
+  const tickets = dataset.tickets.filter((ticket) => ticket.tenant_id === tenantId);
+  const unique = (fn) => Array.from(new Set(tickets.map(fn).filter(Boolean)));
+  return {
+    canales: unique((ticket) => ticket.canal),
+    categorias: unique((ticket) => ticket.categoria),
+    estados: unique((ticket) => ticket.estado),
+    agentes: unique((ticket) => ticket.asignado_a),
+    zonas: unique((ticket) => ticket.ubicacion?.zona || ticket.ubicacion?.barrio),
+    etiquetas: Array.from(
+      new Set(
+        tickets.flatMap((ticket) => (Array.isArray(ticket.etiquetas) ? ticket.etiquetas : [])),
+      ),
+    ),
+  };
+}
+
+function summary(filters) {
+  const tickets = filterTickets(filters);
+  const interactions = filterInteractions(filters, tickets);
+  const orders = filterOrders(filters, tickets);
+  const surveys = filterSurveys(filters, tickets);
+  const sla = computeSlaMetrics(tickets);
+  const efficiency = computeEfficiency(tickets);
+  const volume = computeVolume(tickets);
+  const quality = computeQuality(surveys, tickets);
+  const pyme = computePymeMetrics(orders, tickets, interactions);
+  return {
+    generatedAt: dataset.generatedAt,
+    tenantId: filters.tenantId,
+    filters: {
+      from: filters.from.toISOString(),
+      to: filters.to.toISOString(),
+      canal: filters.canal,
+      categoria: filters.categoria,
+      estado: filters.estado,
+      agente: filters.agente,
+      zona: filters.zona,
+    },
+    totals: {
+      tickets: tickets.length,
+      abiertos: tickets.filter((ticket) => ticket.estado !== 'resuelto').length,
+      backlog: tickets.filter((ticket) => ticket.estado === 'backlog').length,
+      adjuntos: tickets.reduce((acc, ticket) => acc + (ticket.adjuntos_count || 0), 0),
+    },
+    sla,
+    efficiency,
+    volume,
+    quality,
+    pyme,
+  };
+}
+
+export {
+  dataset,
+  summary,
+  filterTickets,
+  filterInteractions,
+  filterOrders,
+  filterSurveys,
+  computeTimeseries,
+  computeBreakdown,
+  computeHeatmap,
+  computePoints,
+  computeTop,
+  computeOperations,
+  computeCohorts,
+  computeHotspots,
+  computeChronic,
+  getFiltersCatalog,
+  computePymeMetrics,
+};

--- a/app.js
+++ b/app.js
@@ -178,6 +178,14 @@ app.options('*', cors(corsOptions));
 
 app.use(sessionMiddleware);
 
+import('./analytics/index.js')
+  .then((module) => {
+    app.use('/analytics', module.router);
+  })
+  .catch((error) => {
+    console.error('Analytics module failed to load', error);
+  });
+
 app.get('/plans', (req, res) => {
   const plans = Object.keys(PLAN_DEFINITIONS).map((key) => buildPlanPayload(key));
   res.json({ plans });

--- a/docs/analytics/README.md
+++ b/docs/analytics/README.md
@@ -1,0 +1,78 @@
+# Módulo de Analítica y CRM
+
+Este módulo agrega endpoints backend (`/analytics`) y un panel frontend para dashboards de municipios, PyMEs y operaciones. El objetivo es ofrecer métricas listas para visualizar, mapas interactivos con filtros cruzados y tablas exportables.
+
+## KPIs y vistas principales
+
+### Dashboard Municipio
+- **KPIs**: tickets totales, abiertos, backlog, % automatización.
+- **SLA**: percentiles P50/P90/P95 para Time To Acknowledge y Time To Resolution.
+- **Series**: tickets diarios apilados por categoría.
+- **Breakdowns**: categorías, canales y estados.
+- **Mapa**: calor y puntos con selección de área que filtra el resto de widgets.
+- **Calidad**: CSAT/NPS por tipo y agente.
+
+### Dashboard PyME
+- **KPIs**: pedidos, ticket medio, conversión, recurrencia 30 días.
+- **Series**: pedidos diarios e ingresos.
+- **Breakdowns**: categorías, canales, estados de pedido.
+- **Mapa**: calor de pedidos y puntos.
+- **Tablas**: top productos, plantillas WhatsApp (envíos, respuestas, CTR), cohortes de compra.
+
+### Dashboard Operaciones
+- **KPIs**: abiertos, violaciones de SLA, automatizados, volumen total.
+- **Serie**: tickets diarios.
+- **Aging**: distribución por buckets (0-4h, 4-24h, etc.).
+- **Mapa**: incidencias activas.
+- **Tabla**: carga de agentes con abiertos, tiempo medio y satisfacción estimada.
+
+## Filtros globales
+
+- **Entidad (tenant)**: selector de `tenant_id` (demo: `tenant-municipio-1`, `tenant-municipio-2`, `tenant-pyme-1`, `tenant-pyme-2`).
+- **Rango de fechas**: selector con presets 7/30 días.
+- **Canal, categoría, estado, agente, zona**: multiselección con búsqueda.
+- **Selección en mapa**: arrastre para definir bounding box y filtrar todos los widgets.
+- **Compartir vista**: copia la URL con filtros vigentes.
+
+Los filtros se mantienen vía query params para soportar “Compartir vista”. Se usa cache HTTP de 10 min por combinación de filtros.
+
+## Backend
+
+- Endpoints bajo `/analytics` (solo GET) con respuesta cacheada.
+- Datos semilla generados en memoria (`analytics/dataGenerator.js`) con multitenancy y métricas derivadas.
+- Agregados: percentiles SLA, eficiencia (primer contacto, re-aperturas), calidad (CSAT/NPS), geo heatmap, cohortes PyME, métricas WhatsApp.
+- RBAC básico vía rol (`admin`, `operador`, `visor`) con sanitización para roles de lectura.
+- Observabilidad: contador de requests, hits de cache y endpoint interno `/analytics/internal/health`.
+
+### Extender o adaptar
+
+1. **Fuentes de datos**: reemplazar el generador en `analytics/dataGenerator.js` por consultas SQL reales (manteniendo las estructuras de salida).
+2. **Nuevos KPIs**: agregar funciones en `analytics/store.js` y exponerlas mediante un endpoint en `analytics/router.js` (respetar cache + filtros).
+3. **Jobs nocturnos**: `generateDataset` simula pre-cómputos; reemplazar por jobs reales y cargar resultados en memoria o caché distribuido.
+4. **RBAC / multitenancy**: ajustar `analytics/rbac.js` para leer datos reales de sesión/JWT.
+
+## Frontend
+
+- Nueva ruta `/analytics` que renderiza `AnalyticsPage` con tres pestañas.
+- `AnalyticsFiltersContext` centraliza filtros y sincroniza con query params.
+- Componentes reutilizables (`WidgetFrame`, `MapWidget`, `KpiTile`, gráficos con `recharts`).
+- Exportaciones por widget a CSV/PNG (`utils/exportUtils.ts`).
+- Mapas usan `MapLibreMap` con soporte para selección de bounding box.
+
+### Añadir widgets
+1. Crear componente (ej. `WidgetFrame`) y consumir servicio desde `useAnalyticsDashboard` o un hook propio.
+2. Exponer datos desde backend si aún no existen (endpoint o campo nuevo).
+3. Agregar el widget a la pestaña correspondiente dentro del layout responsivo (`grid gap-4`).
+
+### Performance
+- Tablas con máximo 20 filas (top-N) y scroll.
+- Mapas y gráficas se actualizan al cambiar filtros con memoización básica.
+- Para datasets grandes se recomienda sustituir el store in-memory por API paginada + React Query.
+
+## Pruebas
+
+`tests/analyticsModule.test.cjs` verifica cálculos clave (SLA, heatmap, operaciones, PyME). Ejecutar `npm test` para validar.
+
+## Feature flag
+
+El módulo se activa si `ANALYTICS_ENABLED` no es `false`. Ajustar TTL de cache vía `ANALYTICS_CACHE_TTL_MS`.

--- a/src/components/analytics/AnalyticsFilterBar.tsx
+++ b/src/components/analytics/AnalyticsFilterBar.tsx
@@ -1,0 +1,193 @@
+import { useMemo } from 'react';
+import { addDays } from 'date-fns';
+import { CalendarIcon, Share2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Calendar } from '@/components/ui/calendar';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { Checkbox } from '@/components/ui/checkbox';
+import { useToast } from '@/components/ui/use-toast';
+import type { FilterCatalogResponse } from '@/services/analyticsService';
+import { useAnalyticsFilters } from '@/context/AnalyticsFiltersContext';
+
+interface AnalyticsFilterBarProps {
+  filters?: FilterCatalogResponse;
+  loading?: boolean;
+}
+
+interface MultiFilterProps {
+  label: string;
+  placeholder?: string;
+  values: string[];
+  options: string[];
+  onChange: (values: string[]) => void;
+}
+
+function MultiSelectFilter({ label, placeholder, values, options, onChange }: MultiFilterProps) {
+  const display = values.length ? `${values.length} seleccionados` : placeholder ?? 'Todos';
+  const normalizedOptions = useMemo(
+    () => options.map((option) => ({ value: option, label: option })),
+    [options],
+  );
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline" size="sm" className="min-w-[160px] justify-start gap-2">
+          {label}
+          <span className="truncate text-xs text-muted-foreground">{display}</span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-64 p-0" align="start">
+        <Command>
+          <CommandInput placeholder={`Filtrar ${label.toLowerCase()}`} />
+          <CommandList>
+            <CommandEmpty>Sin resultados</CommandEmpty>
+            <CommandGroup>
+              {normalizedOptions.map((option) => {
+                const isSelected = values.includes(option.value);
+                return (
+                  <CommandItem
+                    key={option.value}
+                    onSelect={() => {
+                      if (isSelected) {
+                        onChange(values.filter((value) => value !== option.value));
+                      } else {
+                        onChange([...values, option.value]);
+                      }
+                    }}
+                    className="flex items-center gap-2"
+                  >
+                    <Checkbox checked={isSelected} className="mr-2" />
+                    <span>{option.label}</span>
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          </CommandList>
+          <div className="flex items-center justify-between border-t p-2 text-xs">
+            <Button variant="ghost" size="sm" onClick={() => onChange([])}>
+              Limpiar
+            </Button>
+            <span className="text-muted-foreground">{values.length} activos</span>
+          </div>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export function AnalyticsFilterBar({ filters, loading }: AnalyticsFilterBarProps) {
+  const { filters: state, setDateRange, setFilters } = useAnalyticsFilters();
+  const { toast } = useToast();
+
+  const from = useMemo(() => new Date(state.from), [state.from]);
+  const to = useMemo(() => new Date(state.to), [state.to]);
+
+  const handleShare = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      toast({ description: 'Link copiado al portapapeles' });
+    } catch (error) {
+      console.error('No se pudo copiar la URL', error);
+      toast({ description: 'No se pudo copiar la URL', variant: 'destructive' });
+    }
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-3 rounded-lg border bg-background/60 p-3">
+      <Select
+        value={state.tenantId}
+        onValueChange={(value) => setFilters({ tenantId: value })}
+      >
+        <SelectTrigger className="w-[200px]">
+          <SelectValue placeholder="Entidad" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="tenant-municipio-1">tenant-municipio-1</SelectItem>
+          <SelectItem value="tenant-municipio-2">tenant-municipio-2</SelectItem>
+          <SelectItem value="tenant-pyme-1">tenant-pyme-1</SelectItem>
+          <SelectItem value="tenant-pyme-2">tenant-pyme-2</SelectItem>
+        </SelectContent>
+      </Select>
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button variant="outline" size="sm" className="justify-start gap-2">
+            <CalendarIcon className="h-4 w-4" />
+            <span>
+              {state.from} - {state.to}
+            </span>
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-0" align="start">
+          <Calendar
+            initialFocus
+            mode="range"
+            defaultMonth={from}
+            selected={{ from, to }}
+            onSelect={(range) => {
+              if (!range?.from || !range?.to) return;
+              setDateRange(range.from, range.to);
+            }}
+            numberOfMonths={2}
+          />
+          <div className="flex items-center justify-between border-t p-3 text-xs">
+            <Button variant="ghost" size="sm" onClick={() => setDateRange(addDays(new Date(), -30), new Date())}>
+              Últimos 30 días
+            </Button>
+            <Button variant="ghost" size="sm" onClick={() => setDateRange(addDays(new Date(), -7), new Date())}>
+              Últimos 7 días
+            </Button>
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      <MultiSelectFilter
+        label="Canales"
+        placeholder="Todos"
+        values={state.canal ?? []}
+        options={filters?.canales ?? []}
+        onChange={(value) => setFilters({ canal: value })}
+      />
+      <MultiSelectFilter
+        label="Categorías"
+        placeholder="Todas"
+        values={state.categoria ?? []}
+        options={filters?.categorias ?? []}
+        onChange={(value) => setFilters({ categoria: value })}
+      />
+      <MultiSelectFilter
+        label="Estados"
+        placeholder="Todos"
+        values={state.estado ?? []}
+        options={filters?.estados ?? []}
+        onChange={(value) => setFilters({ estado: value })}
+      />
+      <MultiSelectFilter
+        label="Agentes"
+        placeholder="Todos"
+        values={state.agente ?? []}
+        options={filters?.agentes ?? []}
+        onChange={(value) => setFilters({ agente: value })}
+      />
+      <MultiSelectFilter
+        label="Zonas"
+        placeholder="Todas"
+        values={state.zona ?? []}
+        options={filters?.zonas ?? []}
+        onChange={(value) => setFilters({ zona: value })}
+      />
+
+      <Button variant="outline" size="sm" className="ml-auto gap-2" onClick={handleShare} disabled={loading}>
+        <Share2 className="h-4 w-4" /> Compartir vista
+      </Button>
+    </div>
+  );
+}

--- a/src/components/analytics/DonutChart.tsx
+++ b/src/components/analytics/DonutChart.tsx
@@ -1,0 +1,46 @@
+import { useMemo } from 'react';
+import { Pie, PieChart, ResponsiveContainer, Tooltip, Cell, Legend } from 'recharts';
+import type { BreakdownResponse } from '@/services/analyticsService';
+import { WidgetFrame } from './WidgetFrame';
+import ChartTooltip from './ChartTooltip';
+
+interface DonutChartProps {
+  title: string;
+  description?: string;
+  data?: BreakdownResponse;
+  exportName: string;
+  loading?: boolean;
+}
+
+const palette = ['#2563eb', '#f97316', '#22d3ee', '#16a34a', '#f43f5e', '#9333ea', '#facc15', '#0ea5e9'];
+
+export function DonutChart({ title, description, data, exportName, loading }: DonutChartProps) {
+  const formatted = useMemo(() => {
+    if (!data?.items?.length) return [];
+    return data.items
+      .map((item) => ({ name: item.label, value: item.value }))
+      .sort((a, b) => b.value - a.value);
+  }, [data]);
+
+  return (
+    <WidgetFrame title={title} description={description} csvData={formatted} exportFilename={exportName}>
+      <div className="h-72 w-full">
+        {loading ? (
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">Preparando datos...</div>
+        ) : (
+          <ResponsiveContainer>
+            <PieChart>
+              <Pie data={formatted} dataKey="value" nameKey="name" innerRadius={60} outerRadius={90} paddingAngle={4}>
+                {formatted.map((entry, index) => (
+                  <Cell key={entry.name} fill={palette[index % palette.length]} />
+                ))}
+              </Pie>
+              <Tooltip content={<ChartTooltip />} />
+              <Legend verticalAlign="bottom" height={32} wrapperStyle={{ fontSize: 12 }} />
+            </PieChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </WidgetFrame>
+  );
+}

--- a/src/components/analytics/KpiTile.tsx
+++ b/src/components/analytics/KpiTile.tsx
@@ -1,0 +1,45 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/lib/utils';
+
+interface KpiTileProps {
+  title: string;
+  value: number | string;
+  suffix?: string;
+  delta?: { value: number; label?: string; positive?: boolean };
+  loading?: boolean;
+  className?: string;
+}
+
+export function KpiTile({ title, value, suffix, delta, loading, className }: KpiTileProps) {
+  return (
+    <Card className={cn('bg-background/80 backdrop-blur', className)}>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-medium text-muted-foreground">{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <Skeleton className="h-8 w-24" />
+        ) : (
+          <div className="flex items-baseline gap-2">
+            <span className="text-3xl font-semibold tracking-tight">
+              {typeof value === 'number' ? value.toLocaleString('es-AR', { maximumFractionDigits: 1 }) : value}
+            </span>
+            {suffix ? <span className="text-sm text-muted-foreground">{suffix}</span> : null}
+          </div>
+        )}
+        {delta ? (
+          <p
+            className={cn(
+              'mt-2 text-xs font-medium',
+              delta.positive ? 'text-emerald-500' : 'text-amber-500',
+            )}
+          >
+            {delta.positive ? '▲' : '▼'} {Math.abs(delta.value).toFixed(1)}%
+            {delta.label ? <span className="ml-1 text-muted-foreground">{delta.label}</span> : null}
+          </p>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/analytics/MapWidget.tsx
+++ b/src/components/analytics/MapWidget.tsx
@@ -1,0 +1,129 @@
+import { useMemo, useState } from 'react';
+import MapLibreMap from '@/components/MapLibreMap';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import type { HeatmapResponse, PointsResponse } from '@/services/analyticsService';
+import { WidgetFrame } from './WidgetFrame';
+
+interface MapWidgetProps {
+  title: string;
+  description?: string;
+  heatmap?: HeatmapResponse;
+  points?: PointsResponse;
+  loading?: boolean;
+  exportName: string;
+  onBoundingBoxChange?: (bbox: [number, number, number, number] | null) => void;
+}
+
+type Mode = 'heatmap' | 'puntos';
+
+export function MapWidget({
+  title,
+  description,
+  heatmap,
+  points,
+  loading,
+  exportName,
+  onBoundingBoxChange,
+}: MapWidgetProps) {
+  const [mode, setMode] = useState<Mode>('heatmap');
+  const [lastBbox, setLastBbox] = useState<[number, number, number, number] | null>(null);
+
+  const dataset = useMemo(() => {
+    if (!heatmap) return [];
+    const base = heatmap.cells.map((cell) => ({
+      id: cell.cellId,
+      lat: cell.centroid_lat,
+      lng: cell.centroid_lon,
+      weight: cell.count,
+      categoria: Object.keys(cell.breakdown ?? {})[0] ?? 'general',
+      estado: 'aggregated',
+    }));
+    if (mode === 'puntos' && points?.points?.length) {
+      return points.points.map((point) => ({
+        id: point.cellId,
+        lat: point.lat,
+        lng: point.lon,
+        weight: 1,
+        categoria: point.categoria,
+        estado: point.estado,
+      }));
+    }
+    return base;
+  }, [heatmap, points, mode]);
+
+  const csv = useMemo(() => {
+    if (!heatmap) return [];
+    return heatmap.cells.map((cell) => ({
+      cell: cell.cellId,
+      total: cell.count,
+      lat: cell.centroid_lat,
+      lon: cell.centroid_lon,
+      ...cell.breakdown,
+    }));
+  }, [heatmap]);
+
+  const hotspots = heatmap?.hotspots ?? [];
+
+  const handleBbox = (bbox: [number, number, number, number] | null) => {
+    setLastBbox(bbox);
+    onBoundingBoxChange?.(bbox);
+  };
+
+  return (
+    <WidgetFrame
+      title={title}
+      description={description}
+      csvData={csv}
+      exportFilename={exportName}
+      actions={
+        <div className="flex items-center gap-2">
+          <Button
+            variant={mode === 'heatmap' ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => setMode('heatmap')}
+          >
+            Calor
+          </Button>
+          <Button
+            variant={mode === 'puntos' ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => setMode('puntos')}
+          >
+            Puntos
+          </Button>
+        </div>
+      }
+    >
+      <div className="space-y-3">
+        {loading ? (
+          <div className="flex h-80 items-center justify-center text-sm text-muted-foreground">
+            Cargando mapa...
+          </div>
+        ) : (
+          <MapLibreMap
+            className="h-80 w-full rounded-md"
+            heatmapData={dataset}
+            showHeatmap={mode === 'heatmap'}
+            onBoundingBoxChange={handleBbox}
+          />
+        )}
+        <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+          <span>Hotspots:</span>
+          {hotspots.slice(0, 5).map((hotspot) => (
+            <Badge key={hotspot.cellId} variant="secondary" className="gap-1">
+              {hotspot.cellId}
+              <span className="font-semibold">{hotspot.count}</span>
+            </Badge>
+          ))}
+          {hotspots.length === 0 ? <span>Sin datos destacados</span> : null}
+          {lastBbox ? (
+            <Button variant="link" className="ml-auto h-6 px-0" onClick={() => handleBbox(null)}>
+              Limpiar selección
+            </Button>
+          ) : null}
+        </div>
+      </div>
+    </WidgetFrame>
+  );
+}

--- a/src/components/analytics/OperationsTable.tsx
+++ b/src/components/analytics/OperationsTable.tsx
@@ -1,0 +1,47 @@
+import { useMemo } from 'react';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import type { OperationsResponse } from '@/services/analyticsService';
+import { WidgetFrame } from './WidgetFrame';
+
+interface OperationsTableProps {
+  title: string;
+  data?: OperationsResponse;
+  exportName: string;
+  loading?: boolean;
+}
+
+export function OperationsTable({ title, data, exportName, loading }: OperationsTableProps) {
+  const rows = useMemo(() => data?.agents ?? [], [data]);
+  return (
+    <WidgetFrame title={title} csvData={rows} exportFilename={exportName}>
+      <div className="max-h-72 overflow-auto">
+        {loading ? (
+          <div className="flex h-32 items-center justify-center text-sm text-muted-foreground">
+            Calculando carga de agentes...
+          </div>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Agente</TableHead>
+                <TableHead className="text-right">Tickets abiertos</TableHead>
+                <TableHead className="text-right">Tiempo medio (min)</TableHead>
+                <TableHead className="text-right">Satisfacción</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.map((row) => (
+                <TableRow key={row.agente}>
+                  <TableCell className="text-sm font-medium">{row.agente}</TableCell>
+                  <TableCell className="text-right text-sm">{row.abiertos}</TableCell>
+                  <TableCell className="text-right text-sm">{row.tiempoMedio.toFixed(1)}</TableCell>
+                  <TableCell className="text-right text-sm">{row.satisfaccion.toFixed(2)}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </div>
+    </WidgetFrame>
+  );
+}

--- a/src/components/analytics/StackedBarChart.tsx
+++ b/src/components/analytics/StackedBarChart.tsx
@@ -1,0 +1,47 @@
+import { useMemo } from 'react';
+import { Bar, BarChart, CartesianGrid, Legend, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import type { BreakdownResponse } from '@/services/analyticsService';
+import { WidgetFrame } from './WidgetFrame';
+import ChartTooltip from './ChartTooltip';
+
+interface StackedBarChartProps {
+  title: string;
+  description?: string;
+  data?: BreakdownResponse;
+  loading?: boolean;
+  exportName: string;
+}
+
+const palette = ['#2563eb', '#16a34a', '#f97316', '#9333ea', '#facc15', '#0ea5e9'];
+
+export function StackedBarChart({ title, description, data, loading, exportName }: StackedBarChartProps) {
+  const formatted = useMemo(() => {
+    if (!data?.items?.length) return [];
+    return data.items.map((item) => ({ label: item.label, value: item.value }));
+  }, [data]);
+
+  const csv = useMemo(() => formatted.map((item) => ({ ...item })), [formatted]);
+
+  return (
+    <WidgetFrame title={title} description={description} csvData={csv} exportFilename={exportName}>
+      <div className="h-72 w-full">
+        {loading ? (
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+            Generando gráfico...
+          </div>
+        ) : (
+          <ResponsiveContainer>
+            <BarChart data={formatted} margin={{ left: 16, right: 16, top: 10, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" strokeOpacity={0.3} />
+              <XAxis dataKey="label" tickLine={false} axisLine={false} fontSize={12} interval={0} angle={-25} dy={10} />
+              <YAxis tickLine={false} axisLine={false} fontSize={12} />
+              <Tooltip content={<ChartTooltip />} />
+              <Legend verticalAlign="top" height={24} wrapperStyle={{ fontSize: 12 }} />
+              <Bar dataKey="value" fill={palette[0]} radius={[4, 4, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </WidgetFrame>
+  );
+}

--- a/src/components/analytics/TimeSeriesChart.tsx
+++ b/src/components/analytics/TimeSeriesChart.tsx
@@ -1,0 +1,94 @@
+import { useMemo } from 'react';
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { TimeseriesResponse } from '@/services/analyticsService';
+import { WidgetFrame } from './WidgetFrame';
+import ChartTooltip from './ChartTooltip';
+
+interface TimeSeriesChartProps {
+  title: string;
+  description?: string;
+  data?: TimeseriesResponse;
+  loading?: boolean;
+  valueFormatter?: (value: number) => string;
+  exportName: string;
+}
+
+const palette = ['#2563eb', '#f97316', '#16a34a', '#9333ea', '#0ea5e9', '#f43f5e'];
+
+export function TimeSeriesChart({ title, description, data, loading, valueFormatter, exportName }: TimeSeriesChartProps) {
+  const formatted = useMemo(() => {
+    if (!data) return [];
+    return data.series.map((item) => ({
+      date: item.date,
+      total: Number(item.value.toFixed(2)),
+      ...item.breakdown,
+    }));
+  }, [data]);
+
+  const csv = useMemo(() => {
+    if (!formatted.length) return [];
+    return formatted.map((row) => ({ ...row }));
+  }, [formatted]);
+
+  const breakdownKeys = useMemo(() => {
+    if (!data?.series?.length) return [];
+    const keys = new Set<string>();
+    data.series.forEach((item) => {
+      if (item.breakdown) {
+        Object.keys(item.breakdown).forEach((key) => keys.add(key));
+      }
+    });
+    return Array.from(keys);
+  }, [data]);
+
+  return (
+    <WidgetFrame title={title} description={description} csvData={csv} exportFilename={exportName}>
+      <div className="h-72 w-full">
+        {loading ? (
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+            Cargando serie...
+          </div>
+        ) : (
+          <ResponsiveContainer>
+            <AreaChart data={formatted} margin={{ left: 16, right: 16, top: 10, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" strokeOpacity={0.3} />
+              <XAxis dataKey="date" tickLine={false} axisLine={false} fontSize={12} />
+              <YAxis
+                tickLine={false}
+                axisLine={false}
+                fontSize={12}
+                tickFormatter={(value) => (valueFormatter ? valueFormatter(value) : value.toLocaleString())}
+              />
+              <Tooltip content={<ChartTooltip />} />
+              {breakdownKeys.length ? (
+                breakdownKeys.map((key, index) => (
+                  <Area
+                    key={key}
+                    type="monotone"
+                    dataKey={key}
+                    stackId="total"
+                    stroke={palette[index % palette.length]}
+                    fill={palette[index % palette.length]}
+                    fillOpacity={0.2}
+                  />
+                ))
+              ) : (
+                <Area type="monotone" dataKey="total" stroke="#2563eb" fill="#2563eb" fillOpacity={0.2} />
+              )}
+              <Legend verticalAlign="top" height={24} wrapperStyle={{ fontSize: 12 }} />
+            </AreaChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </WidgetFrame>
+  );
+}

--- a/src/components/analytics/TopTable.tsx
+++ b/src/components/analytics/TopTable.tsx
@@ -1,0 +1,44 @@
+import { useMemo } from 'react';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import type { TopResponse } from '@/services/analyticsService';
+import { WidgetFrame } from './WidgetFrame';
+
+interface TopTableProps {
+  title: string;
+  description?: string;
+  data?: TopResponse;
+  exportName: string;
+  loading?: boolean;
+}
+
+export function TopTable({ title, description, data, exportName, loading }: TopTableProps) {
+  const rows = useMemo(() => data?.items ?? [], [data]);
+  return (
+    <WidgetFrame title={title} description={description} csvData={rows} exportFilename={exportName}>
+      <div className="max-h-72 overflow-auto">
+        {loading ? (
+          <div className="flex h-32 items-center justify-center text-sm text-muted-foreground">
+            Cargando tabla...
+          </div>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-3/4">Nombre</TableHead>
+                <TableHead className="text-right">Valor</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.map((row) => (
+                <TableRow key={row.label}>
+                  <TableCell className="truncate text-sm font-medium">{row.label}</TableCell>
+                  <TableCell className="text-right text-sm font-semibold">{row.value.toLocaleString()}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </div>
+    </WidgetFrame>
+  );
+}

--- a/src/components/analytics/WidgetFrame.tsx
+++ b/src/components/analytics/WidgetFrame.tsx
@@ -1,0 +1,81 @@
+import { forwardRef, useRef } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Download, Image as ImageIcon, MoreHorizontal } from 'lucide-react';
+import { exportElementToPng, exportToCsv } from '@/utils/exportUtils';
+
+export interface WidgetFrameProps {
+  title: string;
+  description?: string;
+  csvData?: Record<string, unknown>[];
+  exportFilename?: string;
+  onExportCsv?: () => Record<string, unknown>[] | undefined;
+  actions?: React.ReactNode;
+  className?: string;
+  children: React.ReactNode;
+}
+
+export const WidgetFrame = forwardRef<HTMLDivElement, WidgetFrameProps>(
+  (
+    { title, description, csvData, exportFilename = 'analytics-export', onExportCsv, actions, className, children },
+    ref,
+  ) => {
+    const innerRef = useRef<HTMLDivElement | null>(null);
+    const composedRef = (node: HTMLDivElement | null) => {
+      innerRef.current = node;
+      if (typeof ref === 'function') {
+        ref(node);
+      } else if (ref) {
+        ref.current = node;
+      }
+    };
+
+    const handleCsv = () => {
+      const data = typeof onExportCsv === 'function' ? onExportCsv() : csvData;
+      if (!data || data.length === 0) return;
+      exportToCsv(`${exportFilename}.csv`, data);
+    };
+
+    const handlePng = async () => {
+      await exportElementToPng(innerRef, `${exportFilename}.png`);
+    };
+
+    return (
+      <Card ref={composedRef} className={className}>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <div>
+            <CardTitle className="text-lg font-semibold">{title}</CardTitle>
+            {description ? <CardDescription>{description}</CardDescription> : null}
+          </div>
+          <div className="flex items-center gap-2">
+            {actions}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="icon" className="h-8 w-8">
+                  <MoreHorizontal className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-40">
+                <DropdownMenuItem onSelect={handleCsv} className="flex items-center gap-2">
+                  <Download className="h-4 w-4" /> CSV
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={handlePng} className="flex items-center gap-2">
+                  <ImageIcon className="h-4 w-4" /> PNG
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        </CardHeader>
+        <CardContent>{children}</CardContent>
+      </Card>
+    );
+  },
+);
+
+WidgetFrame.displayName = 'WidgetFrame';

--- a/src/context/AnalyticsFiltersContext.tsx
+++ b/src/context/AnalyticsFiltersContext.tsx
@@ -1,0 +1,154 @@
+import { createContext, useCallback, useContext, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import type { AnalyticsContext, AnalyticsFilters } from '@/services/analyticsService';
+
+type FiltersState = AnalyticsFilters;
+
+type FiltersContextValue = {
+  filters: FiltersState;
+  setFilters: (updates: Partial<FiltersState>) => void;
+  setDateRange: (from: Date, to: Date) => void;
+  setBoundingBox: (bbox: [number, number, number, number] | null) => void;
+  context: AnalyticsContext;
+};
+
+const AnalyticsFiltersContext = createContext<FiltersContextValue | null>(null);
+
+const DEFAULT_RANGE_DAYS = 30;
+
+function formatDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function parseArray(value: string | null): string[] {
+  if (!value) return [];
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function parseBbox(value: string | null): [number, number, number, number] | null {
+  if (!value) return null;
+  const parts = value.split(',').map((part) => Number(part));
+  if (parts.length !== 4 || parts.some((part) => Number.isNaN(part))) {
+    return null;
+  }
+  return [parts[0], parts[1], parts[2], parts[3]];
+}
+
+function buildFilters(params: URLSearchParams, defaults: { tenantId: string; context: AnalyticsContext }) {
+  const now = new Date();
+  const fromParam = params.get('from');
+  const toParam = params.get('to');
+  const from = fromParam ? new Date(fromParam) : new Date(now.getTime() - DEFAULT_RANGE_DAYS * 24 * 60 * 60 * 1000);
+  const to = toParam ? new Date(toParam) : now;
+  return {
+    tenantId: params.get('tenant_id') || defaults.tenantId,
+    from: formatDate(from),
+    to: formatDate(to),
+    canal: parseArray(params.get('canal')),
+    categoria: parseArray(params.get('categoria')),
+    estado: parseArray(params.get('estado')),
+    agente: parseArray(params.get('agente')),
+    zona: parseArray(params.get('zona')),
+    etiquetas: parseArray(params.get('etiquetas')),
+    metric: params.get('metric') || 'tickets_total',
+    group: params.get('group'),
+    dimension: params.get('dimension') || 'categoria',
+    subject: params.get('subject') || 'zonas',
+    bbox: parseBbox(params.get('bbox')),
+    context: (params.get('context') as AnalyticsContext) || defaults.context,
+    search: params.get('search'),
+  } satisfies FiltersState;
+}
+
+export function AnalyticsFiltersProvider({
+  children,
+  defaultTenantId,
+  defaultContext,
+}: {
+  children: React.ReactNode;
+  defaultTenantId: string;
+  defaultContext: AnalyticsContext;
+}) {
+  const [params, setParams] = useSearchParams();
+  const filters = useMemo(
+    () => buildFilters(params, { tenantId: defaultTenantId, context: defaultContext }),
+    [params, defaultTenantId, defaultContext],
+  );
+
+  const updateParams = useCallback(
+    (updates: Partial<FiltersState>) => {
+      const next = new URLSearchParams(params.toString());
+      Object.entries(updates).forEach(([key, value]) => {
+        if (value === undefined || value === null) {
+          next.delete(key);
+          return;
+        }
+        if (Array.isArray(value)) {
+          if (value.length === 0) {
+            next.delete(key);
+          } else {
+            next.set(key, value.join(','));
+          }
+          return;
+        }
+        if (key === 'bbox' && Array.isArray(value)) {
+          next.set(key, value.join(','));
+          return;
+        }
+        next.set(key, String(value));
+      });
+      next.set('tenant_id', updates.tenantId ?? filters.tenantId);
+      next.set('from', updates.from ?? filters.from);
+      next.set('to', updates.to ?? filters.to);
+      next.set('context', updates.context ?? filters.context);
+      setParams(next, { replace: true });
+    },
+    [params, setParams, filters],
+  );
+
+  const setFilters = useCallback(
+    (updates: Partial<FiltersState>) => {
+      updateParams(updates);
+    },
+    [updateParams],
+  );
+
+  const setDateRange = useCallback(
+    (from: Date, to: Date) => {
+      updateParams({ from: formatDate(from), to: formatDate(to) });
+    },
+    [updateParams],
+  );
+
+  const setBoundingBox = useCallback(
+    (bbox: [number, number, number, number] | null) => {
+      if (!bbox) {
+        updateParams({ bbox: null });
+        return;
+      }
+      updateParams({ bbox });
+    },
+    [updateParams],
+  );
+
+  const value = useMemo<FiltersContextValue>(
+    () => ({ filters, setFilters, setDateRange, setBoundingBox, context: filters.context }),
+    [filters, setFilters, setDateRange, setBoundingBox],
+  );
+
+  return <AnalyticsFiltersContext.Provider value={value}>{children}</AnalyticsFiltersContext.Provider>;
+}
+
+export function useAnalyticsFilters() {
+  const ctx = useContext(AnalyticsFiltersContext);
+  if (!ctx) {
+    throw new Error('useAnalyticsFilters must be used within AnalyticsFiltersProvider');
+  }
+  return ctx;
+}

--- a/src/hooks/useAnalyticsDashboard.ts
+++ b/src/hooks/useAnalyticsDashboard.ts
@@ -1,0 +1,111 @@
+import { useEffect, useMemo, useState } from 'react';
+import { analyticsService, type AnalyticsContext } from '@/services/analyticsService';
+import { useAnalyticsFilters } from '@/context/AnalyticsFiltersContext';
+
+type DashboardData = {
+  summary: Awaited<ReturnType<typeof analyticsService.summary>> | null;
+  timeseries: Awaited<ReturnType<typeof analyticsService.timeseries>> | null;
+  breakdownCategoria: Awaited<ReturnType<typeof analyticsService.breakdown>> | null;
+  breakdownCanal: Awaited<ReturnType<typeof analyticsService.breakdown>> | null;
+  breakdownEstado: Awaited<ReturnType<typeof analyticsService.breakdown>> | null;
+  heatmap: Awaited<ReturnType<typeof analyticsService.heatmap>> | null;
+  points: Awaited<ReturnType<typeof analyticsService.points>> | null;
+  topZonas: Awaited<ReturnType<typeof analyticsService.top>> | null;
+  operations: Awaited<ReturnType<typeof analyticsService.operations>> | null;
+  cohorts: Awaited<ReturnType<typeof analyticsService.cohorts>> | null;
+  templates: Awaited<ReturnType<typeof analyticsService.templates>> | null;
+};
+
+export function useAnalyticsDashboard(view: AnalyticsContext) {
+  const { filters } = useAnalyticsFilters();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [data, setData] = useState<DashboardData>({
+    summary: null,
+    timeseries: null,
+    breakdownCategoria: null,
+    breakdownCanal: null,
+    breakdownEstado: null,
+    heatmap: null,
+    points: null,
+    topZonas: null,
+    operations: null,
+    cohorts: null,
+    templates: null,
+  });
+
+  const payload = useMemo(() => ({
+    tenantId: filters.tenantId,
+    from: filters.from,
+    to: filters.to,
+    canal: filters.canal,
+    categoria: filters.categoria,
+    estado: filters.estado,
+    agente: filters.agente,
+    zona: filters.zona,
+    etiquetas: filters.etiquetas,
+    context: view,
+    bbox: filters.bbox ?? undefined,
+    search: filters.search ?? undefined,
+  }), [filters, view]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+
+    async function run() {
+      try {
+        const basePayload = { ...payload };
+        const [summary, timeseries, categoria, canal, estado, heatmap, points, topZonas] = await Promise.all([
+          analyticsService.summary(basePayload),
+          analyticsService.timeseries({ ...basePayload, metric: 'tickets_total', group: 'categoria' }),
+          analyticsService.breakdown({ ...basePayload, dimension: 'categoria' }),
+          analyticsService.breakdown({ ...basePayload, dimension: 'canal' }),
+          analyticsService.breakdown({ ...basePayload, dimension: 'estado' }),
+          analyticsService.heatmap(basePayload),
+          analyticsService.points(basePayload),
+          analyticsService.top({ ...basePayload, subject: 'zonas' }),
+        ]);
+
+        let operations = null;
+        let cohorts = null;
+        let templates = null;
+
+        if (view === 'operaciones' || view === 'municipio') {
+          operations = await analyticsService.operations(basePayload);
+        }
+        if (view === 'pyme') {
+          cohorts = await analyticsService.cohorts(basePayload);
+          templates = await analyticsService.templates(basePayload);
+        }
+
+        setData({
+          summary,
+          timeseries,
+          breakdownCategoria: categoria,
+          breakdownCanal: canal,
+          breakdownEstado: estado,
+          heatmap,
+          points,
+          topZonas,
+          operations,
+          cohorts,
+          templates,
+        });
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        setError(err instanceof Error ? err.message : 'Error cargando datos');
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      }
+    }
+
+    run();
+    return () => controller.abort();
+  }, [payload, view]);
+
+  return { data, loading, error };
+}

--- a/src/pages/analytics/AnalyticsPage.tsx
+++ b/src/pages/analytics/AnalyticsPage.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { AnalyticsFiltersProvider, useAnalyticsFilters } from '@/context/AnalyticsFiltersContext';
+import { analyticsService, type FilterCatalogResponse } from '@/services/analyticsService';
+import { AnalyticsFilterBar } from '@/components/analytics/AnalyticsFilterBar';
+import { MunicipioDashboard } from './MunicipioDashboard';
+import { PymeDashboard } from './PymeDashboard';
+import { OperationsDashboard } from './OperationsDashboard';
+
+function AnalyticsPageContent() {
+  const { filters, setFilters } = useAnalyticsFilters();
+  const [filterCatalog, setFilterCatalog] = useState<FilterCatalogResponse | undefined>();
+  const [loadingFilters, setLoadingFilters] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    async function loadFilters() {
+      setLoadingFilters(true);
+      try {
+        const result = await analyticsService.filters({
+          tenantId: filters.tenantId,
+          from: filters.from,
+          to: filters.to,
+          context: filters.context,
+        });
+        if (active) {
+          setFilterCatalog(result);
+        }
+      } catch (error) {
+        console.error('No se pudieron cargar los filtros', error);
+      } finally {
+        if (active) {
+          setLoadingFilters(false);
+        }
+      }
+    }
+    loadFilters();
+    return () => {
+      active = false;
+    };
+  }, [filters.tenantId, filters.from, filters.to, filters.context]);
+
+  return (
+    <div className="space-y-6">
+      <AnalyticsFilterBar filters={filterCatalog} loading={loadingFilters} />
+      <Tabs
+        value={filters.context ?? 'municipio'}
+        onValueChange={(value) => setFilters({ context: value })}
+        className="space-y-6"
+      >
+        <TabsList>
+          <TabsTrigger value="municipio">Municipio</TabsTrigger>
+          <TabsTrigger value="pyme">PyME</TabsTrigger>
+          <TabsTrigger value="operaciones">Operaciones</TabsTrigger>
+        </TabsList>
+        <TabsContent value="municipio">
+          <MunicipioDashboard />
+        </TabsContent>
+        <TabsContent value="pyme">
+          <PymeDashboard />
+        </TabsContent>
+        <TabsContent value="operaciones">
+          <OperationsDashboard />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+export default function AnalyticsPage() {
+  return (
+    <AnalyticsFiltersProvider defaultTenantId="tenant-municipio-1" defaultContext="municipio">
+      <AnalyticsPageContent />
+    </AnalyticsFiltersProvider>
+  );
+}

--- a/src/pages/analytics/MunicipioDashboard.tsx
+++ b/src/pages/analytics/MunicipioDashboard.tsx
@@ -1,0 +1,158 @@
+import { useMemo } from 'react';
+import { KpiTile } from '@/components/analytics/KpiTile';
+import { TimeSeriesChart } from '@/components/analytics/TimeSeriesChart';
+import { StackedBarChart } from '@/components/analytics/StackedBarChart';
+import { DonutChart } from '@/components/analytics/DonutChart';
+import { TopTable } from '@/components/analytics/TopTable';
+import { MapWidget } from '@/components/analytics/MapWidget';
+import { WidgetFrame } from '@/components/analytics/WidgetFrame';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { useAnalyticsDashboard } from '@/hooks/useAnalyticsDashboard';
+import { useAnalyticsFilters } from '@/context/AnalyticsFiltersContext';
+
+export function MunicipioDashboard() {
+  const { data, loading } = useAnalyticsDashboard('municipio');
+  const { setBoundingBox } = useAnalyticsFilters();
+
+  const summary = data.summary;
+  const qualityRows = useMemo(() => {
+    const quality = summary?.quality;
+    if (!quality) return [];
+    return [
+      ...quality.byType.map((item) => ({
+        scope: item.label,
+        average: item.average,
+        responses: item.responses,
+      })),
+      ...quality.byAgent.map((item) => ({
+        scope: item.label,
+        average: item.average,
+        responses: item.responses,
+      })),
+    ];
+  }, [data.summary]);
+
+  const automationRate = summary?.efficiency?.automationRate ?? 0;
+  const firstContact = summary?.efficiency?.firstContact ?? 0;
+  const reopenRate = summary?.efficiency?.reopenRate ?? 0;
+  const ack = summary?.sla?.ack;
+  const resolve = summary?.sla?.resolve;
+
+  return (
+    <div className="space-y-6">
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <KpiTile title="Tickets totales" value={summary?.totals.tickets ?? 0} loading={loading} />
+        <KpiTile title="Tickets abiertos" value={summary?.totals.abiertos ?? 0} loading={loading} />
+        <KpiTile title="Backlog" value={summary?.totals.backlog ?? 0} loading={loading} />
+        <KpiTile
+          title="% automatizados"
+          value={automationRate}
+          suffix="%"
+          loading={loading}
+        />
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-3">
+        <div className="lg:col-span-2">
+          <TimeSeriesChart
+            title="Tickets diarios"
+            description="Incluye desagregación por categoría"
+            data={data.timeseries ?? undefined}
+            loading={loading}
+            exportName="municipio-timeseries"
+          />
+        </div>
+        <div className="grid gap-4">
+          <WidgetFrame title="SLA - Horas" exportFilename="municipio-sla">
+            <div className="grid grid-cols-2 gap-4 text-sm">
+              <div>
+                <p className="text-xs text-muted-foreground">Time to acknowledge</p>
+                <p className="text-lg font-semibold">P50: {ack?.p50 ?? 0}h</p>
+                <p className="text-xs text-muted-foreground">P90: {ack?.p90 ?? 0}h</p>
+                <p className="text-xs text-muted-foreground">P95: {ack?.p95 ?? 0}h</p>
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground">Time to resolution</p>
+                <p className="text-lg font-semibold">P50: {resolve?.p50 ?? 0}h</p>
+                <p className="text-xs text-muted-foreground">P90: {resolve?.p90 ?? 0}h</p>
+                <p className="text-xs text-muted-foreground">P95: {resolve?.p95 ?? 0}h</p>
+              </div>
+            </div>
+          </WidgetFrame>
+          <WidgetFrame title="Eficiencia" exportFilename="municipio-eficiencia">
+            <div className="space-y-2 text-sm">
+              <p>
+                <span className="font-semibold">Primer contacto:</span>{' '}
+                {firstContact.toFixed(1)}%
+              </p>
+              <p>
+                <span className="font-semibold">Re-aperturas:</span>{' '}
+                {reopenRate.toFixed(1)}%
+              </p>
+            </div>
+          </WidgetFrame>
+        </div>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-3">
+        <StackedBarChart
+          title="Tickets por categoría"
+          data={data.breakdownCategoria ?? undefined}
+          loading={loading}
+          exportName="municipio-categorias"
+        />
+        <DonutChart
+          title="Distribución por canal"
+          data={data.breakdownCanal ?? undefined}
+          loading={loading}
+          exportName="municipio-canales"
+        />
+        <StackedBarChart
+          title="Estados"
+          data={data.breakdownEstado ?? undefined}
+          loading={loading}
+          exportName="municipio-estados"
+        />
+      </section>
+
+      <MapWidget
+        title="Mapa de incidencias"
+        description="Seleccioná un área para filtrar el resto de widgets"
+        heatmap={data.heatmap ?? undefined}
+        points={data.points ?? undefined}
+        loading={loading}
+        exportName="municipio-mapa"
+        onBoundingBoxChange={setBoundingBox}
+      />
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        <TopTable
+          title="Zonas prioritarias"
+          data={data.topZonas ?? undefined}
+          loading={loading}
+          exportName="municipio-zonas"
+        />
+        <WidgetFrame title="Calidad" csvData={qualityRows} exportFilename="municipio-calidad">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Ámbito</TableHead>
+                <TableHead className="text-right">Score</TableHead>
+                <TableHead className="text-right">Respuestas</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {qualityRows.map((row) => (
+                <TableRow key={row.scope}>
+                  <TableCell className="text-sm font-medium">{row.scope}</TableCell>
+                  <TableCell className="text-right text-sm">{row.average.toFixed(2)}</TableCell>
+                  <TableCell className="text-right text-sm">{row.responses}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </WidgetFrame>
+      </section>
+    </div>
+  );
+}

--- a/src/pages/analytics/OperationsDashboard.tsx
+++ b/src/pages/analytics/OperationsDashboard.tsx
@@ -1,0 +1,80 @@
+import { useMemo } from 'react';
+import { KpiTile } from '@/components/analytics/KpiTile';
+import { TimeSeriesChart } from '@/components/analytics/TimeSeriesChart';
+import { StackedBarChart } from '@/components/analytics/StackedBarChart';
+import { MapWidget } from '@/components/analytics/MapWidget';
+import { OperationsTable } from '@/components/analytics/OperationsTable';
+import { WidgetFrame } from '@/components/analytics/WidgetFrame';
+import { useAnalyticsDashboard } from '@/hooks/useAnalyticsDashboard';
+import { useAnalyticsFilters } from '@/context/AnalyticsFiltersContext';
+
+export function OperationsDashboard() {
+  const { data, loading } = useAnalyticsDashboard('operaciones');
+  const { setBoundingBox } = useAnalyticsFilters();
+
+  const operations = data.operations;
+  const agingBreakdown = useMemo(() => {
+    if (!operations) return { dimension: 'aging', items: [] };
+    return {
+      dimension: 'aging',
+      items: Object.entries(operations.agingBuckets).map(([label, value]) => ({ label, value })),
+    };
+  }, [operations]);
+
+  return (
+    <div className="space-y-6">
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <KpiTile title="Tickets abiertos" value={operations?.abiertos ?? 0} loading={loading} />
+        <KpiTile title="SLA vencidos" value={operations?.slaBreaches ?? 0} loading={loading} />
+        <KpiTile title="Automatizados" value={operations?.automated ?? 0} loading={loading} />
+        <KpiTile title="Tickets" value={data.summary?.totals.tickets ?? 0} loading={loading} />
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-3">
+        <div className="lg:col-span-2">
+          <TimeSeriesChart
+            title="Volumen diario"
+            description="Evolución de tickets"
+            data={data.timeseries ?? undefined}
+            loading={loading}
+            exportName="operaciones-timeseries"
+          />
+        </div>
+        <StackedBarChart
+          title="Aging"
+          data={agingBreakdown}
+          loading={loading}
+          exportName="operaciones-aging"
+        />
+      </section>
+
+      <MapWidget
+        title="Tickets en mapa"
+        description="Heatmap de tickets activos"
+        heatmap={data.heatmap ?? undefined}
+        points={data.points ?? undefined}
+        loading={loading}
+        exportName="operaciones-mapa"
+        onBoundingBoxChange={setBoundingBox}
+      />
+
+      <OperationsTable
+        title="Carga por agente"
+        data={operations ?? undefined}
+        loading={loading}
+        exportName="operaciones-agentes"
+      />
+
+      <WidgetFrame title="Estados" exportFilename="operaciones-estados" csvData={data.breakdownEstado?.items}>
+        <div className="grid grid-cols-2 gap-4 text-sm">
+          {(data.breakdownEstado?.items ?? []).map((item) => (
+            <div key={item.label} className="rounded border p-3">
+              <p className="text-xs text-muted-foreground">{item.label}</p>
+              <p className="text-lg font-semibold">{item.value}</p>
+            </div>
+          ))}
+        </div>
+      </WidgetFrame>
+    </div>
+  );
+}

--- a/src/pages/analytics/PymeDashboard.tsx
+++ b/src/pages/analytics/PymeDashboard.tsx
@@ -1,0 +1,162 @@
+import { useMemo } from 'react';
+import { KpiTile } from '@/components/analytics/KpiTile';
+import { TimeSeriesChart } from '@/components/analytics/TimeSeriesChart';
+import { StackedBarChart } from '@/components/analytics/StackedBarChart';
+import { DonutChart } from '@/components/analytics/DonutChart';
+import { MapWidget } from '@/components/analytics/MapWidget';
+import { WidgetFrame } from '@/components/analytics/WidgetFrame';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { useAnalyticsDashboard } from '@/hooks/useAnalyticsDashboard';
+import { useAnalyticsFilters } from '@/context/AnalyticsFiltersContext';
+
+export function PymeDashboard() {
+  const { data, loading } = useAnalyticsDashboard('pyme');
+  const { setBoundingBox } = useAnalyticsFilters();
+
+  const summary = data.summary;
+  const pymeMetrics = summary?.pyme;
+  const cohorts = data.cohorts?.cohorts ?? [];
+  const templates = data.templates?.templates ?? [];
+
+  const horasPico = useMemo(() => pymeMetrics?.horasPico ?? [], [pymeMetrics]);
+
+  return (
+    <div className="space-y-6">
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <KpiTile title="Pedidos" value={pymeMetrics?.totalOrders ?? 0} loading={loading} />
+        <KpiTile title="Ticket medio" value={pymeMetrics?.ticketMedio ?? 0} loading={loading} />
+        <KpiTile title="Conversión" value={pymeMetrics?.conversion ?? 0} suffix="%" loading={loading} />
+        <KpiTile
+          title="Recompra 30 días"
+          value={pymeMetrics?.recurrencia?.d30 ?? 0}
+          loading={loading}
+        />
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-3">
+        <div className="lg:col-span-2">
+          <TimeSeriesChart
+            title="Pedidos diarios"
+            description="Incluye ingresos agregados"
+            data={data.timeseries ?? undefined}
+            loading={loading}
+            exportName="pyme-timeseries"
+          />
+        </div>
+        <WidgetFrame title="Horas pico" exportFilename="pyme-horaspico">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Hora</TableHead>
+                <TableHead className="text-right">Pedidos</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {horasPico.map((row) => (
+                <TableRow key={row.hour}>
+                  <TableCell className="text-sm font-medium">{row.hour}:00</TableCell>
+                  <TableCell className="text-right text-sm">{row.value}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </WidgetFrame>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-3">
+        <StackedBarChart
+          title="Pedidos por categoría"
+          data={data.breakdownCategoria ?? undefined}
+          loading={loading}
+          exportName="pyme-categorias"
+        />
+        <DonutChart
+          title="Conversión por canal"
+          data={data.breakdownCanal ?? undefined}
+          loading={loading}
+          exportName="pyme-canales"
+        />
+        <StackedBarChart
+          title="Estados de pedidos"
+          data={data.breakdownEstado ?? undefined}
+          loading={loading}
+          exportName="pyme-estados"
+        />
+      </section>
+
+      <MapWidget
+        title="Mapa de pedidos"
+        description="Calor de compras por zona"
+        heatmap={data.heatmap ?? undefined}
+        points={data.points ?? undefined}
+        loading={loading}
+        exportName="pyme-mapa"
+        onBoundingBoxChange={setBoundingBox}
+      />
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        <WidgetFrame title="Top productos" exportFilename="pyme-productos" csvData={pymeMetrics?.topProductos}>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>SKU</TableHead>
+                <TableHead className="text-right">Cantidad</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {(pymeMetrics?.topProductos ?? []).map((item) => (
+                <TableRow key={item.label}>
+                  <TableCell className="text-sm font-medium">{item.label}</TableCell>
+                  <TableCell className="text-right text-sm">{item.value}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </WidgetFrame>
+        <WidgetFrame title="Plantillas WhatsApp" exportFilename="pyme-templates" csvData={templates}>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Plantilla</TableHead>
+                <TableHead className="text-right">Envíos</TableHead>
+                <TableHead className="text-right">Respuestas</TableHead>
+                <TableHead className="text-right">CTR</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {templates.map((item) => (
+                <TableRow key={item.plantilla}>
+                  <TableCell className="text-sm font-medium">{item.plantilla}</TableCell>
+                  <TableCell className="text-right text-sm">{item.envios}</TableCell>
+                  <TableCell className="text-right text-sm">{item.respuestas}</TableCell>
+                  <TableCell className="text-right text-sm">{item.ctr.toFixed(1)}%</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </WidgetFrame>
+      </section>
+
+      <WidgetFrame title="Cohortes" exportFilename="pyme-cohortes" csvData={cohorts}>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Cohorte</TableHead>
+              <TableHead className="text-right">Pedidos</TableHead>
+              <TableHead className="text-right">Ingresos</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {cohorts.map((cohort) => (
+              <TableRow key={cohort.cohort}>
+                <TableCell className="text-sm font-medium">{cohort.cohort}</TableCell>
+                <TableCell className="text-right text-sm">{cohort.pedidos}</TableCell>
+                <TableCell className="text-right text-sm">{cohort.ingresos.toFixed(2)}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </WidgetFrame>
+    </div>
+  );
+}

--- a/src/routesConfig.tsx
+++ b/src/routesConfig.tsx
@@ -45,6 +45,7 @@ import CatalogMappingPage from '@/pages/admin/CatalogMappingPage';
 import OpinarArPage from '@/pages/OpinarArPage';
 import EstadisticasPage from '@/pages/EstadisticasPage';
 import Iframe from '@/pages/iframe';
+import AnalyticsPage from '@/pages/analytics/AnalyticsPage';
 
 // NUEVAS IMPORTACIONES PARA EL PORTAL DE USUARIO
 // UserPortalLayout no se importa aquí si se usa como Layout Route en App.tsx
@@ -107,6 +108,7 @@ const routes: RouteConfig[] = [
   { path: '/municipal/stats', element: <EstadisticasPage />, roles: ['admin', 'super_admin'] },
   { path: '/municipal/incidents', element: <EstadisticasPage />, roles: ['admin', 'super_admin'] },
   { path: '/estadisticas', element: <EstadisticasPage />, roles: ['admin', 'super_admin'] },
+  { path: '/analytics', element: <AnalyticsPage />, roles: ['admin', 'empleado', 'super_admin'] },
   { path: '/perfil/plantillas-respuesta', element: <GestionPlantillasPage />, roles: ['admin', 'empleado', 'super_admin'] },
   // Rutas para la gestión de mapeo de catálogos por PYME
   { path: '/admin/pyme/:pymeId/catalog-mappings/new', element: <CatalogMappingPage />, roles: ['admin', 'super_admin'] },

--- a/src/services/analyticsService.ts
+++ b/src/services/analyticsService.ts
@@ -1,0 +1,194 @@
+import { apiFetch } from '@/utils/api';
+
+export type AnalyticsContext = 'municipio' | 'pyme' | 'operaciones' | string;
+
+export interface AnalyticsFiltersPayload {
+  tenantId: string;
+  from: string;
+  to: string;
+  canal?: string[];
+  categoria?: string[];
+  estado?: string[];
+  agente?: string[];
+  zona?: string[];
+  etiquetas?: string[];
+  metric?: string;
+  group?: string | null;
+  dimension?: string;
+  subject?: string;
+  bbox?: [number, number, number, number] | null;
+  context?: AnalyticsContext;
+  search?: string | null;
+}
+
+function buildQuery(params: AnalyticsFiltersPayload): string {
+  const query = new URLSearchParams();
+  query.set('tenant_id', params.tenantId);
+  query.set('from', params.from);
+  query.set('to', params.to);
+  if (params.context) {
+    query.set('context', params.context);
+  }
+  const multi = [
+    ['canal', params.canal],
+    ['categoria', params.categoria],
+    ['estado', params.estado],
+    ['agente', params.agente],
+    ['zona', params.zona],
+    ['etiquetas', params.etiquetas],
+  ] as const;
+  multi.forEach(([key, value]) => {
+    if (value && value.length) {
+      query.set(key, value.join(','));
+    }
+  });
+  if (params.metric) query.set('metric', params.metric);
+  if (params.group) query.set('group', params.group);
+  if (params.dimension) query.set('dimension', params.dimension);
+  if (params.subject) query.set('subject', params.subject);
+  if (params.search) query.set('search', params.search);
+  if (params.bbox) {
+    query.set('bbox', params.bbox.join(','));
+  }
+  return query.toString();
+}
+
+export interface SummaryResponse {
+  generatedAt: string;
+  tenantId: string;
+  totals: {
+    tickets: number;
+    abiertos: number;
+    backlog: number;
+    adjuntos: number;
+  };
+  sla: {
+    ack: { p50: number; p90: number; p95: number };
+    resolve: { p50: number; p90: number; p95: number };
+  };
+  efficiency: {
+    firstContact: number;
+    reopenRate: number;
+    automationRate: number;
+  };
+  volume: {
+    perDay: { date: string; value: number }[];
+    byChannel: { label: string; value: number }[];
+    byCategory: { label: string; value: number }[];
+    byZone: { label: string; value: number }[];
+  };
+  quality: {
+    byType: { label: string; average: number; responses: number }[];
+    byAgent: { label: string; average: number; responses: number }[];
+  };
+  pyme: {
+    totalOrders: number;
+    ticketMedio: number;
+    ingresos: { date: string; value: number }[];
+    topProductos: { label: string; value: number }[];
+    conversion: number;
+    recurrencia: { d30: number; d60: number; d90: number };
+    horasPico: { hour: number; value: number }[];
+    canales: { label: string; value: number }[];
+    plantillas: {
+      plantilla: string;
+      envios: number;
+      respuestas: number;
+      bloqueos: number;
+      ctr: number;
+    }[];
+  };
+}
+
+export interface TimeseriesResponse {
+  metric: string;
+  group: string | null;
+  series: { date: string; value: number; breakdown?: Record<string, number> }[];
+}
+
+export interface BreakdownResponse {
+  dimension: string;
+  items: { label: string; value: number }[];
+}
+
+export interface HeatmapResponse {
+  cells: {
+    cellId: string;
+    tenant_id: string;
+    count: number;
+    centroid_lat: number;
+    centroid_lon: number;
+    breakdown: Record<string, number>;
+  }[];
+  hotspots: {
+    cellId: string;
+    count: number;
+    centroid: [number, number];
+    breakdown: Record<string, number>;
+  }[];
+  chronic: { zone: string; weeks: { week: string; count: number }[] }[];
+}
+
+export interface PointsResponse {
+  points: { cellId: string; lat: number; lon: number; categoria: string; estado: string }[];
+}
+
+export interface TopResponse {
+  subject: string;
+  items: { label: string; value: number }[];
+}
+
+export interface OperationsResponse {
+  abiertos: number;
+  slaBreaches: number;
+  automated: number;
+  agingBuckets: Record<string, number>;
+  agents: { agente: string; abiertos: number; tiempoMedio: number; satisfaccion: number }[];
+}
+
+export interface CohortsResponse {
+  cohorts: { cohort: string; pedidos: number; ingresos: number }[];
+}
+
+export interface TemplatesResponse {
+  templates: {
+    plantilla: string;
+    envios: number;
+    respuestas: number;
+    bloqueos: number;
+    ctr: number;
+  }[];
+}
+
+export interface FilterCatalogResponse {
+  canales: string[];
+  categorias: string[];
+  estados: string[];
+  agentes: string[];
+  zonas: string[];
+  etiquetas: string[];
+}
+
+async function fetcher<T>(endpoint: string, filters: AnalyticsFiltersPayload): Promise<T> {
+  const qs = buildQuery(filters);
+  return apiFetch<T>(`analytics/${endpoint}?${qs}`);
+}
+
+export const analyticsService = {
+  summary: (filters: AnalyticsFiltersPayload) => fetcher<SummaryResponse>('summary', filters),
+  timeseries: (filters: AnalyticsFiltersPayload) =>
+    fetcher<TimeseriesResponse>('timeseries', filters),
+  breakdown: (filters: AnalyticsFiltersPayload) =>
+    fetcher<BreakdownResponse>('breakdown', filters),
+  heatmap: (filters: AnalyticsFiltersPayload) => fetcher<HeatmapResponse>('geo/heatmap', filters),
+  points: (filters: AnalyticsFiltersPayload) => fetcher<PointsResponse>('geo/points', filters),
+  top: (filters: AnalyticsFiltersPayload) => fetcher<TopResponse>('top', filters),
+  operations: (filters: AnalyticsFiltersPayload) =>
+    fetcher<OperationsResponse>('operations', filters),
+  cohorts: (filters: AnalyticsFiltersPayload) => fetcher<CohortsResponse>('cohorts', filters),
+  templates: (filters: AnalyticsFiltersPayload) =>
+    fetcher<TemplatesResponse>('whatsapp/templates', filters),
+  filters: (filters: AnalyticsFiltersPayload) => fetcher<FilterCatalogResponse>('filters', filters),
+};
+
+export type { AnalyticsFiltersPayload as AnalyticsFilters };

--- a/src/utils/exportUtils.ts
+++ b/src/utils/exportUtils.ts
@@ -1,0 +1,91 @@
+import type { RefObject } from 'react';
+
+export function exportToCsv(filename: string, rows: Record<string, unknown>[]) {
+  if (!rows.length) {
+    console.warn('No hay datos para exportar');
+    return;
+  }
+  const headers = Object.keys(rows[0]);
+  const lines = [headers.join(',')];
+  rows.forEach((row) => {
+    const values = headers.map((header) => {
+      const value = row[header];
+      if (value === null || value === undefined) return '';
+      const stringValue = Array.isArray(value) ? value.join('|') : String(value);
+      if (stringValue.includes(',') || stringValue.includes('"') || stringValue.includes('\n')) {
+        return `"${stringValue.replace(/"/g, '""')}"`;
+      }
+      return stringValue;
+    });
+    lines.push(values.join(','));
+  });
+  const blob = new Blob([lines.join('\n')], { type: 'text/csv;charset=utf-8;' });
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.setAttribute('download', filename);
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}
+
+export async function exportElementToPng(ref: RefObject<HTMLElement>, filename: string) {
+  const element = ref.current;
+  if (!element) {
+    console.warn('Elemento no disponible para exportar');
+    return;
+  }
+
+  const bounds = element.getBoundingClientRect();
+  const width = Math.ceil(bounds.width);
+  const height = Math.ceil(bounds.height);
+  const clone = element.cloneNode(true) as HTMLElement;
+  clone.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
+  const serialized = new XMLSerializer().serializeToString(clone);
+  const svg = `<?xml version="1.0" encoding="UTF-8"?>
+    <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">
+      <foreignObject width="100%" height="100%">
+        ${serialized}
+      </foreignObject>
+    </svg>`;
+
+  const svgBlob = new Blob([svg], { type: 'image/svg+xml;charset=utf-8' });
+  const url = URL.createObjectURL(svgBlob);
+
+  await new Promise<void>((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => {
+      const scale = window.devicePixelRatio || 2;
+      const canvas = document.createElement('canvas');
+      canvas.width = width * scale;
+      canvas.height = height * scale;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        reject(new Error('No se pudo inicializar canvas'));
+        return;
+      }
+      ctx.scale(scale, scale);
+      ctx.drawImage(img, 0, 0);
+      const pngUrl = canvas.toDataURL('image/png');
+      URL.revokeObjectURL(url);
+      const link = document.createElement('a');
+      link.href = pngUrl;
+      link.download = filename;
+      link.click();
+      resolve();
+    };
+    img.onerror = (error) => {
+      URL.revokeObjectURL(url);
+      console.error('No se pudo generar PNG', error);
+      reject(error as Error);
+    };
+    img.src = url;
+  });
+}
+
+export function downloadJson(filename: string, data: unknown) {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = filename;
+  link.click();
+}

--- a/tests/analyticsModule.test.cjs
+++ b/tests/analyticsModule.test.cjs
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import {
+  dataset,
+  summary,
+  filterTickets,
+  filterInteractions,
+  computeTimeseries,
+  computeBreakdown,
+  computeHeatmap,
+  computeOperations,
+  computePymeMetrics,
+} from '../analytics/store.js';
+
+function baseFilters(tenantId) {
+  const now = new Date();
+  return {
+    tenantId,
+    from: new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000),
+    to: now,
+    context: null,
+    canal: [],
+    categoria: [],
+    estado: [],
+    agente: [],
+    zona: [],
+    etiquetas: [],
+    rubro: [],
+    pyme: [],
+    bbox: null,
+    search: null,
+    metric: 'tickets_total',
+    group: null,
+    dimension: 'categoria',
+    subject: 'zonas',
+  };
+}
+
+describe('Analytics store', () => {
+  it('should build a summary with SLA and efficiency metrics', () => {
+    const filters = baseFilters('tenant-municipio-1');
+    const report = summary(filters);
+    expect(report.totals.tickets).toBeGreaterThan(0);
+    expect(report.sla.ack.p50).toBeGreaterThan(0);
+    expect(report.efficiency.automationRate).toBeGreaterThanOrEqual(0);
+  });
+
+  it('should compute timeseries grouped by category', () => {
+    const filters = baseFilters('tenant-municipio-1');
+    const tickets = filterTickets(filters);
+    const series = computeTimeseries(tickets, 'tickets_total', 'categoria');
+    expect(series.length).toBeGreaterThan(0);
+    expect(series[0]).toHaveProperty('breakdown');
+  });
+
+  it('should compute breakdown data for channels', () => {
+    const filters = baseFilters('tenant-municipio-1');
+    const tickets = filterTickets(filters);
+    const breakdown = computeBreakdown(tickets, 'canal');
+    expect(breakdown.length).toBeGreaterThan(0);
+    expect(breakdown[0].value).toBeGreaterThan(0);
+  });
+
+  it('should produce geo heatmap cells', () => {
+    const filters = baseFilters('tenant-municipio-1');
+    const tickets = filterTickets(filters);
+    const cells = computeHeatmap(tickets);
+    expect(cells.length).toBeGreaterThan(0);
+    expect(cells[0]).toHaveProperty('cellId');
+  });
+
+  it('should calculate operations aging buckets', () => {
+    const filters = baseFilters('tenant-municipio-1');
+    const tickets = filterTickets(filters);
+    const operations = computeOperations(tickets);
+    const totalQueues = Object.values(operations.agingBuckets).reduce((acc, value) => acc + value, 0);
+    expect(totalQueues).toBeGreaterThanOrEqual(0);
+  });
+
+  it('should compute pyme metrics with templates CTR', () => {
+    const filters = baseFilters('tenant-pyme-1');
+    const tickets = filterTickets(filters);
+    const interactions = filterInteractions(filters, tickets);
+    const orders = dataset.orders.filter(
+      (order) => order.tenant_id === filters.tenantId && new Date(order.creado_en) >= filters.from,
+    );
+    const metrics = computePymeMetrics(orders, tickets, interactions);
+    expect(metrics.totalOrders).toBeGreaterThan(0);
+    expect(metrics.plantillas.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add standalone analytics backend module with caching, RBAC, synthetic data, and /analytics endpoints
- create frontend analytics dashboards with shared filters, map widgets, and export utilities
- document the analytics module and cover core calculations with vitest

## Testing
- npm run test -- analyticsModule.test.cjs

------
https://chatgpt.com/codex/tasks/task_e_68d9bfd1a15c83228b7016656cb78d6b