### PR TITLE
Add demo Junín heatmap fallback for map views

### DIFF
--- a/src/components/analytics/Heatmap.tsx
+++ b/src/components/analytics/Heatmap.tsx
@@ -120,7 +120,6 @@ export const AnalyticsHeatmap: React.FC<HeatmapProps> = ({
           onSelect={onSelect}
           className="h-[600px] rounded-lg"
           fitToBounds={boundsCoordinates.length > 0 ? boundsCoordinates : undefined}
-          fallbackEnabled={false}
         />
         {heatmapData.length === 0 && (
           <Alert variant="default" className="border-border/60 border-dashed bg-muted/40">

--- a/src/utils/demoHeatmap.ts
+++ b/src/utils/demoHeatmap.ts
@@ -1,0 +1,117 @@
+import { HeatPoint } from '@/services/statsService';
+
+const JUNIN_CENTER_LAT = -33.0865;
+const JUNIN_CENTER_LNG = -68.4683;
+const MAX_RADIUS_KM = 6;
+
+const DEMO_CATEGORIES = [
+  'Iluminación',
+  'Residuos',
+  'Seguridad',
+  'Infraestructura',
+  'Tránsito',
+  'Servicios Públicos',
+] as const;
+
+const DEMO_STATES = [
+  'Nuevo',
+  'En progreso',
+  'Resuelto',
+  'Pendiente',
+] as const;
+
+const DEMO_BARRIOS = [
+  'Centro',
+  'Callejón Los Huarpes',
+  'Alto Verde',
+  'Philipps',
+  'Orfila',
+  'La Colonia',
+  'Los Barriales',
+  'Mundo Nuevo',
+  'Algarrobo Grande',
+] as const;
+
+const DEMO_TICKET_TYPES = [
+  'Reclamo',
+  'Incidente',
+  'Reporte de Servicio',
+] as const;
+
+const DEMO_STREETS = [
+  'San Martín',
+  '9 de Julio',
+  'Hipólito Yrigoyen',
+  'Remedios de Escalada',
+  'Avenida Mitre',
+  'Godoy Cruz',
+  'Belgrano',
+  'Salvador González',
+  'Espejo',
+  'Lavalle',
+  'Buenos Aires',
+];
+
+const DEMO_NOTICE = 'Mostrando datos de demostración cerca de Junín, Mendoza.';
+
+const randomFromArray = <T>(array: readonly T[]): T => {
+  const index = Math.floor(Math.random() * array.length);
+  return array[Math.max(0, Math.min(array.length - 1, index))];
+};
+
+const randomCoordinateNearJunin = () => {
+  const radiusInDegrees = (MAX_RADIUS_KM / 111) * Math.sqrt(Math.random());
+  const theta = Math.random() * 2 * Math.PI;
+  const deltaLat = radiusInDegrees * Math.cos(theta);
+  const deltaLng =
+    (radiusInDegrees * Math.sin(theta)) /
+    Math.cos((JUNIN_CENTER_LAT * Math.PI) / 180);
+
+  const lat = JUNIN_CENTER_LAT + deltaLat;
+  const lng = JUNIN_CENTER_LNG + deltaLng;
+
+  return { lat, lng };
+};
+
+const buildDemoAddress = (barrio: string) => {
+  const street = randomFromArray(DEMO_STREETS);
+  const number = 100 + Math.floor(Math.random() * 900);
+  return `${street} ${number}, ${barrio}`;
+};
+
+export const generateJuninDemoHeatmap = (count = 60): HeatPoint[] => {
+  return Array.from({ length: count }).map((_, index) => {
+    const { lat, lng } = randomCoordinateNearJunin();
+    const categoria = randomFromArray(DEMO_CATEGORIES);
+    const estado = randomFromArray(DEMO_STATES);
+    const barrio = randomFromArray(DEMO_BARRIOS);
+    const tipo_ticket = randomFromArray(DEMO_TICKET_TYPES);
+    const weight = Math.max(1, Math.round(Math.random() * 4 + 1));
+
+    return {
+      id: index + 1,
+      lat,
+      lng,
+      weight,
+      categoria,
+      estado,
+      barrio,
+      distrito: 'Junín',
+      direccion: buildDemoAddress(barrio),
+      ticket: `DEMO-${String(index + 1).padStart(4, '0')}`,
+      tipo_ticket,
+    } satisfies HeatPoint;
+  });
+};
+
+export const JUNIN_DEMO_CENTER: [number, number] = [JUNIN_CENTER_LNG, JUNIN_CENTER_LAT];
+export const JUNIN_DEMO_CATEGORIES = [...DEMO_CATEGORIES];
+export const JUNIN_DEMO_STATES = [...DEMO_STATES];
+export const JUNIN_DEMO_BARRIOS = [...DEMO_BARRIOS];
+export const JUNIN_DEMO_TICKET_TYPES = [...DEMO_TICKET_TYPES];
+export const JUNIN_DEMO_NOTICE = DEMO_NOTICE;
+
+export const mergeAndSortStrings = (base: string[], extras: string[]): string[] => {
+  const unique = new Set<string>([...base, ...extras.filter(Boolean)]);
+  return Array.from(unique).sort((a, b) => a.localeCompare(b));
+};


### PR DESCRIPTION
## Summary
- add a utility that generates demo heatmap data centered on Junín, Mendoza
- fall back to the demo data in the incidents map when the backend provides no points or returns an error
- reuse the same fallback for the profile heatmap and allow MapLibre to use its default fallback provider

## Testing
- npm run lint *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68e5def7173c8322802f10bc09f30a96