### PR TITLE
Harden analytics tenant authorization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ Thumbs.db
 *.njsproj
 *.sln
 *.sw?
+server/analytics/data/seed.json
 
 # Others
 *.local

--- a/docs/analytics/README.md
+++ b/docs/analytics/README.md
@@ -1,0 +1,111 @@
+# Módulo de Analítica y CRM (frontend)
+
+El panel de analítica vive en el frontend y consume un backend externo bajo `/analytics`. Este documento resume los datos que espera recibir, cómo se organizan las vistas y qué consideraciones debe tener el equipo de backend para integrarse.
+
+## KPIs y vistas principales
+
+### Dashboard Municipio
+- **KPIs**: tickets totales, abiertos, backlog, % automatización.
+- **SLA**: percentiles P50/P90/P95 para Time To Acknowledge y Time To Resolution.
+- **Series**: tickets diarios apilados por categoría.
+- **Breakdowns**: categorías, canales y estados.
+- **Mapa**: calor y puntos con selección de área que filtra el resto de widgets.
+- **Calidad**: CSAT/NPS por tipo y agente.
+
+### Dashboard PyME
+- **KPIs**: pedidos, ticket medio, conversión, recurrencia 30 días.
+- **Series**: pedidos diarios e ingresos.
+- **Breakdowns**: categorías, canales, estados de pedido.
+- **Mapa**: calor de pedidos y puntos.
+- **Tablas**: top productos, plantillas WhatsApp (envíos, respuestas, CTR), cohortes de compra.
+
+### Dashboard Operaciones
+- **KPIs**: abiertos, violaciones de SLA, automatizados, volumen total.
+- **Serie**: tickets diarios.
+- **Aging**: distribución por buckets (0-4h, 4-24h, etc.).
+- **Mapa**: incidencias activas.
+- **Tabla**: carga de agentes con abiertos, tiempo medio y satisfacción estimada.
+
+## Filtros globales
+
+- **Entidad (tenant)**: selector de `tenant_id` (demo: `muni-centro`, `muni-sur`, `pyme-tienda`).
+- **Rango de fechas**: selector con presets 7/30 días.
+- **Canal, categoría, estado, agente, zona**: multiselección con búsqueda.
+- **Selección en mapa**: arrastre para definir bounding box y filtrar todos los widgets.
+- **Compartir vista**: copia la URL con filtros vigentes.
+
+Los filtros se mantienen vía query params para soportar “Compartir vista”. Se usa cache HTTP de 10 min por combinación de filtros.
+
+## Backend incluido en este repo
+
+El repositorio ahora incorpora un microservicio Node bajo `server/app.cjs` que expone los endpoints `/analytics/*` consumidos por el frontend. No requiere dependencias externas (solo módulos built-in) y genera un dataset sintético de ~6.000 tickets, pedidos y encuestas por los tres tenants demo (`muni-centro`, `muni-sur`, `pyme-tienda`).
+
+### Cómo levantarlo en desarrollo
+
+```bash
+npm run build   # opcional, solo si necesitás empaquetar el frontend
+node server/app.cjs
+```
+
+Por defecto escucha en `http://localhost:4000`. Ajustá `VITE_BACKEND_URL` (por ejemplo `http://localhost:4000`) para que el frontend enrute las peticiones a este backend. El servidor soporta CORS básico (`GET` + `OPTIONS`).
+
+### Seguridad y contexto
+
+- Valida roles (`admin` > `operador` > `visor`) antes de resolver cada endpoint.
+- Verifica que `tenant_id` pertenezca a la lista permitida (`X-Analytics-Tenant-Ids` / `X-Tenant-Ids`), salvo usuarios `admin`.
+- Cachea cada combinación de filtros 10 minutos en memoria.
+- Registra tiempos de respuesta y errores en consola (`[analytics] Request/Error`).
+
+### Dataset y jobs simulados
+
+- Tickets generados con severidad, canal, categoría, adjuntos, SLA y flags de automatización/reapertura.
+- Pedidos PyME con items, totales, zonas, clientes y plantillas WhatsApp asociadas.
+- Encuestas CSAT/NPS vinculadas a tickets y pedidos.
+- Métricas derivadas para cohortes, geo heatmap, hotspots y detección de “problemas crónicos”.
+
+Podés regenerar el dataset borrando `server/analytics/data/seed.json` o llamando a `refreshDataset()` (exportado en `server/analytics`).
+
+## Endpoints disponibles
+
+El frontend consulta estos endpoints (solo `GET`). Todos reciben `tenant_id`, `from`, `to` y filtros opcionales (`canal`, `categoria`, `estado`, `agente`, `zona`, `etiquetas`, `bbox`, `context`, `search`). Las respuestas incluyen únicamente datos agregados o anonimizados.
+
+- `GET /analytics/summary`
+- `GET /analytics/timeseries`
+- `GET /analytics/breakdown`
+- `GET /analytics/geo/heatmap`
+- `GET /analytics/geo/points`
+- `GET /analytics/top`
+- `GET /analytics/operations`
+- `GET /analytics/cohorts`
+- `GET /analytics/whatsapp/templates`
+- `GET /analytics/filters` → catálogo para llenar selects (canales, categorías, estados, agentes, zonas, etiquetas, tenants, contextos disponibles).
+
+### Recomendaciones si migrás a un backend productivo
+
+1. **Cache**: mantené TTL 5-15 minutos por combinación de filtros. Se puede reemplazar el cache in-memory por Redis/KeyDB.
+2. **Multitenancy y seguridad**: replicar la validación de tenant basada en el token de sesión y tu sistema RBAC. Este módulo asume cabeceras `X-Analytics-Role` y `X-Analytics-Tenant-Ids`.
+3. **Pre-cómputos**: migrá los agregados (SLA percentiles, cohortes, geo) a jobs nocturnos/materialized views para datasets reales.
+4. **Geo**: `heatmap` entrega celdas `{ cellId, count, centroid_lat, centroid_lon, breakdown }`. `points` devuelve una muestra anonimizada (máx. 250 puntos).
+5. **Filtros globales**: `GET /analytics/filters` debe devolver listas de valores válidos y opcionalmente la lista de `tenants` disponibles para el usuario.
+
+## Frontend
+
+- Ruta `/analytics` que renderiza `AnalyticsPage` con tres pestañas.
+- `AnalyticsFiltersContext` centraliza filtros, sincroniza query params y espera recibir opciones desde `/analytics/filters`.
+- Componentes reutilizables (`WidgetFrame`, `MapWidget`, `KpiTile`, gráficos con `recharts`).
+- Exportaciones por widget a CSV/PNG (`utils/exportUtils.ts`).
+- Mapas usan `MapLibreMap` con soporte para selección de bounding box.
+
+### Añadir widgets
+1. Crear componente (ej. `WidgetFrame`) y consumir servicio desde `useAnalyticsDashboard` o un hook propio.
+2. Exponer datos desde backend si aún no existen (endpoint o campo nuevo).
+3. Agregar el widget a la pestaña correspondiente dentro del layout responsivo (`grid gap-4`).
+
+### Performance
+- Tablas con máximo 20 filas (top-N) y scroll.
+- Mapas y gráficas se actualizan al cambiar filtros con memoización básica.
+- Para datasets grandes se recomienda sustituir el store in-memory por API paginada + React Query.
+
+## Feature flag
+
+El frontend chequea `window.CHATBOC_CONFIG.analytics`. Si `enabled === false`, esconder la ruta en el enrutador o evitar montar la página. También se puede forzar el tenant o la vista inicial con `defaultTenantId` y `defaultContext`.

--- a/server/analytics/cache.cjs
+++ b/server/analytics/cache.cjs
@@ -1,0 +1,40 @@
+const DEFAULT_TTL_MS = 10 * 60 * 1000;
+
+class MemoryCache {
+  constructor(ttlMs = DEFAULT_TTL_MS) {
+    this.ttlMs = ttlMs;
+    this.store = new Map();
+  }
+
+  get(key) {
+    const record = this.store.get(key);
+    if (!record) return null;
+    const { value, expiresAt } = record;
+    if (Date.now() > expiresAt) {
+      this.store.delete(key);
+      return null;
+    }
+    return value;
+  }
+
+  set(key, value, ttlMs = this.ttlMs) {
+    const expiresAt = Date.now() + ttlMs;
+    this.store.set(key, { value, expiresAt });
+  }
+
+  clear() {
+    this.store.clear();
+  }
+
+  stats() {
+    return {
+      size: this.store.size,
+      ttlMs: this.ttlMs,
+    };
+  }
+}
+
+module.exports = {
+  MemoryCache,
+  cache: new MemoryCache(),
+};

