### PR TITLE
Fix agenda bulk upload request body formatting

### DIFF
--- a/src/components/admin/AgendaPasteForm.tsx
+++ b/src/components/admin/AgendaPasteForm.tsx
@@ -65,8 +65,7 @@ export const AgendaPasteForm: React.FC<AgendaPasteFormProps> = ({ onCancel }) =>
       );
       await apiFetch('/municipal/posts/bulk', {
         method: 'POST',
-        body: JSON.stringify({ events }),
-        headers: { 'Content-Type': 'application/json' },
+        body: { events },
       });
       toast({ title: 'Éxito', description: 'La agenda ha sido procesada correctamente.' });
       onCancel();


### PR DESCRIPTION
## Summary
- update AgendaPasteForm to send the events payload as an object so apiFetch can serialize it correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e59eba31148322aec72ee12828601d