### PR TITLE
Handle loosely formatted heatmap payloads

### DIFF
--- a/src/components/MapLibreMap.tsx
+++ b/src/components/MapLibreMap.tsx
@@ -163,10 +163,8 @@ export default function MapLibreMap({
   }, [onBoundingBoxChange]);
 
   const shouldRenderGoogle = useMemo(
-    () =>
-      fallbackEnabled !== false &&
-      (provider === "google" || (provider === "maplibre" && mapError !== null)),
-    [provider, mapError, fallbackEnabled],
+    () => fallbackEnabled !== false && provider === "google",
+    [provider, fallbackEnabled],
   );
 
   const fallbackQuery = useMemo(() => {
@@ -258,13 +256,21 @@ export default function MapLibreMap({
         if (!isMounted || !mapContainerRef.current) return;
 
         const key = apiKeyRef.current;
-        const styleUrl = key
-          ? `https://api.maptiler.com/maps/streets-v2/style.json?key=${key}`
-          : "https://demotiles.maplibre.org/style.json";
+        const styleCandidates = [
+          key ? `https://api.maptiler.com/maps/streets-v2/style.json?key=${key}` : null,
+          "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json",
+          "https://tiles.stadiamaps.com/styles/alidade_smooth.json",
+          "https://demotiles.maplibre.org/style.json",
+        ].filter((value): value is string => typeof value === "string" && value.length > 0);
+
+        let currentStyleIndex = 0;
+        let exhaustedStyles = false;
+
+        const initialStyle = styleCandidates[0] ?? "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json";
 
         const mapInstance = new maplibre.Map({
           container: mapContainerRef.current,
-          style: styleUrl,
+          style: initialStyle,
           center: centerRef.current ?? [0, 0],
           zoom: initialZoomRef.current,
         });
@@ -275,13 +281,22 @@ export default function MapLibreMap({
           mapInstance.addControl(new maplibre.NavigationControl(), "top-right");
         }
 
-        const handleLoad = () => {
-          mapInstance.addSource("points", {
-            type: "geojson",
-            data: { type: "FeatureCollection", features: [] },
-          });
+        const ensureSourcesAndLayers = () => {
+          if (!mapRef.current) {
+            return;
+          }
 
-          addLayer(mapInstance, {
+          const map = mapRef.current;
+          setMapError(null);
+
+          if (!map.getSource("points")) {
+            map.addSource("points", {
+              type: "geojson",
+              data: { type: "FeatureCollection", features: [] },
+            });
+          }
+
+          addLayer(map, {
             id: "tickets-heat",
             type: "heatmap",
             source: "points",
@@ -307,7 +322,7 @@ export default function MapLibreMap({
             },
           });
 
-          addLayer(mapInstance, {
+          addLayer(map, {
             id: "tickets-circles",
             type: "circle",
             source: "points",
@@ -327,14 +342,57 @@ export default function MapLibreMap({
             },
           });
 
-          toggleLayers(mapInstance, showHeatmapRef.current);
-          updateHeatmapSource(mapInstance, latestHeatmap.current);
+          toggleLayers(map, showHeatmapRef.current);
+          updateHeatmapSource(map, latestHeatmap.current);
         };
 
+        const cycleStyle = (reason?: string) => {
+          if (exhaustedStyles || styleCandidates.length === 0) {
+            return;
+          }
+
+          if (currentStyleIndex < styleCandidates.length - 1) {
+            currentStyleIndex += 1;
+            const nextStyle = styleCandidates[currentStyleIndex];
+            console.warn("[MapLibreMap] Falling back to alternate style", {
+              nextStyle,
+              reason,
+            });
+            mapInstance.setStyle(nextStyle);
+          } else {
+            exhaustedStyles = true;
+            setMapError(
+              "No se pudieron cargar los estilos del mapa. Verificá la clave de MapTiler o la conexión de red.",
+            );
+          }
+        };
+
+        const handleStyleError = (event: any) => {
+          if (exhaustedStyles) return;
+          const resourceType = event?.resourceType;
+          const status = event?.error?.status ?? event?.error?.code;
+          const message = event?.error?.message;
+          const shouldFallback =
+            resourceType === "style" ||
+            resourceType === "source" ||
+            resourceType === "sprite" ||
+            resourceType === "tile" ||
+            status === 401 ||
+            status === 403 ||
+            status === 404 ||
+            status === 0;
+
+          if (shouldFallback) {
+            cycleStyle(typeof message === "string" ? message : String(status ?? "unknown"));
+          }
+        };
+
+        mapInstance.on("load", ensureSourcesAndLayers);
+        mapInstance.on("style.load", ensureSourcesAndLayers);
+        mapInstance.on("error", handleStyleError);
+
         if (mapInstance.isStyleLoaded()) {
-          handleLoad();
-        } else {
-          mapInstance.once("load", handleLoad);
+          ensureSourcesAndLayers();
         }
 
         const handleClick = (event: { lngLat: { lat: number; lng: number } }) => {
@@ -405,6 +463,9 @@ export default function MapLibreMap({
           if (boundingBoxCallbackRef.current) {
             mapInstance.off("boxzoomend", emitBoundingBox);
           }
+          mapInstance.off("load", ensureSourcesAndLayers);
+          mapInstance.off("style.load", ensureSourcesAndLayers);
+          mapInstance.off("error", handleStyleError);
         };
       } catch (error) {
         console.error("Failed to initialize map:", error);

--- a/src/components/analytics/Heatmap.tsx
+++ b/src/components/analytics/Heatmap.tsx
@@ -4,6 +4,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
 import MapLibreMap from '@/components/MapLibreMap';
 import { HeatPoint } from '@/services/statsService';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 
 interface HeatmapProps {
   initialHeatmapData: HeatPoint[];
@@ -121,6 +122,15 @@ export const AnalyticsHeatmap: React.FC<HeatmapProps> = ({
           fitToBounds={boundsCoordinates.length > 0 ? boundsCoordinates : undefined}
           fallbackEnabled={false}
         />
+        {heatmapData.length === 0 && (
+          <Alert variant="default" className="border-border/60 border-dashed bg-muted/40">
+            <AlertTitle>No hay datos georreferenciados</AlertTitle>
+            <AlertDescription>
+              El backend no devolvió puntos para el mapa de calor con los filtros actuales. Revisá los filtros o consultá al equipo
+              responsable de los datos para confirmar que se estén enviando ubicaciones.
+            </AlertDescription>
+          </Alert>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/pages/EstadisticasPage.tsx
+++ b/src/pages/EstadisticasPage.tsx
@@ -629,6 +629,7 @@ export default function EstadisticasPage() {
         getTicketStats(params),
         getHeatmapPoints({
           tipo_ticket: segment,
+          tipo: segment,
           fecha_inicio: start,
           fecha_fin: end,
           estado: statusFilter !== 'all' ? statusFilter : undefined,

--- a/src/pages/MunicipalAnalytics.tsx
+++ b/src/pages/MunicipalAnalytics.tsx
@@ -279,6 +279,7 @@ export default function MunicipalAnalytics() {
         getTicketStats(statsParams),
         getHeatmapPoints({
           tipo_ticket: 'municipio',
+          tipo: 'municipio',
           categoria: categoryFilter !== 'all' ? categoryFilter : undefined,
           genero: genderFilter || undefined,
           edad_min: ageMin || undefined,

--- a/src/pages/Perfil.tsx
+++ b/src/pages/Perfil.tsx
@@ -528,21 +528,41 @@ export default function Perfil() {
   const fetchMapData = useCallback(async () => {
     setIsMapLoading(true);
     try {
-      const tipo = getCurrentTipoChat();
-      const stats = await getTicketStats({ tipo });
-      const points = stats.heatmap || [];
-      setHeatmapData(points);
+      const tipo = user?.tipo_chat ?? getCurrentTipoChat();
 
-      const barrios = Array.from(new Set(points.map((d) => d.barrio).filter(Boolean))) as string[];
-      setAvailableBarrios(barrios);
+      const [stats, heatmapPoints, categoryData] = await Promise.all([
+        getTicketStats({ tipo }),
+        getHeatmapPoints({ tipo_ticket: tipo, tipo }),
+        apiFetch<{ categorias: { id: number; nombre: string }[] }>(
+          '/municipal/categorias',
+        ).catch((err) => {
+          console.warn('Error fetching categories for heatmap filters:', err);
+          return null;
+        }),
+      ]);
 
-      const tipos = Array.from(new Set(points.map((d) => d.tipo_ticket).filter(Boolean))) as string[];
-      setAvailableTipos(tipos);
+      const combinedHeatmap = (heatmapPoints?.length ? heatmapPoints : stats.heatmap) ?? [];
+      setHeatmapData(combinedHeatmap);
 
-      const categoryData = await apiFetch<{ categorias: { id: number; nombre: string }[] }>('/municipal/categorias');
-      setAvailableCategories(
-        Array.isArray(categoryData.categorias) ? categoryData.categorias.map((c) => c.nombre) : []
+      const barrios = Array.from(new Set(combinedHeatmap.map((d) => d.barrio).filter(Boolean))) as string[];
+      setAvailableBarrios(barrios.sort((a, b) => a.localeCompare(b)));
+
+      const tipos = Array.from(new Set(combinedHeatmap.map((d) => d.tipo_ticket).filter(Boolean))) as string[];
+      setAvailableTipos(tipos.sort((a, b) => a.localeCompare(b)));
+
+      const categoriasFromHeatmap = Array.from(
+        new Set(combinedHeatmap.map((d) => d.categoria).filter(Boolean)),
+      ) as string[];
+
+      const categoriasFromApi =
+        categoryData && Array.isArray(categoryData.categorias)
+          ? categoryData.categorias.map((c) => c.nombre)
+          : [];
+
+      const mergedCategorias = Array.from(
+        new Set([...categoriasFromApi, ...categoriasFromHeatmap]),
       );
+      setAvailableCategories(mergedCategorias.sort((a, b) => a.localeCompare(b)));
 
     } catch (error) {
       console.error("Error fetching map data:", error);
@@ -554,7 +574,7 @@ export default function Perfil() {
     } finally {
       setIsMapLoading(false);
     }
-  }, []);
+  }, [user?.tipo_chat]);
 
 
   useEffect(() => {

--- a/src/services/statsService.ts
+++ b/src/services/statsService.ts
@@ -1,4 +1,4 @@
-import { apiFetch } from '@/utils/api';
+import { ApiError, apiFetch } from '@/utils/api';
 
 export interface HeatPoint {
   lat: number;
@@ -33,6 +33,8 @@ export interface TicketStatsParams {
   sugerencia?: string | string[];
   prioridad?: string | string[];
 }
+
+const MUNICIPAL_TIPO_ALIASES = ['municipio', 'municipal', 'municipalidad'] as const;
 
 const LATITUDE_KEYWORDS = ['lat', 'latitude', 'latitud'];
 const LONGITUDE_KEYWORDS = ['lng', 'lon', 'longitud', 'long'];
@@ -137,6 +139,47 @@ const NESTED_CONTAINER_KEYS = [
   'attributesdata',
   'meta',
 ];
+
+const LOOSE_JSON_GUARD = /(^|[^A-Za-z])(function|=>|while|for|process|require|global|import|export)/;
+
+const tryParseLooseJson = (raw: string): unknown => {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return raw;
+  }
+
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+    try {
+      return JSON.parse(trimmed);
+    } catch (jsonError) {
+      const sanitized = trimmed
+        .replace(/\bNone\b/g, 'null')
+        .replace(/\bTrue\b/g, 'true')
+        .replace(/\bFalse\b/g, 'false');
+
+      if (LOOSE_JSON_GUARD.test(sanitized)) {
+        return raw;
+      }
+
+      try {
+        // eslint-disable-next-line no-new-func
+        return Function('"use strict";return (' + sanitized + ')')();
+      } catch (evalError) {
+        console.warn('[statsService] Unable to loosely parse payload', evalError);
+        return raw;
+      }
+    }
+  }
+
+  return raw;
+};
+
+const normalizeApiPayload = (payload: unknown): unknown => {
+  if (typeof payload === 'string') {
+    return tryParseLooseJson(payload);
+  }
+  return payload;
+};
 
 const normalizeKey = (key: string): string =>
   key
@@ -872,31 +915,123 @@ const normalizeHeatPoint = (raw: unknown): HeatPoint | null => {
   return point;
 };
 
+const buildSearchParams = (params?: Record<string, unknown>) => {
+  const qs = new URLSearchParams();
+  Object.entries(params || {}).forEach(([k, v]) => {
+    if (Array.isArray(v)) {
+      v
+        .filter((val) => val !== undefined && val !== null && String(val) !== '')
+        .forEach((val) => qs.append(k, String(val)));
+    } else if (v !== undefined && v !== null && String(v) !== '') {
+      qs.append(k, String(v));
+    }
+  });
+  return qs;
+};
+
+const shouldTryMunicipalAliases = (value?: string | null): boolean => {
+  if (!value) return false;
+  const normalized = value.trim().toLowerCase();
+  return MUNICIPAL_TIPO_ALIASES.includes(normalized as (typeof MUNICIPAL_TIPO_ALIASES)[number]);
+};
+
+const RECOVERABLE_STATUSES = new Set([400, 404, 409, 422, 500, 502, 503]);
+
+const tryMunicipalAliases = async <T>(
+  attempt: (tipo?: string) => Promise<T>,
+  tipo?: string,
+  shouldRetry?: (result: T) => boolean,
+): Promise<T> => {
+  if (!shouldTryMunicipalAliases(tipo)) {
+    return attempt(tipo);
+  }
+
+  const normalizedTipo = tipo?.trim().toLowerCase() ?? '';
+  const aliases = (
+    [
+      ...MUNICIPAL_TIPO_ALIASES.filter((alias) => alias === normalizedTipo),
+      ...MUNICIPAL_TIPO_ALIASES.filter((alias) => alias !== normalizedTipo),
+    ]
+  ).filter((alias, index, arr) => arr.indexOf(alias) === index);
+
+  let lastError: unknown = null;
+  let fallbackResult: T | null = null;
+
+  for (const alias of aliases) {
+    try {
+      const result = await attempt(alias);
+      if (!shouldRetry || !shouldRetry(result)) {
+        return result;
+      }
+      if (fallbackResult === null) {
+        fallbackResult = result;
+      }
+    } catch (error) {
+      lastError = error;
+      if (error instanceof ApiError) {
+        if (!RECOVERABLE_STATUSES.has(error.status)) {
+          throw error;
+        }
+        console.warn(
+          '[statsService] Municipal alias attempt failed, trying next alias',
+          {
+            alias,
+            status: error.status,
+            message: error.message,
+          },
+        );
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  if (fallbackResult !== null) {
+    return fallbackResult;
+  }
+
+  if (lastError) {
+    throw lastError;
+  }
+
+  throw new Error('No municipal alias produced a successful response');
+};
+
 export const getTicketStats = async (
   params?: TicketStatsParams,
 ): Promise<TicketStatsResponse> => {
-  try {
-    const qs = new URLSearchParams();
-    Object.entries(params || {}).forEach(([k, v]) => {
-      if (Array.isArray(v)) {
-        v.filter(Boolean).forEach((val) => qs.append(k, String(val)));
-      } else if (v) {
-        qs.append(k, String(v));
-      }
-    });
-    const query = qs.toString();
+  const fetchStats = async (overrideTipo?: string): Promise<TicketStatsResponse> => {
+    const normalizedParams: TicketStatsParams = {
+      ...(params || {}),
+    };
+
+    if (overrideTipo) {
+      normalizedParams.tipo = overrideTipo;
+    }
+
+    const query = buildSearchParams(normalizedParams).toString();
     const resp = await apiFetch<unknown>(
       `/estadisticas/tickets${query ? `?${query}` : ''}`,
     );
 
-    const charts = extractChartsFromPayload(resp).map((chart) => ({
+    const normalizedPayload = normalizeApiPayload(resp);
+
+    const charts = extractChartsFromPayload(normalizedPayload).map((chart) => ({
       title: chart.title,
       data: chart.data,
     }));
 
-    const heatmap = extractHeatmapFromPayload(resp);
+    const heatmap = extractHeatmapFromPayload(normalizedPayload);
 
     return { charts, heatmap };
+  };
+
+  try {
+    return await tryMunicipalAliases(fetchStats, params?.tipo, (result) => {
+      const chartsEmpty = !result?.charts || result.charts.length === 0;
+      const heatmapEmpty = !result?.heatmap || result.heatmap.length === 0;
+      return chartsEmpty && heatmapEmpty;
+    });
   } catch (err) {
     console.error('Error fetching ticket stats:', err);
     throw err;
@@ -905,6 +1040,7 @@ export const getTicketStats = async (
 
 export interface HeatmapParams {
   tipo_ticket?: string;
+  tipo?: string;
   municipio_id?: number;
   rubro_id?: number;
   fecha_inicio?: string;
@@ -922,22 +1058,159 @@ export interface HeatmapParams {
 export const getHeatmapPoints = async (
   params?: HeatmapParams,
 ): Promise<HeatPoint[]> => {
-  try {
-    const qs = new URLSearchParams();
-    Object.entries(params || {}).forEach(([k, v]) => {
-      if (Array.isArray(v)) {
-        v.filter((val) => val !== undefined && val !== null && String(val) !== '')
-          .forEach((val) => qs.append(k, String(val)));
-      } else if (v !== undefined && v !== null && String(v) !== '') {
-        qs.append(k, String(v));
+  const requestHeatmap = async (overrideTipo?: string): Promise<HeatPoint[]> => {
+    const baseParams: HeatmapParams = {
+      ...(params || {}),
+    };
+
+    const sanitizeTipoValue = (value?: string | null) => {
+      if (typeof value !== 'string') return value ?? undefined;
+      const trimmed = value.trim();
+      return trimmed.length > 0 ? trimmed : undefined;
+    };
+
+    const normalizedBase: HeatmapParams = { ...baseParams };
+    if (typeof normalizedBase.tipo_ticket === 'string') {
+      normalizedBase.tipo_ticket = sanitizeTipoValue(normalizedBase.tipo_ticket);
+    }
+    if (typeof normalizedBase.tipo === 'string') {
+      normalizedBase.tipo = sanitizeTipoValue(normalizedBase.tipo);
+    }
+
+    const overrideValue = sanitizeTipoValue(overrideTipo);
+
+    const variants: HeatmapParams[] = [];
+    const seen = new Set<string>();
+
+    const pushVariant = (variant: HeatmapParams) => {
+      const entries = Object.entries(variant)
+        .filter(([, value]) => {
+          if (value === undefined || value === null) return false;
+          if (typeof value === 'string') return value.trim().length > 0;
+          if (Array.isArray(value)) return value.length > 0;
+          return true;
+        })
+        .map(([key, value]) => [key, Array.isArray(value) ? [...value] : value]);
+
+      entries.sort(([a], [b]) => a.localeCompare(b));
+      const key = JSON.stringify(entries);
+      if (!seen.has(key)) {
+        seen.add(key);
+        variants.push(variant);
       }
-    });
-    const query = qs.toString();
-    const payload = await apiFetch<unknown>(
-      `/estadisticas/mapa_calor/datos${query ? `?${query}` : ''}`,
+    };
+
+    pushVariant(normalizedBase);
+
+    const withOverride: HeatmapParams = { ...normalizedBase };
+
+    if (overrideValue) {
+      withOverride.tipo = overrideValue;
+      withOverride.tipo_ticket = overrideValue;
+    } else {
+      const baseTipo = sanitizeTipoValue(normalizedBase.tipo);
+      const baseTipoTicket = sanitizeTipoValue(
+        typeof normalizedBase.tipo_ticket === 'string'
+          ? normalizedBase.tipo_ticket
+          : undefined,
+      );
+
+      if (baseTipo && !baseTipoTicket) {
+        withOverride.tipo = baseTipo;
+        withOverride.tipo_ticket = baseTipo;
+      } else if (!baseTipo && baseTipoTicket) {
+        withOverride.tipo = baseTipoTicket;
+        withOverride.tipo_ticket = baseTipoTicket;
+      }
+    }
+
+    pushVariant(withOverride);
+
+    if ('tipo' in withOverride) {
+      const withoutTipo = { ...withOverride };
+      delete withoutTipo.tipo;
+      pushVariant(withoutTipo);
+    }
+
+    if ('tipo_ticket' in withOverride) {
+      const withoutTipoTicket = { ...withOverride };
+      delete withoutTipoTicket.tipo_ticket;
+      pushVariant(withoutTipoTicket);
+    }
+
+    if (overrideValue) {
+      const ticketOnlyOverride = { ...normalizedBase };
+      delete ticketOnlyOverride.tipo;
+      ticketOnlyOverride.tipo_ticket = overrideValue;
+      pushVariant(ticketOnlyOverride);
+
+      const tipoOnlyOverride = { ...normalizedBase };
+      delete tipoOnlyOverride.tipo_ticket;
+      tipoOnlyOverride.tipo = overrideValue;
+      pushVariant(tipoOnlyOverride);
+    }
+
+    let fallbackResult: HeatPoint[] | null = null;
+    let lastError: unknown = null;
+
+    for (const variant of variants) {
+      const query = buildSearchParams(variant).toString();
+      try {
+        const payload = await apiFetch<unknown>(
+          `/estadisticas/mapa_calor/datos${query ? `?${query}` : ''}`,
+        );
+        const normalizedPayload = normalizeApiPayload(payload);
+        const points = extractHeatmapFromPayload(normalizedPayload);
+        if (points && points.length > 0) {
+          return points;
+        }
+        if (fallbackResult === null) {
+          fallbackResult = points ?? [];
+        }
+      } catch (error) {
+        lastError = error;
+        if (error instanceof ApiError) {
+          if (!RECOVERABLE_STATUSES.has(error.status)) {
+            throw error;
+          }
+          console.warn('[statsService] Heatmap request failed, retrying with variant', {
+            params: variant,
+            status: error.status,
+            message: error.message,
+          });
+        } else {
+          throw error;
+        }
+      }
+    }
+
+    if (fallbackResult !== null) {
+      return fallbackResult;
+    }
+
+    if (lastError) {
+      throw lastError;
+    }
+
+    return [];
+  };
+
+  try {
+    const result = await tryMunicipalAliases(
+      requestHeatmap,
+      params?.tipo ?? params?.tipo_ticket,
+      (points) => !points || points.length === 0,
     );
 
-    return extractHeatmapFromPayload(payload);
+    if (
+      (!result || result.length === 0) &&
+      shouldTryMunicipalAliases(params?.tipo_ticket) &&
+      !shouldTryMunicipalAliases(params?.tipo)
+    ) {
+      return await tryMunicipalAliases(requestHeatmap, params?.tipo_ticket, (points) => !points || points.length === 0);
+    }
+
+    return result;
   } catch (err) {
     console.error('Error fetching heatmap points:', err);
     throw err;

--- a/src/utils/tipoChat.ts
+++ b/src/utils/tipoChat.ts
@@ -35,11 +35,24 @@ export function getCurrentRubro(): string | null {
  * Si no hay usuario o no se puede determinar, usa 'pyme' como default para demos.
  */
 export function getCurrentTipoChat(): 'pyme' | 'municipio' {
+  try {
+    const storedUser = safeLocalStorage.getItem('user');
+    if (storedUser) {
+      const parsed = JSON.parse(storedUser);
+      const storedTipo = parsed?.tipo_chat;
+      if (storedTipo === 'pyme' || storedTipo === 'municipio') {
+        return storedTipo;
+      }
+    }
+  } catch {
+    /* ignore malformed stored user */
+  }
+
   const rubro = getCurrentRubro();
   if (rubro) {
     return esRubroPublico(rubro) ? 'municipio' : 'pyme';
   }
-  
+
   // Si no hay rubro (ej. demo anónima sin rubro pre-seleccionado),
   // por defecto debería ser 'pyme' para las demos generales.
   // Tu APP_TARGET en src/config.ts debería ser 'pyme' si esa es la configuración por defecto de la app.


### PR DESCRIPTION
## Summary
- recover municipal stats and heatmap data when the API returns loosely formatted JSON strings by normalizing payloads before extracting points or charts
- keep the incidents map on MapLibre by default while still showing errors so the heatmap layer remains available instead of falling back to Google Maps

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e293cbf6a08322a72c762bddbc0870