--- a/server/analytics/context.cjs
+++ b/server/analytics/context.cjs
@@ -1,0 +1,38 @@
+const { normalizeRole } = require('./rbac.cjs');
+
+function parseAllowedTenants(headerValue) {
+  if (!headerValue) return [];
+  return String(headerValue)
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+function buildContextFromHeaders(headers) {
+  const roleHeader = headers['x-analytics-role'] || headers['x-role'];
+  const allowedTenantsHeader =
+    headers['x-analytics-tenant-ids'] || headers['x-tenant-ids'] || headers['x-allowed-tenants'];
+  const defaultTenantHeader = headers['x-default-tenant'];
+
+  const analyticsRole = normalizeRole(roleHeader);
+  const allowedTenants = parseAllowedTenants(allowedTenantsHeader);
+  const defaultTenant =
+    defaultTenantHeader && typeof defaultTenantHeader === 'string'
+      ? defaultTenantHeader
+      : allowedTenants[0] || null;
+
+  return { analyticsRole, allowedTenants, defaultTenant };
+}
+
+function ensureContext(req, res, next) {
+  const context = buildContextFromHeaders(req.headers);
+  req.analyticsRole = context.analyticsRole;
+  req.allowedTenants = context.allowedTenants;
+  req.defaultTenant = context.defaultTenant;
+  next();
+}
+
+module.exports = {
+  ensureContext,
+  buildContextFromHeaders,
+};

--- a/server/analytics/dataset.cjs
+++ b/server/analytics/dataset.cjs
@@ -1,0 +1,356 @@
+const fs = require('fs');
+const path = require('path');
+const { randomUUID } = require('crypto');
+
+const DATASET_PATH = path.join(__dirname, 'data', 'seed.json');
+fs.mkdirSync(path.dirname(DATASET_PATH), { recursive: true });
+
+function mulberry32(seed) {
+  return function rng() {
+    let t = (seed += 0x6d2b79f5);
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function choice(rng, list) {
+  return list[Math.floor(rng() * list.length) % list.length];
+}
+
+function weightedChoice(rng, entries) {
+  const total = entries.reduce((acc, [, weight]) => acc + weight, 0);
+  const target = rng() * total;
+  let cursor = 0;
+  for (const [value, weight] of entries) {
+    cursor += weight;
+    if (target <= cursor) return value;
+  }
+  return entries[entries.length - 1][0];
+}
+
+function round(value, decimals = 2) {
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+}
+
+function generateDataset() {
+  const rng = mulberry32(42);
+
+  const tenants = [
+    {
+      id: 'muni-centro',
+      name: 'Municipio Centro',
+      type: 'municipio',
+      zones: ['Centro', 'Norte', 'Sur', 'Este', 'Oeste', 'Costanera', 'Industrial'],
+      barrios: ['San Martín', 'Belgrano', 'Independencia', 'Mitre', 'Saavedra', 'Dorrego'],
+    },
+    {
+      id: 'muni-sur',
+      name: 'Municipio Sur',
+      type: 'municipio',
+      zones: ['Río', 'Colinas', 'Valle Verde', 'Puerto', 'Aeropuerto', 'Parque'],
+      barrios: ['Amanecer', 'Bosques', 'Puente', 'Marítimo', 'Cordillera'],
+    },
+    {
+      id: 'pyme-tienda',
+      name: 'PyME Tienda Express',
+      type: 'pyme',
+      zones: ['Capital', 'Interior', 'Online', 'Noroeste', 'Litoral'],
+      barrios: ['Comercial', 'Residencial', 'Oficinas', 'Mercado', 'Universidad'],
+    },
+  ];
+
+  const agents = [
+    { id: 'agente-1', name: 'Agente Norte', role: 'operador', team: 'General', tenantIds: ['muni-centro'] },
+    { id: 'agente-2', name: 'Agente Sur', role: 'operador', team: 'General', tenantIds: ['muni-sur'] },
+    { id: 'agente-3', name: 'Agente PyME', role: 'operador', team: 'Ventas', tenantIds: ['pyme-tienda'] },
+    { id: 'agente-4', name: 'Super Admin', role: 'admin', team: 'Coordinación', tenantIds: tenants.map((t) => t.id) },
+  ];
+
+  const categories = [
+    'Alumbrado',
+    'Recolección',
+    'Seguridad',
+    'Transporte',
+    'Salud',
+    'Comercio',
+    'Atención',
+    'Pedidos',
+    'Soporte',
+  ];
+  const states = ['abierto', 'en_progreso', 'derivado', 'resuelto', 'cerrado'];
+  const channels = ['Whatsapp', 'Web', 'App', 'Presencial', 'Telefonico'];
+  const severities = ['baja', 'media', 'alta'];
+  const etiquetas = ['urgente', 'vip', 'reincidente', 'derivado_bot', 'prioridad'];
+
+  const templateCatalog = [
+    'whatsapp_aviso_envio',
+    'whatsapp_confirmacion_pago',
+    'whatsapp_recordatorio',
+    'whatsapp_reengagement',
+  ];
+
+  const products = [
+    { sku: 'sku-101', name: 'Kit PyME Básico', price: 23000 },
+    { sku: 'sku-102', name: 'Kit PyME Premium', price: 43000 },
+    { sku: 'sku-103', name: 'Servicio Mantenimiento', price: 12000 },
+    { sku: 'sku-104', name: 'Consultoría Express', price: 16000 },
+    { sku: 'sku-105', name: 'Licencia Chatbot', price: 8000 },
+  ];
+
+  const now = Date.now();
+  const ninetyDaysMs = 90 * 24 * 60 * 60 * 1000;
+  const tickets = [];
+  const surveys = [];
+  const orders = [];
+  const templateStats = [];
+  const customers = Array.from({ length: 180 }).map((_, index) => ({
+    id: `cliente-${index + 1}`,
+    segment: weightedChoice(rng, [
+      ['nuevo', 1.6],
+      ['recurrente', 1.2],
+      ['premium', 0.6],
+    ]),
+    channelPreference: weightedChoice(rng, [
+      ['Whatsapp', 2.5],
+      ['Web', 1.5],
+      ['App', 1],
+    ]),
+  }));
+
+  const zoneCoordinates = new Map([
+    ['Centro', { lat: -34.6037, lon: -58.3816 }],
+    ['Norte', { lat: -34.5306, lon: -58.4799 }],
+    ['Sur', { lat: -34.6815, lon: -58.3712 }],
+    ['Este', { lat: -34.6032, lon: -58.3312 }],
+    ['Oeste', { lat: -34.6045, lon: -58.4505 }],
+    ['Costanera', { lat: -34.598, lon: -58.362 }],
+    ['Industrial', { lat: -34.6905, lon: -58.4605 }],
+    ['Río', { lat: -34.7001, lon: -58.3611 }],
+    ['Colinas', { lat: -34.7204, lon: -58.4011 }],
+    ['Valle Verde', { lat: -34.735, lon: -58.333 }],
+    ['Puerto', { lat: -34.7033, lon: -58.3201 }],
+    ['Aeropuerto', { lat: -34.8105, lon: -58.5315 }],
+    ['Parque', { lat: -34.7502, lon: -58.4201 }],
+    ['Capital', { lat: -34.6037, lon: -58.3816 }],
+    ['Interior', { lat: -32.8895, lon: -68.8458 }],
+    ['Online', { lat: -34.5201, lon: -58.7001 }],
+    ['Noroeste', { lat: -24.7893, lon: -65.4106 }],
+    ['Litoral', { lat: -27.4515, lon: -58.9865 }],
+  ]);
+
+  function randomDateWithin() {
+    const offset = rng() * ninetyDaysMs;
+    return new Date(now - offset);
+  }
+
+  function randomCellId(zone) {
+    const coord = zoneCoordinates.get(zone) || { lat: -34.6, lon: -58.4 };
+    const latBucket = Math.round(coord.lat * 100);
+    const lonBucket = Math.round(coord.lon * 100);
+    return `h3-${zone}-${latBucket}-${lonBucket}`;
+  }
+
+  for (let i = 0; i < 6000; i += 1) {
+    const tenant = choice(rng, tenants);
+    const createdAt = randomDateWithin();
+    const responseMinutes = Math.floor(rng() * 360);
+    const resolvedMinutes = responseMinutes + Math.floor(rng() * 720);
+    const firstResponseAt = new Date(createdAt.getTime() + responseMinutes * 60 * 1000);
+    const closedAt = new Date(createdAt.getTime() + resolvedMinutes * 60 * 1000);
+    const zone = choice(rng, tenant.zones);
+    const barrio = choice(rng, tenant.barrios);
+    const coords = zoneCoordinates.get(zone) || { lat: -34.6 + rng() * 0.1, lon: -58.4 + rng() * 0.1 };
+    const estado = weightedChoice(rng, [
+      ['abierto', 1],
+      ['en_progreso', 2],
+      ['derivado', 1.5],
+      ['resuelto', 3],
+      ['cerrado', 2.5],
+    ]);
+    const isClosed = ['resuelto', 'cerrado'].includes(estado);
+    const attachments = Math.floor(rng() * 4);
+    const assigned = choice(rng, agents.filter((agent) => agent.tenantIds.includes(tenant.id)));
+    const automated = rng() < (tenant.type === 'pyme' ? 0.35 : 0.25);
+    const reopenedTimes = rng() < 0.12 ? Math.floor(rng() * 3) : 0;
+    const firstContactResolved = rng() < 0.68;
+
+    const ticket = {
+      id: `ticket-${i}-${randomUUID().slice(0, 8)}`,
+      tenantId: tenant.id,
+      canal: choice(rng, channels),
+      categoria: choice(rng, categories),
+      subcategoria: choice(rng, categories),
+      estado,
+      severidad: choice(rng, severities),
+      createdAt: createdAt.toISOString(),
+      firstResponseAt: firstResponseAt.toISOString(),
+      closedAt: isClosed ? closedAt.toISOString() : null,
+      location: {
+        lat: round(coords.lat + (rng() - 0.5) * 0.02, 6),
+        lon: round(coords.lon + (rng() - 0.5) * 0.02, 6),
+        barrio,
+        zona: zone,
+        cellId: randomCellId(zone),
+      },
+      source: automated ? 'bot' : 'humano',
+      adjuntosCount: attachments,
+      etiquetas: etiquetas.filter(() => rng() < 0.2),
+      assignedTo: assigned?.id || null,
+      pymeId: tenant.type === 'pyme' ? tenant.id : null,
+      reopened: reopenedTimes > 0,
+      reopenCount: reopenedTimes,
+      automated,
+      firstContactResolved,
+    };
+
+    tickets.push(ticket);
+
+    const satisfactionType = tenant.type === 'pyme' ? 'NPS' : 'CSAT';
+    const scoreBase = tenant.type === 'pyme' ? 6 + Math.floor(rng() * 5) : 3 + Math.floor(rng() * 3);
+    if (rng() < 0.65) {
+      surveys.push({
+        id: `survey-${i}-${randomUUID().slice(0, 6)}`,
+        tenantId: tenant.id,
+        ticketId: ticket.id,
+        type: satisfactionType,
+        score: Math.min(satisfactionType === 'NPS' ? 10 : 5, Math.max(0, scoreBase + Math.floor(rng() * 3) - 1)),
+        comentario: rng() < 0.2 ? 'Comentario generado automáticamente' : null,
+        timestamp: new Date(createdAt.getTime() + (rng() * resolvedMinutes) * 60 * 1000).toISOString(),
+      });
+    }
+
+    if (tenant.type === 'pyme') {
+      const hasOrder = rng() < 0.7;
+      if (hasOrder) {
+        const orderItems = Array.from({ length: 1 + Math.floor(rng() * 3) }).map(() => {
+          const product = choice(rng, products);
+          const qty = 1 + Math.floor(rng() * 3);
+          return { sku: product.sku, qty, price: product.price };
+        });
+        const total = orderItems.reduce((sum, item) => sum + item.qty * item.price, 0);
+        const orderId = `order-${i}-${randomUUID().slice(0, 6)}`;
+        const customer = choice(rng, customers);
+        orders.push({
+          id: orderId,
+          tenantId: tenant.id,
+          items: orderItems,
+          total,
+          estado: weightedChoice(rng, [
+            ['nuevo', 1.5],
+            ['en_proceso', 2],
+            ['enviado', 1.8],
+            ['entregado', 2.5],
+            ['cancelado', 0.3],
+          ]),
+          canal: weightedChoice(rng, [
+            ['Whatsapp', 2.8],
+            ['Web', 1.5],
+            ['App', 0.9],
+            ['Presencial', 0.8],
+          ]),
+          creadoEn: createdAt.toISOString(),
+          zona: zone,
+          lat: ticket.location.lat,
+          lon: ticket.location.lon,
+          plantillaWhatsApp: choice(rng, templateCatalog),
+          clienteId: customer.id,
+          clienteSegmento: customer.segment,
+        });
+      }
+    }
+  }
+
+  const templatesByTenant = new Map();
+  orders.forEach((order) => {
+    const key = `${order.tenantId}:${order.plantillaWhatsApp}`;
+    if (!templatesByTenant.has(key)) {
+      templatesByTenant.set(key, {
+        tenantId: order.tenantId,
+        plantilla: order.plantillaWhatsApp,
+        envios: 0,
+        entregas: 0,
+        lecturas: 0,
+        respuestas: 0,
+        bloqueos: 0,
+      });
+    }
+    const entry = templatesByTenant.get(key);
+    entry.envios += 1;
+    entry.entregas += 1;
+    entry.lecturas += Math.floor(0.8 * entry.envios + rng() * 5);
+    entry.respuestas += Math.floor(0.45 * entry.envios + rng() * 3);
+    entry.bloqueos += rng() < 0.05 ? 1 : 0;
+  });
+
+  templateCatalog.forEach((tpl) => {
+    tenants
+      .filter((tenant) => tenant.type === 'pyme')
+      .forEach((tenant) => {
+        const key = `${tenant.id}:${tpl}`;
+        if (!templatesByTenant.has(key)) {
+          templatesByTenant.set(key, {
+            tenantId: tenant.id,
+            plantilla: tpl,
+            envios: 5,
+            entregas: 4,
+            lecturas: 3,
+            respuestas: 1,
+            bloqueos: 0,
+          });
+        }
+      });
+  });
+
+  templateStats.push(...templatesByTenant.values());
+
+  const dataset = {
+    generatedAt: new Date().toISOString(),
+    tenants,
+    agents,
+    categories,
+    states,
+    channels,
+    tickets,
+    surveys,
+    orders,
+    templateStats,
+    customers,
+  };
+
+  fs.writeFileSync(DATASET_PATH, JSON.stringify(dataset, null, 2));
+  return dataset;
+}
+
+function loadDataset() {
+  if (fs.existsSync(DATASET_PATH)) {
+    try {
+      const raw = fs.readFileSync(DATASET_PATH, 'utf-8');
+      const parsed = JSON.parse(raw);
+      if (parsed && parsed.tickets && parsed.orders) {
+        return parsed;
+      }
+    } catch (error) {
+      console.warn('[analytics] No se pudo leer el dataset, regenerando', error);
+    }
+  }
+  return generateDataset();
+}
+
+let dataset = loadDataset();
+
+function refreshDataset() {
+  dataset = generateDataset();
+  return dataset;
+}
+
+function getDataset() {
+  return dataset;
+}
+
+module.exports = {
+  getDataset,
+  refreshDataset,
+  DATASET_PATH,
+};

--- a/server/analytics/index.cjs
+++ b/server/analytics/index.cjs
@@ -1,0 +1,14 @@
+const { dispatch } = require('./router.cjs');
+const { ensureContext, buildContextFromHeaders } = require('./context.cjs');
+const { cache } = require('./cache.cjs');
+const { refreshDataset } = require('./dataset.cjs');
+const { getHealth } = require('./resolvers.cjs');
+
+module.exports = {
+  dispatch,
+  ensureContext,
+  buildContextFromHeaders,
+  cache,
+  refreshDataset,
+  getHealth,
+};

--- a/server/analytics/rbac.cjs
+++ b/server/analytics/rbac.cjs
@@ -1,0 +1,20 @@
+const ROLE_HIERARCHY = ['visor', 'operador', 'admin'];
+
+function normalizeRole(role) {
+  if (!role) return 'visor';
+  const normalized = String(role).toLowerCase();
+  if (ROLE_HIERARCHY.includes(normalized)) return normalized;
+  return 'visor';
+}
+
+function authorize(role, requiredRole) {
+  const normalizedRole = normalizeRole(role);
+  const normalizedRequired = normalizeRole(requiredRole);
+  return ROLE_HIERARCHY.indexOf(normalizedRole) >= ROLE_HIERARCHY.indexOf(normalizedRequired);
+}
+
+module.exports = {
+  ROLE_HIERARCHY,
+  normalizeRole,
+  authorize,
+};

--- a/server/analytics/resolvers.cjs
+++ b/server/analytics/resolvers.cjs
@@ -1,0 +1,676 @@
+const { getDataset } = require('./dataset.cjs');
+const { formatDate, percentile, average, sum, groupBy, clamp } = require('./utils.cjs');
+
+const CLOSED_STATES = new Set(['resuelto', 'cerrado']);
+
+function normalizeRange(from, to) {
+  const start = new Date(from);
+  start.setHours(0, 0, 0, 0);
+  const end = new Date(to);
+  end.setHours(23, 59, 59, 999);
+  return { start, end };
+}
+
+function matchesFilter(value, selected) {
+  if (!selected || selected.length === 0) return true;
+  return selected.includes(value);
+}
+
+function matchesTags(ticketTags, selectedTags) {
+  if (!selectedTags || selectedTags.length === 0) return true;
+  if (!ticketTags || ticketTags.length === 0) return false;
+  return ticketTags.some((tag) => selectedTags.includes(tag));
+}
+
+function matchesSearch(ticket, search) {
+  if (!search) return true;
+  const target = search.toLowerCase();
+  return (
+    String(ticket.id).toLowerCase().includes(target) ||
+    (ticket.location?.barrio || '').toLowerCase().includes(target) ||
+    (ticket.location?.zona || '').toLowerCase().includes(target)
+  );
+}
+
+function withinBbox(location, bbox) {
+  if (!bbox) return true;
+  if (!location) return false;
+  const [minLon, minLat, maxLon, maxLat] = bbox;
+  return (
+    location.lon >= minLon &&
+    location.lon <= maxLon &&
+    location.lat >= minLat &&
+    location.lat <= maxLat
+  );
+}
+
+function filterTickets(filters) {
+  const dataset = getDataset();
+  const { start, end } = normalizeRange(filters.from, filters.to);
+  const startMs = start.getTime();
+  const endMs = end.getTime();
+  const agentDirectory = new Map(dataset.agents.map((agent) => [agent.id, agent.name]));
+  const tickets = dataset.tickets.filter((ticket) => {
+    if (ticket.tenantId !== filters.tenantId) return false;
+    const createdAt = new Date(ticket.createdAt).getTime();
+    if (createdAt < startMs || createdAt > endMs) return false;
+    if (!matchesFilter(ticket.canal, filters.canal)) return false;
+    if (!matchesFilter(ticket.categoria, filters.categoria)) return false;
+    if (!matchesFilter(ticket.estado, filters.estado)) return false;
+    if (filters.agente && filters.agente.length) {
+      const agentName = ticket.assignedTo ? agentDirectory.get(ticket.assignedTo) : 'Sin asignar';
+      const matchesAgent = filters.agente.some((value) => {
+        if (value === 'Sin asignar') {
+          return !ticket.assignedTo;
+        }
+        if (!ticket.assignedTo) return false;
+        return value === ticket.assignedTo || value === agentName;
+      });
+      if (!matchesAgent) return false;
+    }
+    if (!matchesFilter(ticket.location?.zona, filters.zona)) return false;
+    if (!matchesTags(ticket.etiquetas, filters.etiquetas)) return false;
+    if (!matchesSearch(ticket, filters.search)) return false;
+    if (!withinBbox(ticket.location, filters.bbox)) return false;
+    return true;
+  });
+  return { dataset, tickets, start, end };
+}
+
+function filterOrders(filters) {
+  const dataset = getDataset();
+  const { start, end } = normalizeRange(filters.from, filters.to);
+  const startMs = start.getTime();
+  const endMs = end.getTime();
+  const orders = dataset.orders.filter((order) => {
+    if (order.tenantId !== filters.tenantId) return false;
+    const createdAt = new Date(order.creadoEn).getTime();
+    if (createdAt < startMs || createdAt > endMs) return false;
+    if (!matchesFilter(order.canal, filters.canal)) return false;
+    if (!matchesFilter(order.zona, filters.zona)) return false;
+    if (!withinBbox({ lat: order.lat, lon: order.lon }, filters.bbox)) return false;
+    return true;
+  });
+  return { dataset, orders, start, end };
+}
+
+function filterSurveys(filters) {
+  const dataset = getDataset();
+  const { start, end } = normalizeRange(filters.from, filters.to);
+  const startMs = start.getTime();
+  const endMs = end.getTime();
+  const surveys = dataset.surveys.filter((survey) => {
+    if (survey.tenantId !== filters.tenantId) return false;
+    const timestamp = new Date(survey.timestamp).getTime();
+    if (timestamp < startMs || timestamp > endMs) return false;
+    if (!matchesFilter(survey.type, filters.metric === 'nps' ? ['NPS'] : filters.metric === 'csat' ? ['CSAT'] : [])) {
+      // Accept all if no specific metric requested
+    }
+    return true;
+  });
+  return { dataset, surveys };
+}
+
+function computeSlaBuckets(tickets) {
+  const ackMinutes = [];
+  const resolveMinutes = [];
+  tickets.forEach((ticket) => {
+    const createdAt = new Date(ticket.createdAt).getTime();
+    if (ticket.firstResponseAt) {
+      ackMinutes.push((new Date(ticket.firstResponseAt).getTime() - createdAt) / (1000 * 60));
+    }
+    if (ticket.closedAt) {
+      resolveMinutes.push((new Date(ticket.closedAt).getTime() - createdAt) / (1000 * 60));
+    }
+  });
+  const build = (values) => ({
+    p50: clamp(percentile(values, 50), 0, Infinity),
+    p90: clamp(percentile(values, 90), 0, Infinity),
+    p95: clamp(percentile(values, 95), 0, Infinity),
+  });
+  return {
+    ack: build(ackMinutes),
+    resolve: build(resolveMinutes),
+  };
+}
+
+function computeVolumeSeries(tickets) {
+  const perDay = new Map();
+  tickets.forEach((ticket) => {
+    const date = formatDate(new Date(ticket.createdAt));
+    if (!perDay.has(date)) perDay.set(date, 0);
+    perDay.set(date, perDay.get(date) + 1);
+  });
+  return Array.from(perDay.entries())
+    .sort(([a], [b]) => (a < b ? -1 : 1))
+    .map(([date, value]) => ({ date, value }));
+}
+
+function computeBreakdown(tickets, key) {
+  const map = new Map();
+  tickets.forEach((ticket) => {
+    const label = key(ticket);
+    if (!label) return;
+    if (!map.has(label)) map.set(label, 0);
+    map.set(label, map.get(label) + 1);
+  });
+  return Array.from(map.entries())
+    .sort(([, a], [, b]) => b - a)
+    .map(([label, value]) => ({ label, value }));
+}
+
+function computeQuality(tickets, surveys, dataset) {
+  const byType = new Map();
+  surveys.forEach((survey) => {
+    const label = survey.type;
+    if (!byType.has(label)) {
+      byType.set(label, { total: 0, count: 0 });
+    }
+    const record = byType.get(label);
+    record.total += survey.score;
+    record.count += 1;
+  });
+
+  const byAgent = new Map();
+  const surveyByTicket = new Map();
+  surveys.forEach((survey) => {
+    if (survey.ticketId) {
+      surveyByTicket.set(survey.ticketId, survey);
+    }
+  });
+
+  tickets.forEach((ticket) => {
+    if (!ticket.assignedTo) return;
+    const survey = surveyByTicket.get(ticket.id);
+    if (!survey) return;
+    if (!byAgent.has(ticket.assignedTo)) {
+      byAgent.set(ticket.assignedTo, { total: 0, count: 0 });
+    }
+    const record = byAgent.get(ticket.assignedTo);
+    record.total += survey.score;
+    record.count += 1;
+  });
+
+  const agentById = new Map(dataset.agents.map((agent) => [agent.id, agent.name]));
+
+  return {
+    byType: Array.from(byType.entries()).map(([label, record]) => ({
+      label,
+      average: record.count ? Number((record.total / record.count).toFixed(2)) : 0,
+      responses: record.count,
+    })),
+    byAgent: Array.from(byAgent.entries()).map(([agentId, record]) => ({
+      label: agentById.get(agentId) || agentId,
+      average: record.count ? Number((record.total / record.count).toFixed(2)) : 0,
+      responses: record.count,
+    })),
+  };
+}
+
+function computePymeMetrics(filters) {
+  const { orders, dataset } = filterOrders(filters);
+  if (!orders.length) {
+    return {
+      totalOrders: 0,
+      ticketMedio: 0,
+      ingresos: [],
+      topProductos: [],
+      conversion: 0,
+      recurrencia: { d30: 0, d60: 0, d90: 0 },
+      horasPico: [],
+      canales: [],
+      plantillas: [],
+    };
+  }
+
+  const ingresos = new Map();
+  const productos = new Map();
+  const canales = new Map();
+  const horas = new Map();
+  const ordersByCustomer = new Map();
+
+  orders.forEach((order) => {
+    const date = formatDate(new Date(order.creadoEn));
+    ingresos.set(date, (ingresos.get(date) || 0) + order.total);
+    canales.set(order.canal, (canales.get(order.canal) || 0) + 1);
+    const hour = new Date(order.creadoEn).getHours();
+    horas.set(hour, (horas.get(hour) || 0) + 1);
+    if (order.clienteId) {
+      if (!ordersByCustomer.has(order.clienteId)) {
+        ordersByCustomer.set(order.clienteId, []);
+      }
+      ordersByCustomer.get(order.clienteId).push(new Date(order.creadoEn));
+    }
+    order.items.forEach((item) => {
+      productos.set(item.sku, (productos.get(item.sku) || 0) + item.qty);
+    });
+  });
+
+  const recurrencia = { d30: 0, d60: 0, d90: 0 };
+  ordersByCustomer.forEach((dates) => {
+    dates.sort((a, b) => a.getTime() - b.getTime());
+    const first = dates[0];
+    const counts = dates.length;
+    if (counts < 2) return;
+    const windows = [30, 60, 90];
+    windows.forEach((days) => {
+      const limit = new Date(first.getTime() + days * 24 * 60 * 60 * 1000);
+      const inWindow = dates.filter((date) => date <= limit).length;
+      if (inWindow >= 2) {
+        if (days === 30) recurrencia.d30 += 1;
+        if (days === 60) recurrencia.d60 += 1;
+        if (days === 90) recurrencia.d90 += 1;
+      }
+    });
+  });
+
+  const totalOrders = orders.length;
+  const conversionBase = dataset.tickets.filter((ticket) => ticket.tenantId === filters.tenantId).length;
+  const conversion = conversionBase ? Number(((totalOrders / conversionBase) * 100).toFixed(2)) : 0;
+  const plantillaStats = dataset.templateStats
+    .filter((item) => item.tenantId === filters.tenantId)
+    .map((item) => ({
+      plantilla: item.plantilla,
+      envios: item.envios,
+      respuestas: item.respuestas,
+      bloqueos: item.bloqueos,
+      ctr: item.envios ? Number(((item.respuestas / item.envios) * 100).toFixed(2)) : 0,
+    }));
+
+  return {
+    totalOrders,
+    ticketMedio: Number((sum(orders.map((order) => order.total)) / totalOrders).toFixed(2)),
+    ingresos: Array.from(ingresos.entries())
+      .sort(([a], [b]) => (a < b ? -1 : 1))
+      .map(([date, value]) => ({ date, value: Number(value.toFixed(2)) })),
+    topProductos: Array.from(productos.entries())
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, 20)
+      .map(([sku, value]) => ({ label: sku, value })),
+    conversion,
+    recurrencia,
+    horasPico: Array.from(horas.entries())
+      .sort(([a], [b]) => a - b)
+      .map(([hour, value]) => ({ hour, value })),
+    canales: Array.from(canales.entries())
+      .sort(([, a], [, b]) => b - a)
+      .map(([label, value]) => ({ label, value })),
+    plantillas: plantillaStats,
+  };
+}
+
+function getSummary(filters) {
+  const { dataset, tickets } = filterTickets(filters);
+  const { surveys } = filterSurveys(filters);
+  const sla = computeSlaBuckets(tickets);
+  const openTickets = tickets.filter((ticket) => !CLOSED_STATES.has(ticket.estado));
+  const backlogThreshold = Date.now() - 72 * 60 * 60 * 1000;
+  const backlog = openTickets.filter((ticket) => new Date(ticket.createdAt).getTime() < backlogThreshold).length;
+  const adjuntos = sum(tickets.map((ticket) => ticket.adjuntosCount || 0));
+
+  const efficiency = {
+    firstContact: tickets.length
+      ? Number(((tickets.filter((ticket) => ticket.firstContactResolved).length / tickets.length) * 100).toFixed(2))
+      : 0,
+    reopenRate: tickets.length
+      ? Number(((tickets.filter((ticket) => ticket.reopened).length / tickets.length) * 100).toFixed(2))
+      : 0,
+    automationRate: tickets.length
+      ? Number(((tickets.filter((ticket) => ticket.automated).length / tickets.length) * 100).toFixed(2))
+      : 0,
+  };
+
+  const volume = {
+    perDay: computeVolumeSeries(tickets),
+    byChannel: computeBreakdown(tickets, (ticket) => ticket.canal),
+    byCategory: computeBreakdown(tickets, (ticket) => ticket.categoria),
+    byZone: computeBreakdown(tickets, (ticket) => ticket.location?.zona || 'Sin zona'),
+  };
+
+  const quality = computeQuality(tickets, surveys, dataset);
+  const pyme = dataset.tenants.find((tenant) => tenant.id === filters.tenantId && tenant.type === 'pyme')
+    ? computePymeMetrics(filters)
+    : {
+        totalOrders: 0,
+        ticketMedio: 0,
+        ingresos: [],
+        topProductos: [],
+        conversion: 0,
+        recurrencia: { d30: 0, d60: 0, d90: 0 },
+        horasPico: [],
+        canales: [],
+        plantillas: [],
+      };
+
+  return {
+    generatedAt: new Date().toISOString(),
+    tenantId: filters.tenantId,
+    totals: {
+      tickets: tickets.length,
+      abiertos: openTickets.length,
+      backlog,
+      adjuntos,
+    },
+    sla,
+    efficiency,
+    volume,
+    quality,
+    pyme,
+  };
+}
+
+function getTimeseries(filters) {
+  const { tickets } = filterTickets(filters);
+  const seriesMap = new Map();
+  tickets.forEach((ticket) => {
+    const date = formatDate(new Date(ticket.createdAt));
+    if (!seriesMap.has(date)) {
+      seriesMap.set(date, { value: 0, breakdown: {} });
+    }
+    const record = seriesMap.get(date);
+    record.value += 1;
+    if (filters.group) {
+      const key = String(ticket[filters.group]) || 'Sin dato';
+      record.breakdown[key] = (record.breakdown[key] || 0) + 1;
+    }
+  });
+  return {
+    metric: filters.metric,
+    group: filters.group,
+    series: Array.from(seriesMap.entries())
+      .sort(([a], [b]) => (a < b ? -1 : 1))
+      .map(([date, record]) => ({ date, value: record.value, breakdown: record.breakdown })),
+  };
+}
+
+function getBreakdown(filters) {
+  const { tickets, dataset } = filterTickets(filters);
+  let dimensionGetter;
+  switch (filters.dimension) {
+    case 'categoria':
+      dimensionGetter = (ticket) => ticket.categoria;
+      break;
+    case 'canal':
+      dimensionGetter = (ticket) => ticket.canal;
+      break;
+    case 'estado':
+      dimensionGetter = (ticket) => ticket.estado;
+      break;
+    case 'agente':
+      dimensionGetter = (ticket) => dataset.agents.find((agent) => agent.id === ticket.assignedTo)?.name || 'Sin asignar';
+      break;
+    case 'zona':
+      dimensionGetter = (ticket) => ticket.location?.zona || 'Sin zona';
+      break;
+    default:
+      dimensionGetter = (ticket) => ticket[filters.dimension] || 'Sin dato';
+  }
+  return {
+    dimension: filters.dimension,
+    items: computeBreakdown(tickets, dimensionGetter),
+  };
+}
+
+function getHeatmap(filters) {
+  const { tickets } = filterTickets(filters);
+  const cells = new Map();
+  const breakdownByZone = new Map();
+  const weeklyByZone = new Map();
+
+  tickets.forEach((ticket) => {
+    const cellId = ticket.location?.cellId || 'cell-desconocido';
+    if (!cells.has(cellId)) {
+      cells.set(cellId, {
+        cellId,
+        tenant_id: ticket.tenantId,
+        count: 0,
+        centroid_lat: ticket.location?.lat || 0,
+        centroid_lon: ticket.location?.lon || 0,
+        breakdown: {},
+      });
+    }
+    const cell = cells.get(cellId);
+    cell.count += 1;
+    const category = ticket.categoria || 'Sin categoria';
+    cell.breakdown[category] = (cell.breakdown[category] || 0) + 1;
+
+    const zone = ticket.location?.zona || 'Sin zona';
+    breakdownByZone.set(zone, (breakdownByZone.get(zone) || 0) + 1);
+
+    const weekKey = `${zone}-${formatDate(new Date(ticket.createdAt))}`;
+    weeklyByZone.set(weekKey, (weeklyByZone.get(weekKey) || 0) + 1);
+  });
+
+  const hotspots = Array.from(cells.values())
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 10)
+    .map((cell) => ({
+      cellId: cell.cellId,
+      count: cell.count,
+      centroid: [cell.centroid_lat, cell.centroid_lon],
+      breakdown: cell.breakdown,
+    }));
+
+  const chronic = [];
+  const zoneWeeks = groupBy(Array.from(weeklyByZone.entries()), ([key]) => key.split('-')[0]);
+  zoneWeeks.forEach((entries, zone) => {
+    const weeks = entries
+      .map(([key, count]) => ({ week: key.split('-').slice(1).join('-'), count }))
+      .sort((a, b) => (a.week < b.week ? -1 : 1));
+    const chronicWeeks = weeks.filter((week) => week.count >= 3);
+    if (chronicWeeks.length >= 4) {
+      chronic.push({ zone, weeks: chronicWeeks });
+    }
+  });
+
+  return {
+    cells: Array.from(cells.values()),
+    hotspots,
+    chronic,
+  };
+}
+
+function getPoints(filters) {
+  const { tickets } = filterTickets(filters);
+  const sample = tickets.slice(0, 250);
+  return {
+    points: sample.map((ticket) => ({
+      cellId: ticket.location?.cellId || 'cell-desconocido',
+      lat: ticket.location?.lat || 0,
+      lon: ticket.location?.lon || 0,
+      categoria: ticket.categoria,
+      estado: ticket.estado,
+    })),
+  };
+}
+
+function getTop(filters) {
+  const { tickets } = filterTickets(filters);
+  if (filters.subject === 'zonas') {
+    return {
+      subject: 'zonas',
+      items: computeBreakdown(tickets, (ticket) => ticket.location?.zona || 'Sin zona').slice(0, 20),
+    };
+  }
+  if (filters.subject === 'barrios') {
+    return {
+      subject: 'barrios',
+      items: computeBreakdown(tickets, (ticket) => ticket.location?.barrio || 'Sin barrio').slice(0, 20),
+    };
+  }
+  return {
+    subject: filters.subject,
+    items: computeBreakdown(tickets, (ticket) => ticket[filters.subject] || 'Sin dato').slice(0, 20),
+  };
+}
+
+function getOperations(filters) {
+  const { dataset, tickets } = filterTickets(filters);
+  const openTickets = tickets.filter((ticket) => !CLOSED_STATES.has(ticket.estado));
+  const slaBreaches = openTickets.filter((ticket) => {
+    const createdAt = new Date(ticket.createdAt).getTime();
+    const firstResponse = ticket.firstResponseAt ? new Date(ticket.firstResponseAt).getTime() : null;
+    const now = Date.now();
+    const ackExceeded = firstResponse ? firstResponse - createdAt > 4 * 60 * 60 * 1000 : now - createdAt > 4 * 60 * 60 * 1000;
+    const resolveExceeded = now - createdAt > 48 * 60 * 60 * 1000;
+    return ackExceeded || resolveExceeded;
+  }).length;
+
+  const automated = openTickets.filter((ticket) => ticket.automated).length;
+  const automationRate = openTickets.length ? Number(((automated / openTickets.length) * 100).toFixed(2)) : 0;
+
+  const agingBuckets = {
+    '0-4h': 0,
+    '4-24h': 0,
+    '1-3d': 0,
+    '3-7d': 0,
+    '+7d': 0,
+  };
+  const now = Date.now();
+  openTickets.forEach((ticket) => {
+    const ageHours = (now - new Date(ticket.createdAt).getTime()) / (1000 * 60 * 60);
+    if (ageHours <= 4) agingBuckets['0-4h'] += 1;
+    else if (ageHours <= 24) agingBuckets['4-24h'] += 1;
+    else if (ageHours <= 72) agingBuckets['1-3d'] += 1;
+    else if (ageHours <= 168) agingBuckets['3-7d'] += 1;
+    else agingBuckets['+7d'] += 1;
+  });
+
+  const agentStats = new Map();
+  openTickets.forEach((ticket) => {
+    const agentId = ticket.assignedTo || 'sin_asignar';
+    if (!agentStats.has(agentId)) {
+      agentStats.set(agentId, { abiertos: 0, tiempoTotal: 0, satisfaccion: [] });
+    }
+    const record = agentStats.get(agentId);
+    record.abiertos += 1;
+    record.tiempoTotal += now - new Date(ticket.createdAt).getTime();
+  });
+
+  const surveys = getDataset().surveys.filter((survey) => survey.tenantId === filters.tenantId);
+  surveys.forEach((survey) => {
+    const ticket = tickets.find((item) => item.id === survey.ticketId);
+    if (!ticket || !ticket.assignedTo) return;
+    const agentId = ticket.assignedTo;
+    if (!agentStats.has(agentId)) {
+      agentStats.set(agentId, { abiertos: 0, tiempoTotal: 0, satisfaccion: [] });
+    }
+    agentStats.get(agentId).satisfaccion.push(survey.score);
+  });
+
+  const agentDirectory = new Map(dataset.agents.map((agent) => [agent.id, agent.name]));
+
+  const agents = Array.from(agentStats.entries()).map(([agentId, record]) => ({
+    agente: agentDirectory.get(agentId) || agentId,
+    abiertos: record.abiertos,
+    tiempoMedio: record.abiertos
+      ? Number((record.tiempoTotal / record.abiertos / (1000 * 60 * 60)).toFixed(2))
+      : 0,
+    satisfaccion: record.satisfaccion.length
+      ? Number((average(record.satisfaccion)).toFixed(2))
+      : 0,
+  }));
+
+  return {
+    abiertos: openTickets.length,
+    slaBreaches,
+    automated,
+    automationRate,
+    agingBuckets,
+    agents,
+  };
+}
+
+function getCohorts(filters) {
+  const { orders } = filterOrders(filters);
+  const cohorts = new Map();
+  const customers = new Map();
+  orders.forEach((order) => {
+    const month = formatDate(new Date(order.creadoEn)).slice(0, 7);
+    if (!customers.has(order.clienteId)) {
+      customers.set(order.clienteId, month);
+    }
+    const cohort = customers.get(order.clienteId);
+    if (!cohorts.has(cohort)) {
+      cohorts.set(cohort, { pedidos: 0, ingresos: 0 });
+    }
+    const record = cohorts.get(cohort);
+    record.pedidos += 1;
+    record.ingresos += order.total;
+  });
+  return {
+    cohorts: Array.from(cohorts.entries())
+      .sort(([a], [b]) => (a < b ? -1 : 1))
+      .map(([cohort, data]) => ({ cohort, pedidos: data.pedidos, ingresos: Number(data.ingresos.toFixed(2)) })),
+  };
+}
+
+function getTemplates(filters) {
+  const dataset = getDataset();
+  const templates = dataset.templateStats
+    .filter((template) => template.tenantId === filters.tenantId)
+    .map((template) => ({
+      plantilla: template.plantilla,
+      envios: template.envios,
+      respuestas: template.respuestas,
+      bloqueos: template.bloqueos,
+      ctr: template.envios ? Number(((template.respuestas / template.envios) * 100).toFixed(2)) : 0,
+    }));
+  return { templates };
+}
+
+function getFilters(filters, req) {
+  const dataset = getDataset();
+  const tenant = dataset.tenants.find((item) => item.id === filters.tenantId);
+  const tenantTickets = dataset.tickets.filter((ticket) => ticket.tenantId === filters.tenantId);
+  return {
+    canales: Array.from(new Set(tenantTickets.map((ticket) => ticket.canal))).sort(),
+    categorias: Array.from(new Set(tenantTickets.map((ticket) => ticket.categoria))).sort(),
+    estados: Array.from(new Set(tenantTickets.map((ticket) => ticket.estado))).sort(),
+    agentes: (() => {
+      const set = new Set(
+        tenantTickets
+          .map((ticket) => ticket.assignedTo)
+          .filter(Boolean)
+          .map((agentId) => dataset.agents.find((agent) => agent.id === agentId)?.name || agentId),
+      );
+      if (tenantTickets.some((ticket) => !ticket.assignedTo)) {
+        set.add('Sin asignar');
+      }
+      return Array.from(set).sort();
+    })(),
+    zonas: Array.from(new Set(tenantTickets.map((ticket) => ticket.location?.zona).filter(Boolean))).sort(),
+    etiquetas: Array.from(new Set(tenantTickets.flatMap((ticket) => ticket.etiquetas || []))).sort(),
+    tenants: req.allowedTenants && req.allowedTenants.length ? req.allowedTenants : dataset.tenants.map((item) => item.id),
+    defaultTenantId: req.defaultTenant || (tenant ? tenant.id : null),
+    defaultContext: tenant?.type === 'pyme' ? 'pyme' : 'municipio',
+    contexts: ['municipio', 'pyme', 'operaciones'],
+  };
+}
+
+function getHealth() {
+  const dataset = getDataset();
+  return {
+    generatedAt: dataset.generatedAt,
+    totals: {
+      tenants: dataset.tenants.length,
+      tickets: dataset.tickets.length,
+      orders: dataset.orders.length,
+      surveys: dataset.surveys.length,
+    },
+  };
+}
+
+module.exports = {
+  getSummary,
+  getTimeseries,
+  getBreakdown,
+  getHeatmap,
+  getPoints,
+  getTop,
+  getOperations,
+  getCohorts,
+  getTemplates,
+  getFilters,
+  getHealth,
+};

--- a/server/analytics/router.cjs
+++ b/server/analytics/router.cjs
@@ -1,0 +1,134 @@
+const { parseFilters } = require('./schema.cjs');
+const { authorize } = require('./rbac.cjs');
+const { cache } = require('./cache.cjs');
+const {
+  getSummary,
+  getTimeseries,
+  getBreakdown,
+  getHeatmap,
+  getPoints,
+  getTop,
+  getOperations,
+  getCohorts,
+  getTemplates,
+  getFilters,
+  getHealth,
+} = require('./resolvers.cjs');
+
+function trackRequest(durationMs, context = {}) {
+  const payload = { durationMs, ...context };
+  if (durationMs > 3000) {
+    console.warn('[analytics] Request slow', payload);
+  } else {
+    console.log('[analytics] Request', payload);
+  }
+}
+
+function trackError(error, context = {}) {
+  console.error('[analytics] Error', { message: error.message, stack: error.stack, ...context });
+}
+
+function buildCacheKey(filters, role) {
+  return JSON.stringify({ filters: { ...filters, from: filters.from.toISOString(), to: filters.to.toISOString() }, role });
+}
+
+function sanitizeForRole(role, payload) {
+  if (role === 'admin') return payload;
+  return payload;
+}
+
+function canAccessTenant(req, tenantId) {
+  if (!tenantId) return false;
+  if (req.analyticsRole === 'admin') return true;
+
+  const allowedTenants = Array.isArray(req.allowedTenants) ? req.allowedTenants : [];
+  if (allowedTenants.length > 0) {
+    return allowedTenants.includes(tenantId);
+  }
+
+  if (req.defaultTenant) {
+    return req.defaultTenant === tenantId;
+  }
+
+  return false;
+}
+
+function createHandler({ requiredRole = 'visor', resolver }) {
+  return async (req) => {
+    const start = Date.now();
+    let filters;
+    try {
+      filters = parseFilters(req);
+    } catch (error) {
+      trackError(error, { stage: 'parseFilters', path: req.path });
+      return { status: 400, body: { message: error.message } };
+    }
+
+    const role = req.analyticsRole;
+    if (!authorize(role, requiredRole)) {
+      return { status: 403, body: { message: 'Permiso insuficiente' } };
+    }
+
+    if (!canAccessTenant(req, filters.tenantId)) {
+      return { status: 403, body: { message: 'El tenant solicitado no está autorizado para esta sesión' } };
+    }
+
+    const cacheKey = buildCacheKey(filters, role);
+    const cached = cache.get(cacheKey);
+    if (cached) {
+      trackRequest(Date.now() - start, { cacheHit: true, endpoint: req.path });
+      return { status: 200, body: cached };
+    }
+
+    try {
+      const payload = await resolver(filters, req);
+      const sanitized = sanitizeForRole(role, payload);
+      cache.set(cacheKey, sanitized);
+      trackRequest(Date.now() - start, { endpoint: req.path });
+      return { status: 200, body: sanitized };
+    } catch (error) {
+      trackError(error, { endpoint: req.path });
+      return { status: 500, body: { message: 'Error interno en el módulo de analítica' } };
+    }
+  };
+}
+
+const routes = new Map();
+
+function register(path, options) {
+  routes.set(path, createHandler(options));
+}
+
+register('/summary', { resolver: getSummary });
+register('/timeseries', { resolver: getTimeseries });
+register('/breakdown', { resolver: getBreakdown });
+register('/geo/heatmap', { resolver: getHeatmap });
+register('/geo/points', { resolver: getPoints });
+register('/top', { resolver: getTop });
+register('/operations', { requiredRole: 'operador', resolver: getOperations });
+register('/cohorts', { requiredRole: 'operador', resolver: getCohorts });
+register('/whatsapp/templates', { requiredRole: 'operador', resolver: getTemplates });
+register('/filters', { resolver: getFilters });
+
+async function dispatch(req) {
+  const handler = routes.get(req.path);
+  if (!handler) {
+    if (req.path === '/health') {
+      try {
+        const payload = getHealth();
+        return { status: 200, body: { status: 'ok', ...payload } };
+      } catch (error) {
+        trackError(error, { endpoint: '/analytics/health' });
+        return { status: 500, body: { status: 'error', message: error.message } };
+      }
+    }
+    return { status: 404, body: { message: 'No se encontró el recurso solicitado' } };
+  }
+  return handler(req);
+}
+
+module.exports = {
+  dispatch,
+  canAccessTenant,
+  createHandler,
+};

--- a/server/analytics/schema.cjs
+++ b/server/analytics/schema.cjs
@@ -1,0 +1,66 @@
+const { normalizeRole } = require('./rbac.cjs');
+
+function parseDate(value, field) {
+  if (!value) throw new Error(`Falta el parámetro obligatorio ${field}`);
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`El parámetro ${field} no tiene un formato de fecha válido`);
+  }
+  return date;
+}
+
+function parseStringArray(value) {
+  if (!value) return [];
+  return String(value)
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function parseBbox(value) {
+  if (!value) return null;
+  const parts = String(value)
+    .split(',')
+    .map((part) => Number(part.trim()));
+  if (parts.length !== 4 || parts.some((part) => Number.isNaN(part))) {
+    throw new Error('El parámetro bbox debe incluir cuatro números (minLon,minLat,maxLon,maxLat)');
+  }
+  return parts;
+}
+
+function parseFilters(req) {
+  const { query } = req;
+  const tenantId = query.tenant_id || query.tenantId;
+  if (!tenantId || typeof tenantId !== 'string') {
+    throw new Error('El parámetro tenant_id es obligatorio');
+  }
+  const from = parseDate(query.from, 'from');
+  const to = parseDate(query.to, 'to');
+  if (to.getTime() < from.getTime()) {
+    throw new Error('El rango de fechas es inválido: to debe ser mayor o igual a from');
+  }
+
+  return {
+    tenantId,
+    from,
+    to,
+    canal: parseStringArray(query.canal),
+    categoria: parseStringArray(query.categoria),
+    estado: parseStringArray(query.estado),
+    agente: parseStringArray(query.agente),
+    zona: parseStringArray(query.zona),
+    etiquetas: parseStringArray(query.etiquetas),
+    metric: query.metric ? String(query.metric) : 'tickets_total',
+    group: query.group ? String(query.group) : null,
+    dimension: query.dimension ? String(query.dimension) : 'categoria',
+    subject: query.subject ? String(query.subject) : 'zonas',
+    bbox: parseBbox(query.bbox),
+    context: query.context ? String(query.context) : null,
+    search: query.search ? String(query.search) : null,
+    role: normalizeRole(req.analyticsRole),
+  };
+}
+
+module.exports = {
+  parseFilters,
+};

--- a/server/analytics/utils.cjs
+++ b/server/analytics/utils.cjs
@@ -1,0 +1,60 @@
+function formatDate(date) {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function toHours(deltaMs) {
+  return deltaMs / (1000 * 60 * 60);
+}
+
+function toMinutes(deltaMs) {
+  return deltaMs / (1000 * 60);
+}
+
+function percentile(values, p) {
+  if (!values.length) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const rank = (p / 100) * (sorted.length - 1);
+  const low = Math.floor(rank);
+  const high = Math.ceil(rank);
+  if (low === high) return sorted[low];
+  const weight = rank - low;
+  return sorted[low] + (sorted[high] - sorted[low]) * weight;
+}
+
+function average(values) {
+  if (!values.length) return 0;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function sum(values) {
+  return values.reduce((acc, value) => acc + value, 0);
+}
+
+function groupBy(list, iteratee) {
+  return list.reduce((acc, item) => {
+    const key = iteratee(item);
+    if (!acc.has(key)) {
+      acc.set(key, []);
+    }
+    acc.get(key).push(item);
+    return acc;
+  }, new Map());
+}
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+module.exports = {
+  formatDate,
+  toHours,
+  toMinutes,
+  percentile,
+  average,
+  sum,
+  groupBy,
+  clamp,
+};

--- a/server/app.cjs
+++ b/server/app.cjs
@@ -1,0 +1,86 @@
+const http = require('node:http');
+const { URL } = require('node:url');
+const { dispatch, buildContextFromHeaders, cache, getHealth } = require('./analytics');
+
+function toQueryObject(searchParams) {
+  const query = {};
+  for (const [key, value] of searchParams.entries()) {
+    query[key] = value;
+  }
+  return query;
+}
+
+function applyCors(res, origin) {
+  res.setHeader('Access-Control-Allow-Origin', origin || '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type,Authorization,X-Analytics-Role,X-Analytics-Tenant-Ids,X-Tenant-Ids,X-Allowed-Tenants,X-Default-Tenant');
+}
+
+function sendJson(res, status, body, origin) {
+  applyCors(res, origin);
+  res.statusCode = status;
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  res.end(JSON.stringify(body));
+}
+
+function createServer() {
+  const server = http.createServer(async (req, res) => {
+    const origin = req.headers.origin || '*';
+    if (req.method === 'OPTIONS') {
+      applyCors(res, origin);
+      res.statusCode = 204;
+      res.end();
+      return;
+    }
+
+    const parsedUrl = new URL(req.url || '/', `http://${req.headers.host || 'localhost'}`);
+    const pathname = parsedUrl.pathname;
+
+    if (pathname === '/healthz') {
+      try {
+        const payload = getHealth();
+        sendJson(res, 200, { status: 'ok', ...payload, cache: cache.stats() }, origin);
+      } catch (error) {
+        sendJson(res, 500, { status: 'error', message: error.message }, origin);
+      }
+      return;
+    }
+
+    if (!pathname.startsWith('/analytics')) {
+      sendJson(res, 200, { status: 'ok', message: 'Analytics module activo' }, origin);
+      return;
+    }
+
+    const context = buildContextFromHeaders(req.headers);
+    const query = toQueryObject(parsedUrl.searchParams);
+    const path = pathname.slice('/analytics'.length) || '/';
+    const request = {
+      method: req.method,
+      path,
+      query,
+      headers: req.headers,
+      analyticsRole: context.analyticsRole,
+      allowedTenants: context.allowedTenants,
+      defaultTenant: context.defaultTenant,
+    };
+
+    try {
+      const result = await dispatch(request);
+      sendJson(res, result.status, result.body, origin);
+    } catch (error) {
+      console.error('[analytics] Error inesperado', error);
+      sendJson(res, 500, { message: 'Error inesperado en el servidor de analítica' }, origin);
+    }
+  });
+
+  return server;
+}
+
+if (require.main === module) {
+  const port = Number(process.env.PORT || 4000);
+  createServer().listen(port, () => {
+    console.log(`[analytics] Servidor escuchando en el puerto ${port}`);
+  });
+}
+
+module.exports = createServer;

--- a/src/components/analytics/AnalyticsFilterBar.tsx
+++ b/src/components/analytics/AnalyticsFilterBar.tsx
@@ -1,0 +1,207 @@
+import { useMemo } from 'react';
+import { addDays } from 'date-fns';
+import { CalendarIcon, Share2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Calendar } from '@/components/ui/calendar';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { Checkbox } from '@/components/ui/checkbox';
+import { useToast } from '@/components/ui/use-toast';
+import type { FilterCatalogResponse } from '@/services/analyticsService';
+import { useAnalyticsFilters } from '@/context/AnalyticsFiltersContext';
+
+interface AnalyticsFilterBarProps {
+  filters?: FilterCatalogResponse;
+  loading?: boolean;
+  tenantOptions?: string[];
+}
+
+interface MultiFilterProps {
+  label: string;
+  placeholder?: string;
+  values: string[];
+  options: string[];
+  onChange: (values: string[]) => void;
+}
+
+function MultiSelectFilter({ label, placeholder, values, options, onChange }: MultiFilterProps) {
+  const display = values.length ? `${values.length} seleccionados` : placeholder ?? 'Todos';
+  const normalizedOptions = useMemo(
+    () => options.map((option) => ({ value: option, label: option })),
+    [options],
+  );
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline" size="sm" className="min-w-[160px] justify-start gap-2">
+          {label}
+          <span className="truncate text-xs text-muted-foreground">{display}</span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-64 p-0" align="start">
+        <Command>
+          <CommandInput placeholder={`Filtrar ${label.toLowerCase()}`} />
+          <CommandList>
+            <CommandEmpty>Sin resultados</CommandEmpty>
+            <CommandGroup>
+              {normalizedOptions.map((option) => {
+                const isSelected = values.includes(option.value);
+                return (
+                  <CommandItem
+                    key={option.value}
+                    onSelect={() => {
+                      if (isSelected) {
+                        onChange(values.filter((value) => value !== option.value));
+                      } else {
+                        onChange([...values, option.value]);
+                      }
+                    }}
+                    className="flex items-center gap-2"
+                  >
+                    <Checkbox checked={isSelected} className="mr-2" />
+                    <span>{option.label}</span>
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          </CommandList>
+          <div className="flex items-center justify-between border-t p-2 text-xs">
+            <Button variant="ghost" size="sm" onClick={() => onChange([])}>
+              Limpiar
+            </Button>
+            <span className="text-muted-foreground">{values.length} activos</span>
+          </div>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export function AnalyticsFilterBar({ filters, loading, tenantOptions }: AnalyticsFilterBarProps) {
+  const { filters: state, setDateRange, setFilters } = useAnalyticsFilters();
+  const { toast } = useToast();
+
+  const from = useMemo(() => new Date(state.from), [state.from]);
+  const to = useMemo(() => new Date(state.to), [state.to]);
+  const tenantValues = useMemo(() => {
+    const fromProps = tenantOptions ?? [];
+    const fromCatalog = filters?.tenants ?? [];
+    return Array.from(new Set([...fromProps, ...fromCatalog].filter((tenant) => tenant && tenant.length)));
+  }, [tenantOptions, filters?.tenants]);
+
+  const handleShare = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      toast({ description: 'Link copiado al portapapeles' });
+    } catch (error) {
+      console.error('No se pudo copiar la URL', error);
+      toast({ description: 'No se pudo copiar la URL', variant: 'destructive' });
+    }
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-3 rounded-lg border bg-background/60 p-3">
+      <Select
+        value={state.tenantId || ''}
+        onValueChange={(value) => setFilters({ tenantId: value })}
+        disabled={!tenantValues.length || loading}
+      >
+        <SelectTrigger className="w-[200px]">
+          <SelectValue placeholder="Entidad" />
+        </SelectTrigger>
+        <SelectContent>
+          {tenantValues.length === 0 ? (
+            <SelectItem value="" disabled>
+              Sin entidades disponibles
+            </SelectItem>
+          ) : (
+            tenantValues.map((tenant) => (
+              <SelectItem key={tenant} value={tenant}>
+                {tenant}
+              </SelectItem>
+            ))
+          )}
+        </SelectContent>
+      </Select>
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button variant="outline" size="sm" className="justify-start gap-2">
+            <CalendarIcon className="h-4 w-4" />
+            <span>
+              {state.from} - {state.to}
+            </span>
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-0" align="start">
+          <Calendar
+            initialFocus
+            mode="range"
+            defaultMonth={from}
+            selected={{ from, to }}
+            onSelect={(range) => {
+              if (!range?.from || !range?.to) return;
+              setDateRange(range.from, range.to);
+            }}
+            numberOfMonths={2}
+          />
+          <div className="flex items-center justify-between border-t p-3 text-xs">
+            <Button variant="ghost" size="sm" onClick={() => setDateRange(addDays(new Date(), -30), new Date())}>
+              Últimos 30 días
+            </Button>
+            <Button variant="ghost" size="sm" onClick={() => setDateRange(addDays(new Date(), -7), new Date())}>
+              Últimos 7 días
+            </Button>
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      <MultiSelectFilter
+        label="Canales"
+        placeholder="Todos"
+        values={state.canal ?? []}
+        options={filters?.canales ?? []}
+        onChange={(value) => setFilters({ canal: value })}
+      />
+      <MultiSelectFilter
+        label="Categorías"
+        placeholder="Todas"
+        values={state.categoria ?? []}
+        options={filters?.categorias ?? []}
+        onChange={(value) => setFilters({ categoria: value })}
+      />
+      <MultiSelectFilter
+        label="Estados"
+        placeholder="Todos"
+        values={state.estado ?? []}
+        options={filters?.estados ?? []}
+        onChange={(value) => setFilters({ estado: value })}
+      />
+      <MultiSelectFilter
+        label="Agentes"
+        placeholder="Todos"
+        values={state.agente ?? []}
+        options={filters?.agentes ?? []}
+        onChange={(value) => setFilters({ agente: value })}
+      />
+      <MultiSelectFilter
+        label="Zonas"
+        placeholder="Todas"
+        values={state.zona ?? []}
+        options={filters?.zonas ?? []}
+        onChange={(value) => setFilters({ zona: value })}
+      />
+
+      <Button variant="outline" size="sm" className="ml-auto gap-2" onClick={handleShare} disabled={loading}>
+        <Share2 className="h-4 w-4" /> Compartir vista
+      </Button>
+    </div>
+  );
+}

--- a/src/components/analytics/DonutChart.tsx
+++ b/src/components/analytics/DonutChart.tsx
@@ -1,0 +1,46 @@
+import { useMemo } from 'react';
+import { Pie, PieChart, ResponsiveContainer, Tooltip, Cell, Legend } from 'recharts';
+import type { BreakdownResponse } from '@/services/analyticsService';
+import { WidgetFrame } from './WidgetFrame';
+import ChartTooltip from './ChartTooltip';
+
+interface DonutChartProps {
+  title: string;
+  description?: string;
+  data?: BreakdownResponse;
+  exportName: string;
+  loading?: boolean;
+}
+
+const palette = ['#2563eb', '#f97316', '#22d3ee', '#16a34a', '#f43f5e', '#9333ea', '#facc15', '#0ea5e9'];
+
+export function DonutChart({ title, description, data, exportName, loading }: DonutChartProps) {
+  const formatted = useMemo(() => {
+    if (!data?.items?.length) return [];
+    return data.items
+      .map((item) => ({ name: item.label, value: item.value }))
+      .sort((a, b) => b.value - a.value);
+  }, [data]);
+
+  return (
+    <WidgetFrame title={title} description={description} csvData={formatted} exportFilename={exportName}>
+      <div className="h-72 w-full">
+        {loading ? (
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">Preparando datos...</div>
+        ) : (
+          <ResponsiveContainer>
+            <PieChart>
+              <Pie data={formatted} dataKey="value" nameKey="name" innerRadius={60} outerRadius={90} paddingAngle={4}>
+                {formatted.map((entry, index) => (
+                  <Cell key={entry.name} fill={palette[index % palette.length]} />
+                ))}
+              </Pie>
+              <Tooltip content={<ChartTooltip />} />
+              <Legend verticalAlign="bottom" height={32} wrapperStyle={{ fontSize: 12 }} />
+            </PieChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </WidgetFrame>
+  );
+}

--- a/src/components/analytics/KpiTile.tsx
+++ b/src/components/analytics/KpiTile.tsx
@@ -1,0 +1,45 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/lib/utils';
+
+interface KpiTileProps {
+  title: string;
+  value: number | string;
+  suffix?: string;
+  delta?: { value: number; label?: string; positive?: boolean };
+  loading?: boolean;
+  className?: string;
+}
+
+export function KpiTile({ title, value, suffix, delta, loading, className }: KpiTileProps) {
+  return (
+    <Card className={cn('bg-background/80 backdrop-blur', className)}>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-medium text-muted-foreground">{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <Skeleton className="h-8 w-24" />
+        ) : (
+          <div className="flex items-baseline gap-2">
+            <span className="text-3xl font-semibold tracking-tight">
+              {typeof value === 'number' ? value.toLocaleString('es-AR', { maximumFractionDigits: 1 }) : value}
+            </span>
+            {suffix ? <span className="text-sm text-muted-foreground">{suffix}</span> : null}
+          </div>
+        )}
+        {delta ? (
+          <p
+            className={cn(
+              'mt-2 text-xs font-medium',
+              delta.positive ? 'text-emerald-500' : 'text-amber-500',
+            )}
+          >
+            {delta.positive ? '▲' : '▼'} {Math.abs(delta.value).toFixed(1)}%
+            {delta.label ? <span className="ml-1 text-muted-foreground">{delta.label}</span> : null}
+          </p>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/analytics/MapWidget.tsx
+++ b/src/components/analytics/MapWidget.tsx
@@ -1,0 +1,129 @@
+import { useMemo, useState } from 'react';
+import MapLibreMap from '@/components/MapLibreMap';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import type { HeatmapResponse, PointsResponse } from '@/services/analyticsService';
+import { WidgetFrame } from './WidgetFrame';
+
+interface MapWidgetProps {
+  title: string;
+  description?: string;
+  heatmap?: HeatmapResponse;
+  points?: PointsResponse;
+  loading?: boolean;
+  exportName: string;
+  onBoundingBoxChange?: (bbox: [number, number, number, number] | null) => void;
+}
+
+type Mode = 'heatmap' | 'puntos';
+
+export function MapWidget({
+  title,
+  description,
+  heatmap,
+  points,
+  loading,
+  exportName,
+  onBoundingBoxChange,
+}: MapWidgetProps) {
+  const [mode, setMode] = useState<Mode>('heatmap');
+  const [lastBbox, setLastBbox] = useState<[number, number, number, number] | null>(null);
+
+  const dataset = useMemo(() => {
+    if (!heatmap) return [];
+    const base = heatmap.cells.map((cell) => ({
+      id: cell.cellId,
+      lat: cell.centroid_lat,
+      lng: cell.centroid_lon,
+      weight: cell.count,
+      categoria: Object.keys(cell.breakdown ?? {})[0] ?? 'general',
+      estado: 'aggregated',
+    }));
+    if (mode === 'puntos' && points?.points?.length) {
+      return points.points.map((point) => ({
+        id: point.cellId,
+        lat: point.lat,
+        lng: point.lon,
+        weight: 1,
+        categoria: point.categoria,
+        estado: point.estado,
+      }));
+    }
+    return base;
+  }, [heatmap, points, mode]);
+
+  const csv = useMemo(() => {
+    if (!heatmap) return [];
+    return heatmap.cells.map((cell) => ({
+      cell: cell.cellId,
+      total: cell.count,
+      lat: cell.centroid_lat,
+      lon: cell.centroid_lon,
+      ...cell.breakdown,
+    }));
+  }, [heatmap]);
+
+  const hotspots = heatmap?.hotspots ?? [];
+
+  const handleBbox = (bbox: [number, number, number, number] | null) => {
+    setLastBbox(bbox);
+    onBoundingBoxChange?.(bbox);
+  };
+
+  return (
+    <WidgetFrame
+      title={title}
+      description={description}
+      csvData={csv}
+      exportFilename={exportName}
+      actions={
+        <div className="flex items-center gap-2">
+          <Button
+            variant={mode === 'heatmap' ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => setMode('heatmap')}
+          >
+            Calor
+          </Button>
+          <Button
+            variant={mode === 'puntos' ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => setMode('puntos')}
+          >
+            Puntos
+          </Button>
+        </div>
+      }
+    >
+      <div className="space-y-3">
+        {loading ? (
+          <div className="flex h-80 items-center justify-center text-sm text-muted-foreground">
+            Cargando mapa...
+          </div>
+        ) : (
+          <MapLibreMap
+            className="h-80 w-full rounded-md"
+            heatmapData={dataset}
+            showHeatmap={mode === 'heatmap'}
+            onBoundingBoxChange={handleBbox}
+          />
+        )}
+        <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+          <span>Hotspots:</span>
+          {hotspots.slice(0, 5).map((hotspot) => (
+            <Badge key={hotspot.cellId} variant="secondary" className="gap-1">
+              {hotspot.cellId}
+              <span className="font-semibold">{hotspot.count}</span>
+            </Badge>
+          ))}
+          {hotspots.length === 0 ? <span>Sin datos destacados</span> : null}
+          {lastBbox ? (
+            <Button variant="link" className="ml-auto h-6 px-0" onClick={() => handleBbox(null)}>
+              Limpiar selección
+            </Button>
+          ) : null}
+        </div>
+      </div>
+    </WidgetFrame>
+  );
+}

--- a/src/components/analytics/OperationsTable.tsx
+++ b/src/components/analytics/OperationsTable.tsx
@@ -1,0 +1,47 @@
+import { useMemo } from 'react';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import type { OperationsResponse } from '@/services/analyticsService';
+import { WidgetFrame } from './WidgetFrame';
+
+interface OperationsTableProps {
+  title: string;
+  data?: OperationsResponse;
+  exportName: string;
+  loading?: boolean;
+}
+
+export function OperationsTable({ title, data, exportName, loading }: OperationsTableProps) {
+  const rows = useMemo(() => data?.agents ?? [], [data]);
+  return (
+    <WidgetFrame title={title} csvData={rows} exportFilename={exportName}>
+      <div className="max-h-72 overflow-auto">
+        {loading ? (
+          <div className="flex h-32 items-center justify-center text-sm text-muted-foreground">
+            Calculando carga de agentes...
+          </div>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Agente</TableHead>
+                <TableHead className="text-right">Tickets abiertos</TableHead>
+                <TableHead className="text-right">Tiempo medio (min)</TableHead>
+                <TableHead className="text-right">Satisfacción</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.map((row) => (
+                <TableRow key={row.agente}>
+                  <TableCell className="text-sm font-medium">{row.agente}</TableCell>
+                  <TableCell className="text-right text-sm">{row.abiertos}</TableCell>
+                  <TableCell className="text-right text-sm">{row.tiempoMedio.toFixed(1)}</TableCell>
+                  <TableCell className="text-right text-sm">{row.satisfaccion.toFixed(2)}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </div>
+    </WidgetFrame>
+  );
+}

--- a/src/components/analytics/StackedBarChart.tsx
+++ b/src/components/analytics/StackedBarChart.tsx
@@ -1,0 +1,47 @@
+import { useMemo } from 'react';
+import { Bar, BarChart, CartesianGrid, Legend, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import type { BreakdownResponse } from '@/services/analyticsService';
+import { WidgetFrame } from './WidgetFrame';
+import ChartTooltip from './ChartTooltip';
+
+interface StackedBarChartProps {
+  title: string;
+  description?: string;
+  data?: BreakdownResponse;
+  loading?: boolean;
+  exportName: string;
+}
+
+const palette = ['#2563eb', '#16a34a', '#f97316', '#9333ea', '#facc15', '#0ea5e9'];
+
+export function StackedBarChart({ title, description, data, loading, exportName }: StackedBarChartProps) {
+  const formatted = useMemo(() => {
+    if (!data?.items?.length) return [];
+    return data.items.map((item) => ({ label: item.label, value: item.value }));
+  }, [data]);
+
+  const csv = useMemo(() => formatted.map((item) => ({ ...item })), [formatted]);
+
+  return (
+    <WidgetFrame title={title} description={description} csvData={csv} exportFilename={exportName}>
+      <div className="h-72 w-full">
+        {loading ? (
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+            Generando gráfico...
+          </div>
+        ) : (
+          <ResponsiveContainer>
+            <BarChart data={formatted} margin={{ left: 16, right: 16, top: 10, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" strokeOpacity={0.3} />
+              <XAxis dataKey="label" tickLine={false} axisLine={false} fontSize={12} interval={0} angle={-25} dy={10} />
+              <YAxis tickLine={false} axisLine={false} fontSize={12} />
+              <Tooltip content={<ChartTooltip />} />
+              <Legend verticalAlign="top" height={24} wrapperStyle={{ fontSize: 12 }} />
+              <Bar dataKey="value" fill={palette[0]} radius={[4, 4, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </WidgetFrame>
+  );
+}

--- a/src/components/analytics/TimeSeriesChart.tsx
+++ b/src/components/analytics/TimeSeriesChart.tsx
@@ -1,0 +1,94 @@
+import { useMemo } from 'react';
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { TimeseriesResponse } from '@/services/analyticsService';
+import { WidgetFrame } from './WidgetFrame';
+import ChartTooltip from './ChartTooltip';
+
+interface TimeSeriesChartProps {
+  title: string;
+  description?: string;
+  data?: TimeseriesResponse;
+  loading?: boolean;
+  valueFormatter?: (value: number) => string;
+  exportName: string;
+}
+
+const palette = ['#2563eb', '#f97316', '#16a34a', '#9333ea', '#0ea5e9', '#f43f5e'];
+
+export function TimeSeriesChart({ title, description, data, loading, valueFormatter, exportName }: TimeSeriesChartProps) {
+  const formatted = useMemo(() => {
+    if (!data) return [];
+    return data.series.map((item) => ({
+      date: item.date,
+      total: Number(item.value.toFixed(2)),
+      ...item.breakdown,
+    }));
+  }, [data]);
+
+  const csv = useMemo(() => {
+    if (!formatted.length) return [];
+    return formatted.map((row) => ({ ...row }));
+  }, [formatted]);
+
+  const breakdownKeys = useMemo(() => {
+    if (!data?.series?.length) return [];
+    const keys = new Set<string>();
+    data.series.forEach((item) => {
+      if (item.breakdown) {
+        Object.keys(item.breakdown).forEach((key) => keys.add(key));
+      }
+    });
+    return Array.from(keys);
+  }, [data]);
+
+  return (
+    <WidgetFrame title={title} description={description} csvData={csv} exportFilename={exportName}>
+      <div className="h-72 w-full">
+        {loading ? (
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+            Cargando serie...
+          </div>
+        ) : (
+          <ResponsiveContainer>
+            <AreaChart data={formatted} margin={{ left: 16, right: 16, top: 10, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" strokeOpacity={0.3} />
+              <XAxis dataKey="date" tickLine={false} axisLine={false} fontSize={12} />
+              <YAxis
+                tickLine={false}
+                axisLine={false}
+                fontSize={12}
+                tickFormatter={(value) => (valueFormatter ? valueFormatter(value) : value.toLocaleString())}
+              />
+              <Tooltip content={<ChartTooltip />} />
+              {breakdownKeys.length ? (
+                breakdownKeys.map((key, index) => (
+                  <Area
+                    key={key}
+                    type="monotone"
+                    dataKey={key}
+                    stackId="total"
+                    stroke={palette[index % palette.length]}
+                    fill={palette[index % palette.length]}
+                    fillOpacity={0.2}
+                  />
+                ))
+              ) : (
+                <Area type="monotone" dataKey="total" stroke="#2563eb" fill="#2563eb" fillOpacity={0.2} />
+              )}
+              <Legend verticalAlign="top" height={24} wrapperStyle={{ fontSize: 12 }} />
+            </AreaChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </WidgetFrame>
+  );
+}

--- a/src/components/analytics/TopTable.tsx
+++ b/src/components/analytics/TopTable.tsx
@@ -1,0 +1,44 @@
+import { useMemo } from 'react';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import type { TopResponse } from '@/services/analyticsService';
+import { WidgetFrame } from './WidgetFrame';
+
+interface TopTableProps {
+  title: string;
+  description?: string;
+  data?: TopResponse;
+  exportName: string;
+  loading?: boolean;
+}
+
+export function TopTable({ title, description, data, exportName, loading }: TopTableProps) {
+  const rows = useMemo(() => data?.items ?? [], [data]);
+  return (
+    <WidgetFrame title={title} description={description} csvData={rows} exportFilename={exportName}>
+      <div className="max-h-72 overflow-auto">
+        {loading ? (
+          <div className="flex h-32 items-center justify-center text-sm text-muted-foreground">
+            Cargando tabla...
+          </div>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-3/4">Nombre</TableHead>
+                <TableHead className="text-right">Valor</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.map((row) => (
+                <TableRow key={row.label}>
+                  <TableCell className="truncate text-sm font-medium">{row.label}</TableCell>
+                  <TableCell className="text-right text-sm font-semibold">{row.value.toLocaleString()}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </div>
+    </WidgetFrame>
+  );
+}

--- a/src/components/analytics/WidgetFrame.tsx
+++ b/src/components/analytics/WidgetFrame.tsx
@@ -1,0 +1,81 @@
+import { forwardRef, useRef } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Download, Image as ImageIcon, MoreHorizontal } from 'lucide-react';
+import { exportElementToPng, exportToCsv } from '@/utils/exportUtils';
+
+export interface WidgetFrameProps {
+  title: string;
+  description?: string;
+  csvData?: Record<string, unknown>[];
+  exportFilename?: string;
+  onExportCsv?: () => Record<string, unknown>[] | undefined;
+  actions?: React.ReactNode;
+  className?: string;
+  children: React.ReactNode;
+}
+
+export const WidgetFrame = forwardRef<HTMLDivElement, WidgetFrameProps>(
+  (
+    { title, description, csvData, exportFilename = 'analytics-export', onExportCsv, actions, className, children },
+    ref,
+  ) => {
+    const innerRef = useRef<HTMLDivElement | null>(null);
+    const composedRef = (node: HTMLDivElement | null) => {
+      innerRef.current = node;
+      if (typeof ref === 'function') {
+        ref(node);
+      } else if (ref) {
+        ref.current = node;
+      }
+    };
+
+    const handleCsv = () => {
+      const data = typeof onExportCsv === 'function' ? onExportCsv() : csvData;
+      if (!data || data.length === 0) return;
+      exportToCsv(`${exportFilename}.csv`, data);
+    };
+
+    const handlePng = async () => {
+      await exportElementToPng(innerRef, `${exportFilename}.png`);
+    };
+
+    return (
+      <Card ref={composedRef} className={className}>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <div>
+            <CardTitle className="text-lg font-semibold">{title}</CardTitle>
+            {description ? <CardDescription>{description}</CardDescription> : null}
+          </div>
+          <div className="flex items-center gap-2">
+            {actions}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="icon" className="h-8 w-8">
+                  <MoreHorizontal className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-40">
+                <DropdownMenuItem onSelect={handleCsv} className="flex items-center gap-2">
+                  <Download className="h-4 w-4" /> CSV
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={handlePng} className="flex items-center gap-2">
+                  <ImageIcon className="h-4 w-4" /> PNG
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        </CardHeader>
+        <CardContent>{children}</CardContent>
+      </Card>
+    );
+  },
+);
+
+WidgetFrame.displayName = 'WidgetFrame';

--- a/src/context/AnalyticsFiltersContext.tsx
+++ b/src/context/AnalyticsFiltersContext.tsx
@@ -1,0 +1,170 @@
+import { createContext, useCallback, useContext, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import type { AnalyticsContext, AnalyticsFilters } from '@/services/analyticsService';
+
+type FiltersState = AnalyticsFilters;
+
+type FiltersContextValue = {
+  filters: FiltersState;
+  setFilters: (updates: Partial<FiltersState>) => void;
+  setDateRange: (from: Date, to: Date) => void;
+  setBoundingBox: (bbox: [number, number, number, number] | null) => void;
+  context: AnalyticsContext;
+};
+
+const AnalyticsFiltersContext = createContext<FiltersContextValue | null>(null);
+
+const DEFAULT_RANGE_DAYS = 30;
+
+function formatDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function parseArray(value: string | null): string[] {
+  if (!value) return [];
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function parseBbox(value: string | null): [number, number, number, number] | null {
+  if (!value) return null;
+  const parts = value.split(',').map((part) => Number(part));
+  if (parts.length !== 4 || parts.some((part) => Number.isNaN(part))) {
+    return null;
+  }
+  return [parts[0], parts[1], parts[2], parts[3]];
+}
+
+function buildFilters(
+  params: URLSearchParams,
+  defaults: { tenantId?: string; context?: AnalyticsContext },
+) {
+  const now = new Date();
+  const fromParam = params.get('from');
+  const toParam = params.get('to');
+  const from = fromParam ? new Date(fromParam) : new Date(now.getTime() - DEFAULT_RANGE_DAYS * 24 * 60 * 60 * 1000);
+  const to = toParam ? new Date(toParam) : now;
+  const contextParam = params.get('context') as AnalyticsContext | null;
+  return {
+    tenantId: params.get('tenant_id') || defaults.tenantId || '',
+    from: formatDate(from),
+    to: formatDate(to),
+    canal: parseArray(params.get('canal')),
+    categoria: parseArray(params.get('categoria')),
+    estado: parseArray(params.get('estado')),
+    agente: parseArray(params.get('agente')),
+    zona: parseArray(params.get('zona')),
+    etiquetas: parseArray(params.get('etiquetas')),
+    metric: params.get('metric') || 'tickets_total',
+    group: params.get('group'),
+    dimension: params.get('dimension') || 'categoria',
+    subject: params.get('subject') || 'zonas',
+    bbox: parseBbox(params.get('bbox')),
+    context: contextParam || defaults.context || 'municipio',
+    search: params.get('search'),
+  } satisfies FiltersState;
+}
+
+export function AnalyticsFiltersProvider({
+  children,
+  defaultTenantId,
+  defaultContext,
+}: {
+  children: React.ReactNode;
+  defaultTenantId?: string;
+  defaultContext?: AnalyticsContext;
+}) {
+  const [params, setParams] = useSearchParams();
+  const filters = useMemo(
+    () => buildFilters(params, { tenantId: defaultTenantId, context: defaultContext }),
+    [params, defaultTenantId, defaultContext],
+  );
+
+  const updateParams = useCallback(
+    (updates: Partial<FiltersState>) => {
+      const next = new URLSearchParams(params.toString());
+      Object.entries(updates).forEach(([key, value]) => {
+        if (value === undefined || value === null) {
+          next.delete(key);
+          return;
+        }
+        if (Array.isArray(value)) {
+          if (value.length === 0) {
+            next.delete(key);
+          } else {
+            next.set(key, value.join(','));
+          }
+          return;
+        }
+        if (key === 'bbox' && Array.isArray(value)) {
+          next.set(key, value.join(','));
+          return;
+        }
+        next.set(key, String(value));
+      });
+      const tenantValue = updates.tenantId ?? filters.tenantId;
+      if (tenantValue) {
+        next.set('tenant_id', tenantValue);
+      } else {
+        next.delete('tenant_id');
+      }
+      const fromValue = updates.from ?? filters.from;
+      if (fromValue) {
+        next.set('from', fromValue);
+      }
+      const toValue = updates.to ?? filters.to;
+      if (toValue) {
+        next.set('to', toValue);
+      }
+      const contextValue = updates.context ?? filters.context;
+      next.set('context', contextValue || 'municipio');
+      setParams(next, { replace: true });
+    },
+    [params, setParams, filters],
+  );
+
+  const setFilters = useCallback(
+    (updates: Partial<FiltersState>) => {
+      updateParams(updates);
+    },
+    [updateParams],
+  );
+
+  const setDateRange = useCallback(
+    (from: Date, to: Date) => {
+      updateParams({ from: formatDate(from), to: formatDate(to) });
+    },
+    [updateParams],
+  );
+
+  const setBoundingBox = useCallback(
+    (bbox: [number, number, number, number] | null) => {
+      if (!bbox) {
+        updateParams({ bbox: null });
+        return;
+      }
+      updateParams({ bbox });
+    },
+    [updateParams],
+  );
+
+  const value = useMemo<FiltersContextValue>(
+    () => ({ filters, setFilters, setDateRange, setBoundingBox, context: filters.context }),
+    [filters, setFilters, setDateRange, setBoundingBox],
+  );
+
+  return <AnalyticsFiltersContext.Provider value={value}>{children}</AnalyticsFiltersContext.Provider>;
+}
+
+export function useAnalyticsFilters() {
+  const ctx = useContext(AnalyticsFiltersContext);
+  if (!ctx) {
+    throw new Error('useAnalyticsFilters must be used within AnalyticsFiltersProvider');
+  }
+  return ctx;
+}

--- a/src/hooks/useAnalyticsDashboard.ts
+++ b/src/hooks/useAnalyticsDashboard.ts
@@ -1,0 +1,120 @@
+import { useEffect, useMemo, useState } from 'react';
+import { analyticsService, type AnalyticsContext } from '@/services/analyticsService';
+import { useAnalyticsFilters } from '@/context/AnalyticsFiltersContext';
+
+type DashboardData = {
+  summary: Awaited<ReturnType<typeof analyticsService.summary>> | null;
+  timeseries: Awaited<ReturnType<typeof analyticsService.timeseries>> | null;
+  breakdownCategoria: Awaited<ReturnType<typeof analyticsService.breakdown>> | null;
+  breakdownCanal: Awaited<ReturnType<typeof analyticsService.breakdown>> | null;
+  breakdownEstado: Awaited<ReturnType<typeof analyticsService.breakdown>> | null;
+  heatmap: Awaited<ReturnType<typeof analyticsService.heatmap>> | null;
+  points: Awaited<ReturnType<typeof analyticsService.points>> | null;
+  topZonas: Awaited<ReturnType<typeof analyticsService.top>> | null;
+  operations: Awaited<ReturnType<typeof analyticsService.operations>> | null;
+  cohorts: Awaited<ReturnType<typeof analyticsService.cohorts>> | null;
+  templates: Awaited<ReturnType<typeof analyticsService.templates>> | null;
+};
+
+const EMPTY_DATA: DashboardData = {
+  summary: null,
+  timeseries: null,
+  breakdownCategoria: null,
+  breakdownCanal: null,
+  breakdownEstado: null,
+  heatmap: null,
+  points: null,
+  topZonas: null,
+  operations: null,
+  cohorts: null,
+  templates: null,
+};
+
+export function useAnalyticsDashboard(view: AnalyticsContext) {
+  const { filters } = useAnalyticsFilters();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [data, setData] = useState<DashboardData>(() => ({ ...EMPTY_DATA }));
+
+  const payload = useMemo(() => ({
+    tenantId: filters.tenantId,
+    from: filters.from,
+    to: filters.to,
+    canal: filters.canal,
+    categoria: filters.categoria,
+    estado: filters.estado,
+    agente: filters.agente,
+    zona: filters.zona,
+    etiquetas: filters.etiquetas,
+    context: view,
+    bbox: filters.bbox ?? undefined,
+    search: filters.search ?? undefined,
+  }), [filters, view]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+
+    if (!payload.tenantId) {
+      setData({ ...EMPTY_DATA });
+      setError('Seleccioná una entidad para ver métricas');
+      setLoading(false);
+      return () => controller.abort();
+    }
+
+    async function run() {
+      try {
+        const basePayload = { ...payload };
+        const [summary, timeseries, categoria, canal, estado, heatmap, points, topZonas] = await Promise.all([
+          analyticsService.summary(basePayload),
+          analyticsService.timeseries({ ...basePayload, metric: 'tickets_total', group: 'categoria' }),
+          analyticsService.breakdown({ ...basePayload, dimension: 'categoria' }),
+          analyticsService.breakdown({ ...basePayload, dimension: 'canal' }),
+          analyticsService.breakdown({ ...basePayload, dimension: 'estado' }),
+          analyticsService.heatmap(basePayload),
+          analyticsService.points(basePayload),
+          analyticsService.top({ ...basePayload, subject: 'zonas' }),
+        ]);
+
+        let operations = null;
+        let cohorts = null;
+        let templates = null;
+
+        if (view === 'operaciones' || view === 'municipio') {
+          operations = await analyticsService.operations(basePayload);
+        }
+        if (view === 'pyme') {
+          cohorts = await analyticsService.cohorts(basePayload);
+          templates = await analyticsService.templates(basePayload);
+        }
+
+        setData({
+          summary,
+          timeseries,
+          breakdownCategoria: categoria,
+          breakdownCanal: canal,
+          breakdownEstado: estado,
+          heatmap,
+          points,
+          topZonas,
+          operations,
+          cohorts,
+          templates,
+        });
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        setError(err instanceof Error ? err.message : 'Error cargando datos');
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      }
+    }
+
+    run();
+    return () => controller.abort();
+  }, [payload, view]);
+
+  return { data, loading, error };
+}

--- a/src/pages/analytics/AnalyticsPage.tsx
+++ b/src/pages/analytics/AnalyticsPage.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { AnalyticsFiltersProvider, useAnalyticsFilters } from '@/context/AnalyticsFiltersContext';
+import { analyticsService, type FilterCatalogResponse } from '@/services/analyticsService';
+import { AnalyticsFilterBar } from '@/components/analytics/AnalyticsFilterBar';
+import { MunicipioDashboard } from './MunicipioDashboard';
+import { PymeDashboard } from './PymeDashboard';
+import { OperationsDashboard } from './OperationsDashboard';
+import { getAnalyticsSettings } from '@/utils/config';
+import type { AnalyticsContext } from '@/services/analyticsService';
+
+interface AnalyticsPageContentProps {
+  initialTenants?: string[];
+  defaultTenantId?: string;
+}
+
+function AnalyticsPageContent({ initialTenants = [], defaultTenantId }: AnalyticsPageContentProps) {
+  const { filters, setFilters } = useAnalyticsFilters();
+  const [filterCatalog, setFilterCatalog] = useState<FilterCatalogResponse | undefined>();
+  const [loadingFilters, setLoadingFilters] = useState(false);
+
+  const tenantOptions = useMemo(() => {
+    const fromCatalog = filterCatalog?.tenants ?? [];
+    return Array.from(new Set([...initialTenants, ...fromCatalog]));
+  }, [filterCatalog?.tenants, initialTenants]);
+
+  useEffect(() => {
+    const preferredTenant = filterCatalog?.defaultTenantId || defaultTenantId || tenantOptions[0];
+    if (!preferredTenant) return;
+    if (!filters.tenantId) {
+      setFilters({ tenantId: preferredTenant });
+      return;
+    }
+    if (!tenantOptions.length) return;
+    if (!tenantOptions.includes(filters.tenantId)) {
+      setFilters({ tenantId: preferredTenant });
+    }
+  }, [tenantOptions, filters.tenantId, setFilters, filterCatalog?.defaultTenantId, defaultTenantId]);
+
+  useEffect(() => {
+    let active = true;
+    async function loadFilters() {
+      setLoadingFilters(true);
+      if (!filters.tenantId) {
+        setFilterCatalog(undefined);
+        setLoadingFilters(false);
+        return;
+      }
+      try {
+        const result = await analyticsService.filters({
+          tenantId: filters.tenantId,
+          from: filters.from,
+          to: filters.to,
+          context: filters.context,
+        });
+        if (active) {
+          setFilterCatalog(result);
+        }
+      } catch (error) {
+        console.error('No se pudieron cargar los filtros', error);
+      } finally {
+        if (active) {
+          setLoadingFilters(false);
+        }
+      }
+    }
+    loadFilters();
+    return () => {
+      active = false;
+    };
+  }, [filters.tenantId, filters.from, filters.to, filters.context]);
+
+  return (
+    <div className="space-y-6">
+      <AnalyticsFilterBar
+        filters={filterCatalog}
+        loading={loadingFilters}
+        tenantOptions={tenantOptions}
+      />
+      <Tabs
+        value={filters.context ?? 'municipio'}
+        onValueChange={(value) => setFilters({ context: value })}
+        className="space-y-6"
+      >
+        <TabsList>
+          <TabsTrigger value="municipio">Municipio</TabsTrigger>
+          <TabsTrigger value="pyme">PyME</TabsTrigger>
+          <TabsTrigger value="operaciones">Operaciones</TabsTrigger>
+        </TabsList>
+        <TabsContent value="municipio">
+          <MunicipioDashboard />
+        </TabsContent>
+        <TabsContent value="pyme">
+          <PymeDashboard />
+        </TabsContent>
+        <TabsContent value="operaciones">
+          <OperationsDashboard />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+export default function AnalyticsPage() {
+  const settings = getAnalyticsSettings();
+  const allowedContexts: AnalyticsContext[] = ['municipio', 'pyme', 'operaciones'];
+  const defaultContext = useMemo(() => {
+    if (!settings.defaultContext) return 'municipio' as AnalyticsContext;
+    return allowedContexts.includes(settings.defaultContext as AnalyticsContext)
+      ? (settings.defaultContext as AnalyticsContext)
+      : ('municipio' as AnalyticsContext);
+  }, [settings.defaultContext]);
+
+  return (
+    <AnalyticsFiltersProvider defaultTenantId={settings.defaultTenantId} defaultContext={defaultContext}>
+      <AnalyticsPageContent
+        initialTenants={settings.tenants}
+        defaultTenantId={settings.defaultTenantId}
+      />
+    </AnalyticsFiltersProvider>
+  );
+}

--- a/src/pages/analytics/MunicipioDashboard.tsx
+++ b/src/pages/analytics/MunicipioDashboard.tsx
@@ -1,0 +1,170 @@
+import { useMemo } from 'react';
+import { KpiTile } from '@/components/analytics/KpiTile';
+import { TimeSeriesChart } from '@/components/analytics/TimeSeriesChart';
+import { StackedBarChart } from '@/components/analytics/StackedBarChart';
+import { DonutChart } from '@/components/analytics/DonutChart';
+import { TopTable } from '@/components/analytics/TopTable';
+import { MapWidget } from '@/components/analytics/MapWidget';
+import { WidgetFrame } from '@/components/analytics/WidgetFrame';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { useAnalyticsDashboard } from '@/hooks/useAnalyticsDashboard';
+import { useAnalyticsFilters } from '@/context/AnalyticsFiltersContext';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { AlertCircle } from 'lucide-react';
+
+export function MunicipioDashboard() {
+  const { data, loading, error } = useAnalyticsDashboard('municipio');
+  const { setBoundingBox } = useAnalyticsFilters();
+
+  const summary = data.summary;
+  const qualityRows = useMemo(() => {
+    const quality = summary?.quality;
+    if (!quality) return [];
+    return [
+      ...quality.byType.map((item) => ({
+        scope: item.label,
+        average: item.average,
+        responses: item.responses,
+      })),
+      ...quality.byAgent.map((item) => ({
+        scope: item.label,
+        average: item.average,
+        responses: item.responses,
+      })),
+    ];
+  }, [data.summary]);
+
+  const automationRate = summary?.efficiency?.automationRate ?? 0;
+  const firstContact = summary?.efficiency?.firstContact ?? 0;
+  const reopenRate = summary?.efficiency?.reopenRate ?? 0;
+  const ack = summary?.sla?.ack;
+  const resolve = summary?.sla?.resolve;
+  const isSelectionError = error?.toLowerCase().includes('seleccioná');
+
+  return (
+    <div className="space-y-6">
+      {error ? (
+        <Alert variant={isSelectionError ? 'default' : 'destructive'}>
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>
+            {isSelectionError ? 'Seleccioná una entidad' : 'No se pudieron cargar los datos'}
+          </AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      ) : null}
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <KpiTile title="Tickets totales" value={summary?.totals.tickets ?? 0} loading={loading} />
+        <KpiTile title="Tickets abiertos" value={summary?.totals.abiertos ?? 0} loading={loading} />
+        <KpiTile title="Backlog" value={summary?.totals.backlog ?? 0} loading={loading} />
+        <KpiTile
+          title="% automatizados"
+          value={automationRate}
+          suffix="%"
+          loading={loading}
+        />
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-3">
+        <div className="lg:col-span-2">
+          <TimeSeriesChart
+            title="Tickets diarios"
+            description="Incluye desagregación por categoría"
+            data={data.timeseries ?? undefined}
+            loading={loading}
+            exportName="municipio-timeseries"
+          />
+        </div>
+        <div className="grid gap-4">
+          <WidgetFrame title="SLA - Horas" exportFilename="municipio-sla">
+            <div className="grid grid-cols-2 gap-4 text-sm">
+              <div>
+                <p className="text-xs text-muted-foreground">Time to acknowledge</p>
+                <p className="text-lg font-semibold">P50: {ack?.p50 ?? 0}h</p>
+                <p className="text-xs text-muted-foreground">P90: {ack?.p90 ?? 0}h</p>
+                <p className="text-xs text-muted-foreground">P95: {ack?.p95 ?? 0}h</p>
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground">Time to resolution</p>
+                <p className="text-lg font-semibold">P50: {resolve?.p50 ?? 0}h</p>
+                <p className="text-xs text-muted-foreground">P90: {resolve?.p90 ?? 0}h</p>
+                <p className="text-xs text-muted-foreground">P95: {resolve?.p95 ?? 0}h</p>
+              </div>
+            </div>
+          </WidgetFrame>
+          <WidgetFrame title="Eficiencia" exportFilename="municipio-eficiencia">
+            <div className="space-y-2 text-sm">
+              <p>
+                <span className="font-semibold">Primer contacto:</span>{' '}
+                {firstContact.toFixed(1)}%
+              </p>
+              <p>
+                <span className="font-semibold">Re-aperturas:</span>{' '}
+                {reopenRate.toFixed(1)}%
+              </p>
+            </div>
+          </WidgetFrame>
+        </div>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-3">
+        <StackedBarChart
+          title="Tickets por categoría"
+          data={data.breakdownCategoria ?? undefined}
+          loading={loading}
+          exportName="municipio-categorias"
+        />
+        <DonutChart
+          title="Distribución por canal"
+          data={data.breakdownCanal ?? undefined}
+          loading={loading}
+          exportName="municipio-canales"
+        />
+        <StackedBarChart
+          title="Estados"
+          data={data.breakdownEstado ?? undefined}
+          loading={loading}
+          exportName="municipio-estados"
+        />
+      </section>
+
+      <MapWidget
+        title="Mapa de incidencias"
+        description="Seleccioná un área para filtrar el resto de widgets"
+        heatmap={data.heatmap ?? undefined}
+        points={data.points ?? undefined}
+        loading={loading}
+        exportName="municipio-mapa"
+        onBoundingBoxChange={setBoundingBox}
+      />
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        <TopTable
+          title="Zonas prioritarias"
+          data={data.topZonas ?? undefined}
+          loading={loading}
+          exportName="municipio-zonas"
+        />
+        <WidgetFrame title="Calidad" csvData={qualityRows} exportFilename="municipio-calidad">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Ámbito</TableHead>
+                <TableHead className="text-right">Score</TableHead>
+                <TableHead className="text-right">Respuestas</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {qualityRows.map((row) => (
+                <TableRow key={row.scope}>
+                  <TableCell className="text-sm font-medium">{row.scope}</TableCell>
+                  <TableCell className="text-right text-sm">{row.average.toFixed(2)}</TableCell>
+                  <TableCell className="text-right text-sm">{row.responses}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </WidgetFrame>
+      </section>
+    </div>
+  );
+}

--- a/src/pages/analytics/OperationsDashboard.tsx
+++ b/src/pages/analytics/OperationsDashboard.tsx
@@ -1,0 +1,92 @@
+import { useMemo } from 'react';
+import { KpiTile } from '@/components/analytics/KpiTile';
+import { TimeSeriesChart } from '@/components/analytics/TimeSeriesChart';
+import { StackedBarChart } from '@/components/analytics/StackedBarChart';
+import { MapWidget } from '@/components/analytics/MapWidget';
+import { OperationsTable } from '@/components/analytics/OperationsTable';
+import { WidgetFrame } from '@/components/analytics/WidgetFrame';
+import { useAnalyticsDashboard } from '@/hooks/useAnalyticsDashboard';
+import { useAnalyticsFilters } from '@/context/AnalyticsFiltersContext';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { AlertCircle } from 'lucide-react';
+
+export function OperationsDashboard() {
+  const { data, loading, error } = useAnalyticsDashboard('operaciones');
+  const { setBoundingBox } = useAnalyticsFilters();
+
+  const operations = data.operations;
+  const agingBreakdown = useMemo(() => {
+    if (!operations) return { dimension: 'aging', items: [] };
+    return {
+      dimension: 'aging',
+      items: Object.entries(operations.agingBuckets).map(([label, value]) => ({ label, value })),
+    };
+  }, [operations]);
+  const isSelectionError = error?.toLowerCase().includes('seleccioná');
+
+  return (
+    <div className="space-y-6">
+      {error ? (
+        <Alert variant={isSelectionError ? 'default' : 'destructive'}>
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>
+            {isSelectionError ? 'Seleccioná una entidad' : 'No se pudieron cargar los datos'}
+          </AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      ) : null}
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <KpiTile title="Tickets abiertos" value={operations?.abiertos ?? 0} loading={loading} />
+        <KpiTile title="SLA vencidos" value={operations?.slaBreaches ?? 0} loading={loading} />
+        <KpiTile title="Automatizados" value={operations?.automated ?? 0} loading={loading} />
+        <KpiTile title="Tickets" value={data.summary?.totals.tickets ?? 0} loading={loading} />
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-3">
+        <div className="lg:col-span-2">
+          <TimeSeriesChart
+            title="Volumen diario"
+            description="Evolución de tickets"
+            data={data.timeseries ?? undefined}
+            loading={loading}
+            exportName="operaciones-timeseries"
+          />
+        </div>
+        <StackedBarChart
+          title="Aging"
+          data={agingBreakdown}
+          loading={loading}
+          exportName="operaciones-aging"
+        />
+      </section>
+
+      <MapWidget
+        title="Tickets en mapa"
+        description="Heatmap de tickets activos"
+        heatmap={data.heatmap ?? undefined}
+        points={data.points ?? undefined}
+        loading={loading}
+        exportName="operaciones-mapa"
+        onBoundingBoxChange={setBoundingBox}
+      />
+
+      <OperationsTable
+        title="Carga por agente"
+        data={operations ?? undefined}
+        loading={loading}
+        exportName="operaciones-agentes"
+      />
+
+      <WidgetFrame title="Estados" exportFilename="operaciones-estados" csvData={data.breakdownEstado?.items}>
+        <div className="grid grid-cols-2 gap-4 text-sm">
+          {(data.breakdownEstado?.items ?? []).map((item) => (
+            <div key={item.label} className="rounded border p-3">
+              <p className="text-xs text-muted-foreground">{item.label}</p>
+              <p className="text-lg font-semibold">{item.value}</p>
+            </div>
+          ))}
+        </div>
+      </WidgetFrame>
+    </div>
+  );
+}

--- a/src/pages/analytics/PymeDashboard.tsx
+++ b/src/pages/analytics/PymeDashboard.tsx
@@ -1,0 +1,174 @@
+import { useMemo } from 'react';
+import { KpiTile } from '@/components/analytics/KpiTile';
+import { TimeSeriesChart } from '@/components/analytics/TimeSeriesChart';
+import { StackedBarChart } from '@/components/analytics/StackedBarChart';
+import { DonutChart } from '@/components/analytics/DonutChart';
+import { MapWidget } from '@/components/analytics/MapWidget';
+import { WidgetFrame } from '@/components/analytics/WidgetFrame';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { useAnalyticsDashboard } from '@/hooks/useAnalyticsDashboard';
+import { useAnalyticsFilters } from '@/context/AnalyticsFiltersContext';
+import { AlertCircle } from 'lucide-react';
+
+export function PymeDashboard() {
+  const { data, loading, error } = useAnalyticsDashboard('pyme');
+  const { setBoundingBox } = useAnalyticsFilters();
+
+  const summary = data.summary;
+  const pymeMetrics = summary?.pyme;
+  const cohorts = data.cohorts?.cohorts ?? [];
+  const templates = data.templates?.templates ?? [];
+
+  const horasPico = useMemo(() => pymeMetrics?.horasPico ?? [], [pymeMetrics]);
+  const isSelectionError = error?.toLowerCase().includes('seleccioná');
+
+  return (
+    <div className="space-y-6">
+      {error ? (
+        <Alert variant={isSelectionError ? 'default' : 'destructive'}>
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>
+            {isSelectionError ? 'Seleccioná una entidad' : 'No se pudieron cargar los datos'}
+          </AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      ) : null}
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <KpiTile title="Pedidos" value={pymeMetrics?.totalOrders ?? 0} loading={loading} />
+        <KpiTile title="Ticket medio" value={pymeMetrics?.ticketMedio ?? 0} loading={loading} />
+        <KpiTile title="Conversión" value={pymeMetrics?.conversion ?? 0} suffix="%" loading={loading} />
+        <KpiTile
+          title="Recompra 30 días"
+          value={pymeMetrics?.recurrencia?.d30 ?? 0}
+          loading={loading}
+        />
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-3">
+        <div className="lg:col-span-2">
+          <TimeSeriesChart
+            title="Pedidos diarios"
+            description="Incluye ingresos agregados"
+            data={data.timeseries ?? undefined}
+            loading={loading}
+            exportName="pyme-timeseries"
+          />
+        </div>
+        <WidgetFrame title="Horas pico" exportFilename="pyme-horaspico">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Hora</TableHead>
+                <TableHead className="text-right">Pedidos</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {horasPico.map((row) => (
+                <TableRow key={row.hour}>
+                  <TableCell className="text-sm font-medium">{row.hour}:00</TableCell>
+                  <TableCell className="text-right text-sm">{row.value}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </WidgetFrame>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-3">
+        <StackedBarChart
+          title="Pedidos por categoría"
+          data={data.breakdownCategoria ?? undefined}
+          loading={loading}
+          exportName="pyme-categorias"
+        />
+        <DonutChart
+          title="Conversión por canal"
+          data={data.breakdownCanal ?? undefined}
+          loading={loading}
+          exportName="pyme-canales"
+        />
+        <StackedBarChart
+          title="Estados de pedidos"
+          data={data.breakdownEstado ?? undefined}
+          loading={loading}
+          exportName="pyme-estados"
+        />
+      </section>
+
+      <MapWidget
+        title="Mapa de pedidos"
+        description="Calor de compras por zona"
+        heatmap={data.heatmap ?? undefined}
+        points={data.points ?? undefined}
+        loading={loading}
+        exportName="pyme-mapa"
+        onBoundingBoxChange={setBoundingBox}
+      />
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        <WidgetFrame title="Top productos" exportFilename="pyme-productos" csvData={pymeMetrics?.topProductos}>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>SKU</TableHead>
+                <TableHead className="text-right">Cantidad</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {(pymeMetrics?.topProductos ?? []).map((item) => (
+                <TableRow key={item.label}>
+                  <TableCell className="text-sm font-medium">{item.label}</TableCell>
+                  <TableCell className="text-right text-sm">{item.value}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </WidgetFrame>
+        <WidgetFrame title="Plantillas WhatsApp" exportFilename="pyme-templates" csvData={templates}>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Plantilla</TableHead>
+                <TableHead className="text-right">Envíos</TableHead>
+                <TableHead className="text-right">Respuestas</TableHead>
+                <TableHead className="text-right">CTR</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {templates.map((item) => (
+                <TableRow key={item.plantilla}>
+                  <TableCell className="text-sm font-medium">{item.plantilla}</TableCell>
+                  <TableCell className="text-right text-sm">{item.envios}</TableCell>
+                  <TableCell className="text-right text-sm">{item.respuestas}</TableCell>
+                  <TableCell className="text-right text-sm">{item.ctr.toFixed(1)}%</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </WidgetFrame>
+      </section>
+
+      <WidgetFrame title="Cohortes" exportFilename="pyme-cohortes" csvData={cohorts}>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Cohorte</TableHead>
+              <TableHead className="text-right">Pedidos</TableHead>
+              <TableHead className="text-right">Ingresos</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {cohorts.map((cohort) => (
+              <TableRow key={cohort.cohort}>
+                <TableCell className="text-sm font-medium">{cohort.cohort}</TableCell>
+                <TableCell className="text-right text-sm">{cohort.pedidos}</TableCell>
+                <TableCell className="text-right text-sm">{cohort.ingresos.toFixed(2)}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </WidgetFrame>
+    </div>
+  );
+}

--- a/src/routesConfig.tsx
+++ b/src/routesConfig.tsx
@@ -45,6 +45,7 @@ import CatalogMappingPage from '@/pages/admin/CatalogMappingPage';
 import OpinarArPage from '@/pages/OpinarArPage';
 import EstadisticasPage from '@/pages/EstadisticasPage';
 import Iframe from '@/pages/iframe';
+import AnalyticsPage from '@/pages/analytics/AnalyticsPage';
 
 // NUEVAS IMPORTACIONES PARA EL PORTAL DE USUARIO
 // UserPortalLayout no se importa aquí si se usa como Layout Route en App.tsx
@@ -107,6 +108,7 @@ const routes: RouteConfig[] = [
   { path: '/municipal/stats', element: <EstadisticasPage />, roles: ['admin', 'super_admin'] },
   { path: '/municipal/incidents', element: <EstadisticasPage />, roles: ['admin', 'super_admin'] },
   { path: '/estadisticas', element: <EstadisticasPage />, roles: ['admin', 'super_admin'] },
+  { path: '/analytics', element: <AnalyticsPage />, roles: ['admin', 'empleado', 'super_admin'] },
   { path: '/perfil/plantillas-respuesta', element: <GestionPlantillasPage />, roles: ['admin', 'empleado', 'super_admin'] },
   // Rutas para la gestión de mapeo de catálogos por PYME
   { path: '/admin/pyme/:pymeId/catalog-mappings/new', element: <CatalogMappingPage />, roles: ['admin', 'super_admin'] },

--- a/src/services/analyticsService.ts
+++ b/src/services/analyticsService.ts
@@ -1,0 +1,198 @@
+import { apiFetch } from '@/utils/api';
+
+export type AnalyticsContext = 'municipio' | 'pyme' | 'operaciones' | string;
+
+export interface AnalyticsFiltersPayload {
+  tenantId: string;
+  from: string;
+  to: string;
+  canal?: string[];
+  categoria?: string[];
+  estado?: string[];
+  agente?: string[];
+  zona?: string[];
+  etiquetas?: string[];
+  metric?: string;
+  group?: string | null;
+  dimension?: string;
+  subject?: string;
+  bbox?: [number, number, number, number] | null;
+  context?: AnalyticsContext;
+  search?: string | null;
+}
+
+function buildQuery(params: AnalyticsFiltersPayload): string {
+  const query = new URLSearchParams();
+  query.set('tenant_id', params.tenantId);
+  query.set('from', params.from);
+  query.set('to', params.to);
+  if (params.context) {
+    query.set('context', params.context);
+  }
+  const multi = [
+    ['canal', params.canal],
+    ['categoria', params.categoria],
+    ['estado', params.estado],
+    ['agente', params.agente],
+    ['zona', params.zona],
+    ['etiquetas', params.etiquetas],
+  ] as const;
+  multi.forEach(([key, value]) => {
+    if (value && value.length) {
+      query.set(key, value.join(','));
+    }
+  });
+  if (params.metric) query.set('metric', params.metric);
+  if (params.group) query.set('group', params.group);
+  if (params.dimension) query.set('dimension', params.dimension);
+  if (params.subject) query.set('subject', params.subject);
+  if (params.search) query.set('search', params.search);
+  if (params.bbox) {
+    query.set('bbox', params.bbox.join(','));
+  }
+  return query.toString();
+}
+
+export interface SummaryResponse {
+  generatedAt: string;
+  tenantId: string;
+  totals: {
+    tickets: number;
+    abiertos: number;
+    backlog: number;
+    adjuntos: number;
+  };
+  sla: {
+    ack: { p50: number; p90: number; p95: number };
+    resolve: { p50: number; p90: number; p95: number };
+  };
+  efficiency: {
+    firstContact: number;
+    reopenRate: number;
+    automationRate: number;
+  };
+  volume: {
+    perDay: { date: string; value: number }[];
+    byChannel: { label: string; value: number }[];
+    byCategory: { label: string; value: number }[];
+    byZone: { label: string; value: number }[];
+  };
+  quality: {
+    byType: { label: string; average: number; responses: number }[];
+    byAgent: { label: string; average: number; responses: number }[];
+  };
+  pyme: {
+    totalOrders: number;
+    ticketMedio: number;
+    ingresos: { date: string; value: number }[];
+    topProductos: { label: string; value: number }[];
+    conversion: number;
+    recurrencia: { d30: number; d60: number; d90: number };
+    horasPico: { hour: number; value: number }[];
+    canales: { label: string; value: number }[];
+    plantillas: {
+      plantilla: string;
+      envios: number;
+      respuestas: number;
+      bloqueos: number;
+      ctr: number;
+    }[];
+  };
+}
+
+export interface TimeseriesResponse {
+  metric: string;
+  group: string | null;
+  series: { date: string; value: number; breakdown?: Record<string, number> }[];
+}
+
+export interface BreakdownResponse {
+  dimension: string;
+  items: { label: string; value: number }[];
+}
+
+export interface HeatmapResponse {
+  cells: {
+    cellId: string;
+    tenant_id: string;
+    count: number;
+    centroid_lat: number;
+    centroid_lon: number;
+    breakdown: Record<string, number>;
+  }[];
+  hotspots: {
+    cellId: string;
+    count: number;
+    centroid: [number, number];
+    breakdown: Record<string, number>;
+  }[];
+  chronic: { zone: string; weeks: { week: string; count: number }[] }[];
+}
+
+export interface PointsResponse {
+  points: { cellId: string; lat: number; lon: number; categoria: string; estado: string }[];
+}
+
+export interface TopResponse {
+  subject: string;
+  items: { label: string; value: number }[];
+}
+
+export interface OperationsResponse {
+  abiertos: number;
+  slaBreaches: number;
+  automated: number;
+  agingBuckets: Record<string, number>;
+  agents: { agente: string; abiertos: number; tiempoMedio: number; satisfaccion: number }[];
+}
+
+export interface CohortsResponse {
+  cohorts: { cohort: string; pedidos: number; ingresos: number }[];
+}
+
+export interface TemplatesResponse {
+  templates: {
+    plantilla: string;
+    envios: number;
+    respuestas: number;
+    bloqueos: number;
+    ctr: number;
+  }[];
+}
+
+export interface FilterCatalogResponse {
+  canales: string[];
+  categorias: string[];
+  estados: string[];
+  agentes: string[];
+  zonas: string[];
+  etiquetas: string[];
+  tenants?: string[];
+  defaultTenantId?: string;
+  defaultContext?: AnalyticsContext;
+  contexts?: AnalyticsContext[];
+}
+
+async function fetcher<T>(endpoint: string, filters: AnalyticsFiltersPayload): Promise<T> {
+  const qs = buildQuery(filters);
+  return apiFetch<T>(`analytics/${endpoint}?${qs}`);
+}
+
+export const analyticsService = {
+  summary: (filters: AnalyticsFiltersPayload) => fetcher<SummaryResponse>('summary', filters),
+  timeseries: (filters: AnalyticsFiltersPayload) =>
+    fetcher<TimeseriesResponse>('timeseries', filters),
+  breakdown: (filters: AnalyticsFiltersPayload) =>
+    fetcher<BreakdownResponse>('breakdown', filters),
+  heatmap: (filters: AnalyticsFiltersPayload) => fetcher<HeatmapResponse>('geo/heatmap', filters),
+  points: (filters: AnalyticsFiltersPayload) => fetcher<PointsResponse>('geo/points', filters),
+  top: (filters: AnalyticsFiltersPayload) => fetcher<TopResponse>('top', filters),
+  operations: (filters: AnalyticsFiltersPayload) =>
+    fetcher<OperationsResponse>('operations', filters),
+  cohorts: (filters: AnalyticsFiltersPayload) => fetcher<CohortsResponse>('cohorts', filters),
+  templates: (filters: AnalyticsFiltersPayload) =>
+    fetcher<TemplatesResponse>('whatsapp/templates', filters),
+  filters: (filters: AnalyticsFiltersPayload) => fetcher<FilterCatalogResponse>('filters', filters),
+};
+
+export type { AnalyticsFiltersPayload as AnalyticsFilters };

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -28,6 +28,38 @@ export function getChatbocConfig() {
   };
 }
 
+export interface AnalyticsSettings {
+  enabled: boolean;
+  tenants: string[];
+  defaultTenantId?: string;
+  defaultContext?: string;
+}
+
+export function getAnalyticsSettings(): AnalyticsSettings {
+  if (typeof window === 'undefined') {
+    return { enabled: true, tenants: [] };
+  }
+  const analytics = ((window as any).CHATBOC_CONFIG || {}).analytics || {};
+  const tenants = Array.isArray(analytics.tenants)
+    ? analytics.tenants.filter((tenant: unknown) => typeof tenant === 'string' && tenant.trim())
+    : [];
+  const defaultTenantId =
+    typeof analytics.defaultTenantId === 'string' && analytics.defaultTenantId.trim()
+      ? analytics.defaultTenantId
+      : undefined;
+  const defaultContext =
+    typeof analytics.defaultContext === 'string' && analytics.defaultContext.trim()
+      ? analytics.defaultContext
+      : undefined;
+  const enabled = analytics.enabled === undefined ? true : analytics.enabled !== false;
+  return {
+    enabled,
+    tenants,
+    defaultTenantId,
+    defaultContext,
+  };
+}
+
 export function getIframeToken(): string {
   const globalToken = (window as any).CHATBOC_CONFIG?.entityToken;
   if (typeof globalToken === 'string' && globalToken.trim()) {

--- a/src/utils/exportUtils.ts
+++ b/src/utils/exportUtils.ts
@@ -1,0 +1,91 @@
+import type { RefObject } from 'react';
+
+export function exportToCsv(filename: string, rows: Record<string, unknown>[]) {
+  if (!rows.length) {
+    console.warn('No hay datos para exportar');
+    return;
+  }
+  const headers = Object.keys(rows[0]);
+  const lines = [headers.join(',')];
+  rows.forEach((row) => {
+    const values = headers.map((header) => {
+      const value = row[header];
+      if (value === null || value === undefined) return '';
+      const stringValue = Array.isArray(value) ? value.join('|') : String(value);
+      if (stringValue.includes(',') || stringValue.includes('"') || stringValue.includes('\n')) {
+        return `"${stringValue.replace(/"/g, '""')}"`;
+      }
+      return stringValue;
+    });
+    lines.push(values.join(','));
+  });
+  const blob = new Blob([lines.join('\n')], { type: 'text/csv;charset=utf-8;' });
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.setAttribute('download', filename);
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}
+
+export async function exportElementToPng(ref: RefObject<HTMLElement>, filename: string) {
+  const element = ref.current;
+  if (!element) {
+    console.warn('Elemento no disponible para exportar');
+    return;
+  }
+
+  const bounds = element.getBoundingClientRect();
+  const width = Math.ceil(bounds.width);
+  const height = Math.ceil(bounds.height);
+  const clone = element.cloneNode(true) as HTMLElement;
+  clone.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
+  const serialized = new XMLSerializer().serializeToString(clone);
+  const svg = `<?xml version="1.0" encoding="UTF-8"?>
+    <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">
+      <foreignObject width="100%" height="100%">
+        ${serialized}
+      </foreignObject>
+    </svg>`;
+
+  const svgBlob = new Blob([svg], { type: 'image/svg+xml;charset=utf-8' });
+  const url = URL.createObjectURL(svgBlob);
+
+  await new Promise<void>((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => {
+      const scale = window.devicePixelRatio || 2;
+      const canvas = document.createElement('canvas');
+      canvas.width = width * scale;
+      canvas.height = height * scale;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        reject(new Error('No se pudo inicializar canvas'));
+        return;
+      }
+      ctx.scale(scale, scale);
+      ctx.drawImage(img, 0, 0);
+      const pngUrl = canvas.toDataURL('image/png');
+      URL.revokeObjectURL(url);
+      const link = document.createElement('a');
+      link.href = pngUrl;
+      link.download = filename;
+      link.click();
+      resolve();
+    };
+    img.onerror = (error) => {
+      URL.revokeObjectURL(url);
+      console.error('No se pudo generar PNG', error);
+      reject(error as Error);
+    };
+    img.src = url;
+  });
+}
+
+export function downloadJson(filename: string, data: unknown) {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = filename;
+  link.click();
+}

--- a/tests/analyticsModule.test.ts
+++ b/tests/analyticsModule.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, beforeAll } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { dispatch, refreshDataset } = require('../server/analytics/index.cjs');
+
+type RequestContext = Partial<{
+  role: string;
+  tenants: string[];
+  defaultTenant: string | null;
+}>;
+
+function buildRequest(path: string, query: Record<string, string>, context?: RequestContext) {
+  const { role = 'admin', tenants = ['muni-centro'], defaultTenant } = context ?? {};
+  return {
+    method: 'GET',
+    path,
+    query,
+    headers: {},
+    analyticsRole: role,
+    allowedTenants: tenants,
+    defaultTenant: defaultTenant ?? tenants[0] ?? null,
+  };
+}
+
+describe('analytics dispatch', () => {
+  beforeAll(() => {
+    refreshDataset();
+  });
+
+  it('returns summary metrics for authorized tenant', async () => {
+    const now = new Date();
+    const from = new Date(now.getTime() - 60 * 24 * 60 * 60 * 1000);
+    const query = {
+      tenant_id: 'muni-centro',
+      from: from.toISOString().slice(0, 10),
+      to: now.toISOString().slice(0, 10),
+    };
+    const response = await dispatch(buildRequest('/summary', query));
+    expect(response.status).toBe(200);
+    expect(response.body.totals.tickets).toBeGreaterThan(0);
+    expect(response.body.sla.ack.p50).toBeGreaterThanOrEqual(0);
+  });
+
+  it('denies access when tenant not allowed', async () => {
+    const now = new Date();
+    const query = {
+      tenant_id: 'muni-centro',
+      from: new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10),
+      to: now.toISOString().slice(0, 10),
+    };
+    const response = await dispatch(
+      buildRequest('/summary', query, { role: 'visor', tenants: ['pyme-tienda'] }),
+    );
+    expect(response.status).toBe(403);
+    expect(response.body.message).toContain('tenant');
+  });
+
+  it('allows default tenant when no explicit list provided', async () => {
+    const now = new Date();
+    const query = {
+      tenant_id: 'muni-centro',
+      from: new Date(now.getTime() - 3 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10),
+      to: now.toISOString().slice(0, 10),
+    };
+    const response = await dispatch(
+      buildRequest('/summary', query, {
+        role: 'visor',
+        tenants: [],
+        defaultTenant: 'muni-centro',
+      }),
+    );
+    expect(response.status).toBe(200);
+  });
+
+  it('denies access when tenant not in default or allowed list', async () => {
+    const now = new Date();
+    const query = {
+      tenant_id: 'muni-centro',
+      from: new Date(now.getTime() - 3 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10),
+      to: now.toISOString().slice(0, 10),
+    };
+    const response = await dispatch(
+      buildRequest('/summary', query, {
+        role: 'visor',
+        tenants: [],
+        defaultTenant: 'pyme-tienda',
+      }),
+    );
+    expect(response.status).toBe(403);
+  });
+
+  it('requires operador role for operations endpoint', async () => {
+    const now = new Date();
+    const query = {
+      tenant_id: 'muni-centro',
+      from: new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10),
+      to: now.toISOString().slice(0, 10),
+    };
+    const unauthorized = await dispatch(buildRequest('/operations', query, { role: 'visor' }));
+    expect(unauthorized.status).toBe(403);
+
+    const authorized = await dispatch(buildRequest('/operations', query, { role: 'operador' }));
+    expect(authorized.status).toBe(200);
+    expect(authorized.body.abiertos).toBeGreaterThanOrEqual(0);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure analytics handlers only honor tenants in the allowed list or configured default
- exercise both authorized and unauthorized default-tenant flows in the analytics module tests

## Testing
- npm run test -- analyticsModule.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d9bfd1a15c83228b7016656cb78d6b